### PR TITLE
in ivona-tts, sentence_break is integer not string

### DIFF
--- a/plugins/tts/ivona-tts/ivona.py
+++ b/plugins/tts/ivona-tts/ivona.py
@@ -41,7 +41,7 @@ class IvonaTTSPlugin(plugin.TTSPlugin):
             speech_rate = None
 
         try:
-            sentence_break = self.profile['ivona-tts']['sentence_break']
+            sentence_break = int(self.profile['ivona-tts']['sentence_break'])
         except KeyError:
             sentence_break = None
 


### PR DESCRIPTION
in ivona-tts, sentence_break is integer not string.

pyvona lib raising `PyvonaException`if value of`sentence_break` pass as string

`PyvonaException: Error fetching voice: {"Message":"class java.lang.String can not be converted to an Short"}
`
