### PR TITLE
Fixing unicode accent error 

### DIFF
--- a/jasper/local_mic.py
+++ b/jasper/local_mic.py
@@ -4,6 +4,7 @@ A drop-in replacement for the Mic class that allows for all I/O to occur
 over the terminal. Useful for debugging. Unlike with the typical Mic
 implementation, Jasper is always active listening with local_mic.
 """
+import unicodedata
 
 
 class Mic(object):
@@ -16,7 +17,8 @@ class Mic(object):
         return
 
     def active_listen(self, timeout=3):
-        input = raw_input("YOU: ")
+        input = raw_input("YOU: ").decode('utf8')
+        unicodedata.normalize('NFD', input).encode('ascii', 'ignore')
         self.prev = input
         return [input]
 


### PR DESCRIPTION
Error that occurred while using local mode (textual mode) with accent, by example writing "météo" in the command line interface triggered the error 