### PR TITLE
Fixed translations in populate.py

### DIFF
--- a/naomi/__main__.py
+++ b/naomi/__main__.py
@@ -10,7 +10,7 @@ from application import USE_STANDARD_MIC, USE_TEXT_MIC, USE_BATCH_MIC
 def main(args=None):
     parser = argparse.ArgumentParser(description='Naomi Voice Control Center')
     parser.add_argument(
-        '--debug', 
+        '--debug',
         action='store_true',
         help='Show debug messages'
     )
@@ -57,9 +57,9 @@ def main(args=None):
 
     # Run Naomi
     app = application.Naomi(
-        use_mic = used_mic,
-        batch_file = p_args.batch_file,
-        repopulate = p_args.repopulate
+        use_mic=used_mic,
+        batch_file=p_args.batch_file,
+        repopulate=p_args.repopulate
     )
     if p_args.list_plugins:
         app.list_plugins()

--- a/naomi/__main__.py
+++ b/naomi/__main__.py
@@ -9,8 +9,16 @@ from application import USE_STANDARD_MIC, USE_TEXT_MIC, USE_BATCH_MIC
 
 def main(args=None):
     parser = argparse.ArgumentParser(description='Naomi Voice Control Center')
-    parser.add_argument('--debug', action='store_true',
-                        help='Show debug messages')
+    parser.add_argument(
+        '--debug', 
+        action='store_true',
+        help='Show debug messages'
+    )
+    parser.add_argument(
+        '--reconfigure',
+        action='store_true',
+        help='Rebuild configuration profile'
+    )
     list_info = parser.add_mutually_exclusive_group(required=False)
     list_info.add_argument('--list-plugins', action='store_true',
                            help='List plugins and exit')
@@ -25,13 +33,17 @@ def main(args=None):
                           'commands audio filenames at each line.')
     p_args = parser.parse_args(args)
 
-    print("***********************************************************")
-    print("*                    Naomi Assistant                      *")
-    print("* Made by the Naomi Community, based on the NaomiProject *")
-    print("***********************************************************")
+    print("************************************************************")
+    print("*                    Naomi Assistant                       *")
+    print("* Made by the Naomi Community, based on the Jasper Project *")
+    print("* Source code available from                               *")
+    print("*    https://github.com/NaomiProject/Naomi                 *")
+    print("************************************************************")
 
     # Set up logging
-    logging.basicConfig(level=logging.DEBUG if p_args.debug else logging.INFO)
+    logging.basicConfig(
+        level=logging.DEBUG if p_args.debug else logging.WARNING
+    )
 
     # Select Mic
     if p_args.local:
@@ -44,8 +56,11 @@ def main(args=None):
         used_mic = USE_STANDARD_MIC
 
     # Run Naomi
-    app = application.Naomi(use_mic=used_mic,
-                             batch_file=p_args.batch_file)
+    app = application.Naomi(
+        use_mic = used_mic,
+        batch_file = p_args.batch_file,
+        reconfigure = p_args.reconfigure
+    )
     if p_args.list_plugins:
         app.list_plugins()
         sys.exit(1)

--- a/naomi/__main__.py
+++ b/naomi/__main__.py
@@ -15,7 +15,7 @@ def main(args=None):
         help='Show debug messages'
     )
     parser.add_argument(
-        '--reconfigure',
+        '--repopulate',
         action='store_true',
         help='Rebuild configuration profile'
     )
@@ -59,7 +59,7 @@ def main(args=None):
     app = application.Naomi(
         use_mic = used_mic,
         batch_file = p_args.batch_file,
-        reconfigure = p_args.reconfigure
+        repopulate = p_args.repopulate
     )
     if p_args.list_plugins:
         app.list_plugins()

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -22,7 +22,7 @@ USE_BATCH_MIC = 2
 
 
 class Naomi(object):
-    def __init__(self, use_mic=USE_STANDARD_MIC, batch_file=None):
+    def __init__(self, use_mic=USE_STANDARD_MIC, batch_file=None, reconfigure=False):
         self._logger = logging.getLogger(__name__)
         # Create config dir if it does not exist yet
         if not os.path.exists(paths.CONFIG_PATH):
@@ -70,6 +70,8 @@ class Naomi(object):
                 with open(new_configfile, "r") as f:
                     self.config = yaml.safe_load(f)
                     config_read = True
+                if( reconfigure ):
+                    populate.run(self.config)
             except IOError:
                 # AJC 2018-07-29 Changed this from a warning to debug, since
                 # we attempt to fix the problem right here
@@ -83,7 +85,7 @@ class Naomi(object):
                     "questions to create a new one? "
                 )
                 if(re.match(r'\s*[Yy]', input)):
-                    populate.run()
+                    populate.run({})
                 else:
                     print("Cannot continue. Exiting.")
                     quit()

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -22,7 +22,7 @@ USE_BATCH_MIC = 2
 
 
 class Naomi(object):
-    def __init__(self, use_mic=USE_STANDARD_MIC, batch_file=None, reconfigure=False):
+    def __init__(self, use_mic=USE_STANDARD_MIC, batch_file=None, repopulate=False):
         self._logger = logging.getLogger(__name__)
         # Create config dir if it does not exist yet
         if not os.path.exists(paths.CONFIG_PATH):
@@ -70,7 +70,7 @@ class Naomi(object):
                 with open(new_configfile, "r") as f:
                     self.config = yaml.safe_load(f)
                     config_read = True
-                if( reconfigure ):
+                if( repopulate ):
                     populate.run(self.config)
             except IOError:
                 # AJC 2018-07-29 Changed this from a warning to debug, since

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -22,7 +22,12 @@ USE_BATCH_MIC = 2
 
 
 class Naomi(object):
-    def __init__(self, use_mic=USE_STANDARD_MIC, batch_file=None, repopulate=False):
+    def __init__(
+        self,
+        use_mic=USE_STANDARD_MIC,
+        batch_file=None,
+        repopulate=False
+    ):
         self._logger = logging.getLogger(__name__)
         # Create config dir if it does not exist yet
         if not os.path.exists(paths.CONFIG_PATH):
@@ -70,7 +75,7 @@ class Naomi(object):
                 with open(new_configfile, "r") as f:
                     self.config = yaml.safe_load(f)
                     config_read = True
-                if( repopulate ):
+                if(repopulate):
                     populate.run(self.config)
             except IOError:
                 # AJC 2018-07-29 Changed this from a warning to debug, since

--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -57,8 +57,10 @@ class Conversation(i18n.GettextMixin):
                         self._logger.error('Failed to execute module',
                                            exc_info=True)
                         self.mic.say(self.gettext(
-                            "I'm sorry. I had some trouble with that " +
-                            "operation. Please try again later."))
+                            "I'm sorry. I had some trouble with that "
+                        ) + self.gettext(
+                            "operation. Please try again later.")
+                        )
                     else:
                         self._logger.debug("Handling of phrase '%s' by " +
                                            "module '%s' completed", text,

--- a/naomi/data/locale/fr-FR.po
+++ b/naomi/data/locale/fr-FR.po
@@ -356,8 +356,8 @@ msgstr "La langue?"
 msgid "Voice?"
 msgstr "Voix?"
 
-#: populate.py:988
-msgid "I have two ways to let you know I've heard you: Beep or Voice."
+#: populate.py:990
+msgid "I have two ways to let you know I've heard you; Beep or Voice."
 msgstr "J'ai deux façons de vous faire savoir que je vous ai entendu: Bip ou voix"
 
 #: populate.py:999
@@ -371,6 +371,10 @@ msgstr "Veuillez choisir des bips (B) ou des voix (V):"
 #: populate.py:1014
 msgid "Type the words I should say after hearing my wake word: %s"
 msgstr "Tapez les mots que je devrais dire après avoir entendu mon mot réveil:% s"
+
+#: populate.py:1024
+msgid "Reply"
+msgstr "Répondre"
 
 #: populate.py:1027
 msgid "Is this correct?"

--- a/naomi/data/locale/fr-FR.po
+++ b/naomi/data/locale/fr-FR.po
@@ -8,24 +8,23 @@ msgstr ""
 "Project-Id-Version: 2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-10-28 01:17+0100\n"
-"PO-Revision-Date: 2016-6-16 23:01+0100\n"
-"Last-Translator: Rocca Seb <se.rocca84@gmail.com>\n"
+"PO-Revision-Date: 2018-09-05 23:24-0700\n"
+"Last-Translator: Aaron Chantrill <aaron.chantrill@dottywood.org>\n"
 "Language-Team: Naomi Project\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.5\n"
+"X-Generator: Poedit 2.1.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #: client/conversation.py:24
 msgid "My name is, %s."
 msgstr "Mon nom est %s."
 
-#:client/conversation.py:26
+#: client/conversation.py:26
 msgid "My name is Naomi"
 msgstr "Je suis Naomi"
-
 
 #: client/conversation.py:32
 #, python-format
@@ -38,8 +37,357 @@ msgstr "Puis-je vous aider ?"
 
 #: client/conversation.py:53
 msgid "I'm sorry. I had some trouble with that operation. Please try again later."
-msgstr "Je suis désolé. Il y a quelques problèmes. Merci de réessayer plus tard"
+msgstr "Je suis désolé. Il y a quelques problèmes. Merci de réessayer plus tard."
 
 #: client/conversation.py:60
 msgid "Pardon?"
-msgstr "Pardon ?"
+msgstr "Pardon?"
+
+#: conversation.py:35
+msgid "How can I be of service?"
+msgstr "Comment puis-je être utile?"
+
+#: conversation.py:59
+msgid "I'm sorry. I had some trouble with that "
+msgstr "Je suis désolé. J'ai eu des problèmes avec ça "
+
+#: conversation.py:61
+msgid "operation. Please try again later."
+msgstr "opération. Veuillez réessayer plus tard."
+
+#: populate.py:128
+msgid "Location saved as "
+msgstr "Emplacement enregistré sous "
+
+#: populate.py:182
+msgid "Language Selector"
+msgstr "Sélecteur de langue"
+
+#: populate.py:191
+msgid "Select Language"
+msgstr "Choisir la langue"
+
+#: populate.py:221
+msgid "Hello, thank you for selecting me to be your personal assistant."
+msgstr "Bonjour, merci de m'avoir choisi pour être votre assistant personnel."
+
+#: populate.py:225
+msgid "Let's populate your profile."
+msgstr "Peuplons votre profil."
+
+#: populate.py:229
+msgid "If, at any step, you would prefer not to enter the requested information"
+msgstr "Si, à tout moment, vous préférez ne pas saisir les informations demandées"
+
+#: populate.py:232
+msgid "just hit 'Enter' with a blank field to continue."
+msgstr "appuyez simplement sur \"Entrée\" avec un champ vide pour continuer."
+
+#: populate.py:242
+msgid "First, what name would you like to call me by?"
+msgstr "D'abord, par quel nom aimeriez-vous m'appeler?"
+
+#: populate.py:251
+msgid "Now please tell me a little about yourself."
+msgstr "Maintenant, s'il vous plaît, parlez-moi un peu de vous."
+
+#: populate.py:259
+msgid "What is your first name?"
+msgstr "Quel est votre prénom?"
+
+#: populate.py:268
+msgid "What is your last name?"
+msgstr "Quel est ton nom de famille?"
+
+#: populate.py:280
+msgid "I can use an email account to send notifications to you."
+msgstr "Je peux utiliser un compte de messagerie pour vous envoyer des notifications."
+
+#: populate.py:283 populate.py:332
+msgid "Alternatively, you can skip this step"
+msgstr "Sinon, vous pouvez ignorer cette étape"
+
+#: populate.py:293
+msgid "Please enter your imap server as \"server[:port]\""
+msgstr "Veuillez entrer votre serveur imap en tant que \"serveur[:port]\""
+
+#: populate.py:301
+msgid "What is your email address?"
+msgstr "Quelle est ton adresse email?"
+
+#: populate.py:316
+msgid "What is your email password?"
+msgstr "Quel est votre mot de passe email?"
+
+#: populate.py:328
+msgid "I can use your phone number to send notifications to you."
+msgstr "Je peux utiliser votre numéro de téléphone pour vous envoyer des notifications."
+
+#: populate.py:338
+msgid "No country codes!"
+msgstr "Pas de codes pays!"
+
+#: populate.py:340
+msgid "Any dashes or spaces will be removed for you"
+msgstr "Tous les tirets ou espaces seront supprimés pour vous"
+
+#: populate.py:347
+msgid "What is your Phone number?"
+msgstr "Quel est ton numéro de téléphone?"
+
+#: populate.py:364
+msgid "What is your phone carrier?"
+msgstr "Quel est votre opérateur téléphonique?"
+
+#: populate.py:368
+msgid "If you have a US phone number, "
+msgstr "Si vous avez un numéro de téléphone américain, "
+
+#: populate.py:369
+msgid "you can enter one of the following:"
+msgstr "vous pouvez entrer l'un des éléments suivants:"
+
+#: populate.py:374
+msgid "without the quotes"
+msgstr "sans les guillemets"
+
+#: populate.py:380
+msgid "If your carrier isn't listed or you have an international"
+msgstr "Si votre opérateur ne figure pas dans la liste ou si"
+
+#: populate.py:384
+msgid "number, go to"
+msgstr "vous avez un numéro international, allez à"
+
+#: populate.py:390
+msgid "and enter the email suffix for your carrier (e.g., for Virgin Mobile, enter "
+msgstr "et entrez le suffixe de messagerie pour votre opérateur (par exemple, pour Virgin Mobile, entrez "
+
+#: populate.py:392
+msgid "'vmobl.com'; for T-Mobile Germany, enter 't-d1-sms.de')."
+msgstr "'vmobl.com'; pour T-Mobile Allemagne, entrez 't-d1-sms.de')."
+
+#: populate.py:397
+msgid "What is your Carrier? "
+msgstr "Quel est votre transporteur? "
+
+#: populate.py:429
+msgid "Would you prefer to have notifications sent by"
+msgstr "Préféreriez-vous que les notifications soient envoyées par"
+
+#: populate.py:433
+msgid "email (E) or text message (T)?"
+msgstr "courrier électronique (E) ou par message texte (T)?"
+
+#: populate.py:443
+msgid "Email (E) or Text message (T)?"
+msgstr "courrier électronique (E) ou par message texte (T)?"
+
+#: populate.py:452
+msgid "Please choose email (E) or text message (T)!"
+msgstr "Veuillez choisir un email (E) ou un message texte (T)!"
+
+#: populate.py:468
+msgid "For weather information, please enter your 5-digit zipcode (e.g., 08544)."
+msgstr "Pour obtenir des informations météorologiques, veuillez saisir votre code postal à 5 ​​chiffres (par exemple, 08544)."
+
+#: populate.py:472
+msgid "If you are outside the US, insert the name of the nearest big town/city."
+msgstr "Si vous êtes en dehors des États-Unis, insérez le nom de la grande ville/ville la plus proche."
+
+#: populate.py:478 populate.py:492
+msgid "What is your location?"
+msgstr "Emplacement enregistré sous?"
+
+#: populate.py:486
+msgid "Weather not found."
+msgstr "Météo introuvable."
+
+#: populate.py:487
+msgid "Please try another location."
+msgstr "Veuillez essayer un autre endroit."
+
+#: populate.py:509
+msgid "Please enter a timezone from the list located in the TZ*"
+msgstr "Veuillez entrer un fuseau horaire dans la liste située dans"
+
+#: populate.py:513
+msgid "column at"
+msgstr "la colonne TZ * à"
+
+#: populate.py:517
+msgid "or none at all."
+msgstr "ou pas du tout."
+
+#: populate.py:522 populate.py:536
+msgid "What is your timezone?"
+msgstr "Quel est votre fuseau horaire?"
+
+#: populate.py:532
+msgid "Not a valid timezone. Try again."
+msgstr "Pas un fuseau horaire valide. Réessayer."
+
+#: populate.py:557
+msgid "If you would like to choose a specific speech to text(STT) engine, please specify which!"
+msgstr ""
+"Si vous souhaitez choisir un moteur de parole à texte (STT) spécifique, veuillez spécifier lequel!"
+
+#: populate.py:567
+msgid "Available implementations:"
+msgstr "Implémentations disponibles:"
+
+#: populate.py:578 populate.py:849
+msgid "Unrecognized option."
+msgstr "Option non reconnue."
+
+#: populate.py:582
+msgid "Setting speech to text engine to "
+msgstr "Définition de la parole au moteur de texte à "
+
+#: populate.py:598
+msgid "Please enter your API key:"
+msgstr "Veuillez entrer votre clé API:"
+
+#: populate.py:610
+msgid "Please enter your watson username:"
+msgstr "Veuillez entrer votre nom d'utilisateur watson:"
+
+#: populate.py:617
+msgid "Please enter your watson password:"
+msgstr "Veuillez entrer votre mot de passe watson:"
+
+#: populate.py:630
+msgid "I need your Kaldi g-streamer server url to continue"
+msgstr "J'ai besoin de l'url de votre serveur Kaldi g-streamer pour continuer"
+
+#: populate.py:635
+msgid "default is"
+msgstr "le défaut est"
+
+#: populate.py:645
+msgid "Please enter your server url:"
+msgstr "Veuillez entrer l'URL de votre serveur:"
+
+#: populate.py:668
+msgid "Enter path to julius hmm defs"
+msgstr "Entrez le chemin de julius hmm defs"
+
+#: populate.py:676
+msgid "Enter path to julius tied list"
+msgstr "Entrez le chemin d'accès à la liste de liens julius"
+
+#: populate.py:684
+msgid "Enter path to julius lexicon"
+msgstr "Entrez le chemin de julius lexicon"
+
+#: populate.py:722
+msgid "What is the name of your phonetisaurus-g2p program?"
+msgstr "Quel est le nom de votre programme phonetisaurus-g2p?"
+
+#: populate.py:765
+msgid "Please enter the path to your hmm directory"
+msgstr "Veuillez entrer le chemin de votre répertoire hmm"
+
+#: populate.py:805
+msgid "Please enter the path to your fst model"
+msgstr "Veuillez entrer le chemin de votre premier modèle"
+
+#: populate.py:831
+msgid "If you would like to choose a specific text to speech (TTS) engine,"
+msgstr "Si vous souhaitez choisir un moteur de synthèse vocale (TTS)"
+
+#: populate.py:835
+msgid "please specify which."
+msgstr "spécifique, veuillez spécifier lequel."
+
+#: populate.py:840
+msgid "Available implementations: "
+msgstr "Implémentations disponibles "
+
+#: populate.py:850
+msgid "Setting text to speech engine to"
+msgstr "Réglage du texte sur le moteur vocal à"
+
+#: populate.py:884
+msgid "Available voices: "
+msgstr "Voix disponibles: "
+
+#: populate.py:890
+msgid "Select a voice"
+msgstr "Choisir la langue"
+
+#: populate.py:903
+msgid "You will now need to enter your Ivona account information."
+msgstr "Vous devrez maintenant entrer vos informations de compte Ivona."
+
+#: populate.py:908
+msgid "You will need to create an account at"
+msgstr "Vous devrez créer un compte sur"
+
+#: populate.py:913
+msgid "if you haven't already."
+msgstr "si vous ne l'avez pas déjà fait."
+
+#: populate.py:923
+msgid "What is your Access key?"
+msgstr "Quelle est votre clé d'accès?"
+
+#: populate.py:930
+msgid "What is your Secret key?"
+msgstr "Quelle est votre clé secrète?"
+
+#: populate.py:941
+msgid "(default is Brian)"
+msgstr "(défaut est Brian)"
+
+#: populate.py:941
+msgid "Which voice do you want"
+msgstr "Quelle voix voulez-vous"
+
+#: populate.py:956
+msgid "Server?"
+msgstr "Serveur?"
+
+#: populate.py:970
+msgid "Language?"
+msgstr "La langue?"
+
+#: populate.py:977
+msgid "Voice?"
+msgstr "Voix?"
+
+#: populate.py:988
+msgid "I have two ways to let you know I've heard you: Beep or Voice."
+msgstr "J'ai deux façons de vous faire savoir que je vous ai entendu: Bip ou voix"
+
+#: populate.py:999
+msgid "(B) for beeps or (V) for voice."
+msgstr "(B) pour les bips ou (V) pour la voix."
+
+#: populate.py:1005
+msgid "Please choose beeps (B) or voice (V):"
+msgstr "Veuillez choisir des bips (B) ou des voix (V):"
+
+#: populate.py:1014
+msgid "Type the words I should say after hearing my wake word: %s"
+msgstr "Tapez les mots que je devrais dire après avoir entendu mon mot réveil:% s"
+
+#: populate.py:1027
+msgid "Is this correct?"
+msgstr "Est-ce correct?"
+
+#: populate.py:1043
+msgid "Type the words I should say after hearing a command"
+msgstr "Tapez les mots que je devrais dire après avoir entendu une commande"
+
+#: populate.py:1050
+msgid "Response"
+msgstr "Réponse"
+
+#: populate.py:1071
+msgid "Writing to profile..."
+msgstr "Ecrire à profil ..."
+
+#: populate.py:1080
+msgid "Done."
+msgstr "Terminé."

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -136,7 +136,7 @@ def verifyLocation(place):
 # of that value, otherwise return None
 def CheckForValue(value, list):
     try:
-        temp = list.index(value)
+        temp = list.index(value)+1
     except ValueError:
         temp = None
     return temp
@@ -1006,7 +1006,7 @@ def run(profile):
         response = simple_input(
             t.red + _("Please choose beeps (B) or voice (V):") + t.bold_white
         )
-    if(response.lower()[:1] is "v"):
+    if(response.lower()[:1] == "v"):
         print("")
         print("")
         print("")
@@ -1017,25 +1017,26 @@ def run(profile):
         )
         print("")
         areplyRespon = None
-        while(areplyRespon.lower()[:1] != affirmative.lower()[:1]):
+        while((not areplyRespon) or (areplyRespon.lower()[:1] != affirmative.lower()[:1])):
             areply = simple_input(
                 format_prompt( 
                     "?",
-                    "Reply"
+                    _("Reply")
                 ),
-                get_profile_var(profile,"active_stt","response")
+                get_profile_var(profile,"active_stt","reply")
             )
             print("")
             print(areply + t.bold_blue +" " + _("Is this correct?"))
             print("")
-            while(not CheckForValue(areplyRespon.lower()[:1],[affirmative.lower()[:1],negative.lower()[:1]])):
+            areplyRespon = None
+            while((not areplyRespon) or (not CheckForValue(areplyRespon.lower()[:1],[affirmative.lower()[:1],negative.lower()[:1]]))):
                 areplyRespon = simple_input(
                     format_prompt( 
                         "?",
                         affirmative.upper()[:1] + "/" + negative.upper()[:1] +"?"
                     )
                 )
-        profile['active_stt'] = {'reply': areply}
+        profile['active_stt']['reply'] = areply
         print("")
         print("")
         print("")
@@ -1045,7 +1046,7 @@ def run(profile):
             + _("Type the words I should say after hearing a command")
         )
         aresponseRespon = None
-        while(aresponseRespon.lower()[:1] != affirmative.lower()[:1]):
+        while((not aresponseRespon) or (aresponseRespon.lower()[:1] != affirmative.lower()[:1])):
             aresponse = simple_input(
                 format_prompt( 
                     "?",
@@ -1056,13 +1057,15 @@ def run(profile):
             print("")
             print(aresponse + t.bold_blue+" Is this correct?")
             print("")
-            aresponseRespon = simple_input(
-                format_prompt( 
-                    "?",
-                    affirmative.upper()[:1] + "/" + negative.upper()[:1] + "?"
+            aresponseRespon = None
+            while((not aresponseRespon) or (not CheckForValue(aresponseRespon.lower()[:1],[affirmative.lower()[:1],negative.lower()[:1]]))):
+                aresponseRespon = simple_input(
+                    format_prompt( 
+                        "?",
+                        affirmative.upper()[:1] + "/" + negative.upper()[:1] + "?"
+                    )
                 )
-            )
-        profile['active_stt'] = {'response': aresponse}
+        profile['active_stt']['response'] = aresponse
         print("")
         print("")
         print("")

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -81,11 +81,11 @@ def simple_input(prompt, default=None):
 # AaronC - simple_request is more complicated, and populates
 # the profile variable directly
 def simple_request(profile, var, prompt, cleanInput=None):
-    input = simple_input(prompt, get_profile_var(profile, var))
-    if input:
+    input_str = simple_input(prompt, get_profile_var(profile, var))
+    if input_str:
         if cleanInput:
-            input = cleanInput(input)
-        profile[var] = input
+            input_str = cleanInput(input_str)
+        profile[var] = input_str
 
 
 # AaronC - This is currently used to clean phone numbers
@@ -141,9 +141,9 @@ def verifyLocation(place):
 # of that value (+ 1 so that the first item
 # does not return zero which is interpreted
 # as false), otherwise return None
-def CheckForValue(value, list):
+def CheckForValue(_value, _list):
     try:
-        temp = list.index(value) + 1
+        temp = _list.index(_value) + 1
     except ValueError:
         temp = None
     return temp
@@ -160,6 +160,7 @@ def run(profile):
     #
     global t, _
     t = Terminal()
+    _ = None
 
     language = get_profile_var(profile, "language")
     if(not language):

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 import feedparser
 from getpass import getpass
@@ -5,244 +6,651 @@ import os
 import paths
 import pytz
 import re
+import sys
 import yaml
+# The following is necessary because when this program is run as a standalone
+# program it can't do a relative import, so you have to add the current
+# directory to the path.
 if __name__ == '__main__' and __package__ is None:
-    os.sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import i18n
-# AaronC encrypt is going to be a placeholder for an actual
-# symmetric cipher so passwords are not stored in plain text.
-# from . import encrypt
-
-
-def run():
-    profile = {}
-    # language
-    # language = raw_input("\nWhat is your language ?" +
-    #                     "available: en-US, fr-FR, de-DE : \n")
-    language = ""
-    while not language or (language.lower() != 'english' and
-                           language.lower() != 'français' and
-                           language.lower() != 'deutsche'):
-        print("")
-        print("English")
-        print("Français")
-        language = raw_input("Deutsche: ")
-    if(language.lower() == 'english'):
-        language = 'en-US'
-    elif(language.lower() == 'français'):
-        language = 'fr-FR'
-    elif(language.lower() == 'deutsche'):
-        language = 'de-DE'
-
-    profile['language'] = language
-
-    translations = i18n.parse_translations(paths.data('locale'))
-    translator = i18n.GettextMixin(translations, profile)
-    print("")
-    print(translator.gettext("Hi i'm your Personnal Assistant."))
-    print(translator.gettext("Welcome to the profile populator. "))
-    print(translator.gettext("If, at any step, you'd prefer not to enter " +
-                             "the requested information"))
-    print(translator.gettext("just hit 'Enter' with a blank field to " +
-                             "continue."))
-    print("")
-
-    def simple_request(var, cleanVar, cleanInput=None):
-        input = raw_input(translator.gettext(cleanVar) + ": ")
-        if input:
-            if cleanInput:
-                input = cleanInput(input)
-            profile[var] = input
-
-    # my name
-    simple_request(
-        'keyword',
-        translator.gettext(
-            'First, what name would you like to call me by?'
-        )
-    )
-    print("")
-
-    # your name
-    print(translator.gettext("Now please tell me a little about yourself."))
-    simple_request('first_name', translator.gettext('What is your first name'))
-    simple_request('last_name', translator.gettext('What is your last name'))
-    print("")
-
-    # gmail
-    print(translator.gettext(
-        "I can use your GMail account to send notifications to you."
-    ))
-    print(translator.gettext(
-          "Alternatively, " +
-          "you can skip this step " +
-          "(or just fill in the email address if you " +
-          "want to receive email notifications) and setup a Mailgun " +
-          "account, as at " +
-          "http://naomiproject.github.io/documentation/" +
-          "software/#mailgun.\n"))
-    simple_request(
-        'gmail_address',
-        translator.gettext('Gmail address')
-    )
-    # FIXME This needs to be anything but plaintext.
-    # AaronC 2018-07-29 I've looked into this and the problem that needs to
-    # be solved here is a casual sort of hacker - like if you are working on
-    # your configuration file and your spouse is looking over your shoulder to
-    # get your password. I know that there are standard ways of dealing with
-    # this. I wonder how Thunderbird/Firefox deals with this.
-    profile['gmail_password'] = getpass()
-    print("")
-
-    # phone number
-    def clean_number(s):
-        return re.sub(r'[^0-9]', '', s)
-
-    phone_number = clean_number(
-        raw_input(
-            translator.gettext(
-                "Phone number (no country code). Any dashes or spaces will " +
-                "be removed for you: "
+    os.sys.path.append(
+        os.path.dirname(
+            os.path.dirname(
+                os.path.abspath(__file__)
             )
         )
     )
-    profile['phone_number'] = phone_number
+import i18n
+import subprocess
+from blessings import Terminal
+
+t = None
+
+# AaronC
+# Get a value from the profile, whether it exists or not
+# If the value does not exist in the profile, returns None
+def get_profile_var(profile,*args):
+    response = profile
+    for arg in args:
+        try:
+            response = response[arg]
+        except KeyError:
+            response = None
+            # break out of the for loop
+            break
+    return response
+    
+# AaronC - 
+def format_prompt(icon,prompt):
+    if(icon == "!"):
+        prompt = (
+            t.bold_white + '['
+            + t.bold_cyan + '!'
+            + t.bold_white + '] '
+            + prompt
+        )
+    elif(icon == "?"):
+        prompt = (
+            t.bold_white + '['
+            + t.bold_yellow + '?'
+            + t.bold_white + '] '
+            + prompt
+        )
+    return prompt
+
+# AaronC - simple_input is a lot like raw_input, just adds
+# a colon and space at the end. If a default value is
+# passed in, then adds that to the end followed by two slashes.
+# This used to be one of several standard ways of indicating
+# a default. If you want to override the behavior, of course,
+# then that can be done here.
+# Part of the purpose is to provide a way of overriding
+# raw_input easily without hunting down every reference
+def simple_input(prompt, default = None):
+    prompt += ": "
+    if(default):
+        prompt += default + "// "
+    sys.stdout.write(prompt)
+    response = raw_input()
+    # if the user pressed enter without entering anything,
+    # set the response to default
+    if(default and not response):
+         response = default
+    return response.strip()
+
+# AaronC - simple_request is more complicated, and populates
+# the profile variable directly
+def simple_request(profile, var, prompt, cleanInput=None):
+    input = simple_input(prompt, get_profile_var(profile, var))
+    if input:
+        if cleanInput:
+            input = cleanInput(input)
+        profile[var] = input
+
+# AaronC - This is currently used to clean phone numbers
+def clean_number(s):
+    return re.sub(r'[^0-9]', '', s)
+
+# AaronC - This searches some standard places (/bin, /usr/bin, /usr/local/bin)
+# for a program name.
+# This could be updated to search the PATH, and also verify that execute
+# permissions are set, but for right now this is a quick and dirty
+# placeholder.
+def CheckProgramExists(program):
+    standardlocations = ['/usr/local/bin', '/usr/bin', '/bin']
+    response = False
+    for location in standardlocations:
+        if(os.path.isfile(os.path.join(location, program))):
+            response = True
+    return response
+
+# FIXME
+# AaronC - Location. This uses weather underground for verification, which
+# I am not sure is really cool being as how it is a .com and all.
+# The good thing about using it is that you can either enter
+# a zip code or the closest city. The odd bit is that it shows you a
+# description of the location you have chosen, then stores the raw
+# input. I would have expected it to be stored as a lat/lon or something
+# especially since the weather plugin uses Yahoo weather rather than
+# weather underground. Personally, I would prefer to use NOAA for weather
+# in the US and the World Weather Information Service (but I am open to
+# suggestions) for other locations, and allow others to add country/
+# region specific weather sites as needed, but that is a whole other
+# project.
+# On the privacy side, I think it should be necessary to alert the user
+# any time their information is going to be shared with a new website,
+# and keep a list of authorized websites/services.
+def verifyLocation(place):
+    feed = feedparser.parse('http://rss.wunderground.com/auto/rss_full/' +
+                            place)
+    numEntries = len(feed['entries'])
+    if numEntries == 0:
+        return False
+    else:
+        print( 
+            _("Location saved as ")
+            + feed['feed']['description'][33:]
+        )
+        return True
+
+# If value exists in list, return the index
+# of that value, otherwise return None
+def CheckForValue(value, list):
+    try:
+        temp = list.index(value)
+    except ValueError:
+        temp = None
+    return temp
+
+def run(profile):
+    #
+    # AustinC; Implemented new UX for the population process.
+    # For population blessings is used to handle colors,
+    # formatting, & and screen isolation.
+    #
+    # For plugin & general use elsewhere, blessings or
+    # coloredformatting.py can be used.
+    #
+    global t, _
+    t = Terminal()
+    
+    language = get_profile_var(profile,"language")
+    if(not language):
+        language = 'en-US'
+        profile["language"] = language
+    translations = i18n.parse_translations(paths.data('locale'))
+    translator = i18n.GettextMixin(translations, profile)
+    _ = translator.gettext        
+    #
+    # AustinC; can't use français due to the special char "ç"
+    # it breaks due to it being out of range for ascii
+    #
+    languages = {
+        u'en-US': u'EN-English',
+        u'fr-FR': u'FR-Français',
+        u'de-DE': u'DE-Deutsch'
+    }
+    once = False
+    while not (
+        (
+            once
+        )and(
+            CheckForValue(language,languages.keys())
+        )
+    ):
+        once = True
+        print("")
+        print("")
+        print("")
+        print("    " + t.bold_blue + _("Language Selector"))
+        print("")
+        print("")
+        for key in languages.keys():
+            print t.bold_white + "    " + languages[key]
+        print("")
+        temp = simple_input(
+            format_prompt(
+                "?",
+                _('Select Language')
+            ),
+            language
+        ).lower().strip()
+        if(CheckForValue(temp[:2],[key[:2] for key in languages.keys()])):
+            for key in languages.keys():
+                if(temp[:2] == key[:2]):
+                    language = key
+                    break
+        if(language.lower()[:2] == 'en'):
+            language = 'en-US'
+            affirmative = 'yes'
+            negative = 'no'
+        elif(language.lower()[:2] == 'fr'):
+            language = 'fr-FR'
+            affirmative = 'oui'
+            negative = 'non'
+        elif(language.lower()[:2] == 'de'):
+            language = 'de-DE'
+            affirmative = "ja"
+            negative = "nein"
+
+    profile['language'] = language
+    translations = i18n.parse_translations(paths.data('locale'))
+    translator = i18n.GettextMixin(translations, profile)
+    _ = translator.gettext
     print("")
+    print("")
+    print("")
+    print("    "+t.bold_blue(
+        _("Hello, thank you for selecting me to be your personal assistant.")
+    ))
+    print("")
+    print("    "+t.bold_blue(
+        _("Let's populate your profile.")
+    ))
+    print("")
+    print("    "+t.bold_blue(
+        _("If, at any step, you would prefer not to enter the requested information")
+    ))
+    print("    "+t.bold_blue(
+        _("just hit 'Enter' with a blank field to continue.")
+    ))
+    print("")
+
+    # my name
+    simple_request(
+        profile,
+        'keyword',
+        format_prompt( 
+            "?",
+            _('First, what name would you like to call me by?').decode('utf-8')
+        )
+    )
+    print("")
+    print("")
+    print("")
+
+    # your name
+    print("    " + t.bold_blue +
+        _("Now please tell me a little about yourself.")
+    )
+    print("")
+    simple_request(
+        profile,
+        "first_name",
+        format_prompt( 
+            "?",
+            _("What is your first name?")
+        )
+    )
+    print("")
+    simple_request(
+        profile,
+        'last_name',
+        format_prompt( 
+            "?",
+            _('What is your last name?').decode('utf-8')
+        )
+    )
+    print("")
+    print("")
+    print("")
+
+    # email
+    
+    print(
+        "    "
+        + t.bold_blue
+        + _("I can use an email account to send notifications to you.")
+    )
+    print("")
+    print("    " + _("Alternatively, you can skip this step"))
+    # email
+    try:
+        temp = profile["email"]
+    except KeyError:
+        profile["email"] = {}
+    # email imap
+    profile["email"]["imap"]=simple_input(
+        format_prompt( 
+            "?",
+            _('Please enter your imap server as "server[:port]"')
+        ),
+        get_profile_var(profile,"email","imap")
+    )
+    
+    profile["email"]["address"]=simple_input(
+        format_prompt( 
+            "?",
+            _('What is your email address?')
+        ),
+        get_profile_var(profile,"email","address")
+    )
+    
+    # FIXME This needs to be anything but plaintext.
+    # AaronC 2018-07-29 I've looked into this and the problem that needs to
+    # be solved here is protection from a casual sort of hacker - like if
+    # you are working on your configuration file and your friend is looking
+    # over your shoulder and gets your password. I know that there are
+    # standard ways of dealing with this. I wonder how Thunderbird/Firefox
+    # deals with this.
+    temp = getpass(
+        format_prompt(
+            "?",
+            _('What is your email password?') + ': '
+        )
+    )
+    if( temp ):
+        profile['email']['password'] = temp
+    print("")
+    print("")
+    print("")
+    
+    print(
+        "    "
+        + t.bold_blue
+        + _("I can use your phone number to send notifications to you.")
+    )
+    print(
+        "    "
+        + _("Alternatively, you can skip this step")
+    )
+    print("")
+    print(
+        "    "
+        + t.red
+        + _("No country codes!")
+        + t.bold_blue + " "
+        + _("Any dashes or spaces will be removed for you")
+    )
+    print("")
+    phone_number = clean_number(
+        simple_input(
+            format_prompt(
+                "?",
+                _("What is your Phone number?")
+            ),
+            get_profile_var(profile,'phone_number')
+        )
+    )
+    profile['phone_number'] = phone_number
 
     # carrier
-    print(translator.gettext("Phone carrier (for sending text notifications)."))
-    print(translator.gettext("If you have a US phone number, you can enter " +
-          "one of the following: 'AT&T', 'Verizon', 'T-Mobile' " +
-          "(without the quotes). " +
-          "If your carrier isn't listed or you have an international " +
-          "number, go to http://www.emailtextmessages.com and enter the " +
-          "email suffix for your carrier (e.g., for Virgin Mobile, enter " +
-          "'vmobl.com'; for T-Mobile Germany, enter 't-d1-sms.de')."))
-    carrier = raw_input(translator.gettext('Carrier: '))
-    if carrier == 'AT&T':
-        profile['carrier'] = 'txt.att.net'
-    elif carrier == 'Verizon':
-        profile['carrier'] = 'vtext.com'
-    elif carrier == 'T-Mobile':
-        profile['carrier'] = 'tmomail.net'
-    else:
-        profile['carrier'] = carrier
-    print("")
-
-    # location
-    def verifyLocation(place):
-        feed = feedparser.parse('http://rss.wunderground.com/auto/rss_full/' +
-                                place)
-        numEntries = len(feed['entries'])
-        if numEntries == 0:
-            return False
+    if(profile['phone_number']):
+        print("")
+        print("")
+        print("")
+        # If the phone number is blank, it makes no sense to ask
+        # for the carrier.
+        print(
+            "    "
+            + t.bold_blue
+            + _("What is your phone carrier?")
+        )
+        print(
+            "    "
+            + _("If you have a US phone number, ")
+            + _("you can enter one of the following:")
+        )
+        print(
+            "    'AT&T', 'Verizon', 'T-Mobile' "
+            + t.red
+            + "(" + _("without the quotes") +")."
+        )
+        print("")
+        print(
+            "    "
+            + t.bold_blue
+            + _("If your carrier isn't listed or you have an international")
+        )
+        print(
+            "    "
+            + _("number, go to") + " "
+            + t.bold_yellow + "http://www.emailtextmessages.com"
+        )
+        print(
+            "    "
+            + t.bold_blue
+            + _("and enter the email suffix for your carrier (e.g., for Virgin Mobile, enter ")
+        )
+        print("    " + _("'vmobl.com'; for T-Mobile Germany, enter 't-d1-sms.de')."))
+        print("")
+        carrier = simple_input(
+            format_prompt( 
+                "?",
+                _("What is your Carrier? ")
+            ),
+            get_profile_var(profile,"carrier")
+        )
+        if carrier == 'AT&T':
+            profile['carrier'] = 'txt.att.net'
+        elif carrier == 'Verizon':
+            profile['carrier'] = 'vtext.com'
+        elif carrier == 'T-Mobile':
+            profile['carrier'] = 'tmomail.net'
         else:
-            print(translator.gettext("Location saved as ") +
-                  feed['feed']['description'][33:])
-            return True
+            profile['carrier'] = carrier
+        print("")
 
-    print(translator.gettext("Location should be a 5-digit US zipcode " +
-          "(e.g., 08544). If you are outside the US, insert the name of " +
-          "your nearest big town/city.  For weather requests."))
-    location = raw_input(translator.gettext("Location: "))
+    # Notifications
+    # Used by hackernews and news plugins.
+    # Neither of which attempt to send a text message,
+    # both check to see if you have an email address
+    # in your profile, then if you have "prefers_email"
+    # selected, it will send an article to you via email,
+    # otherwise it does not attempt to send anything to you.
+    
+    # if the user has entered an email address but no phone number
+    # go ahead and assume "prefers email"
+    if((profile['email']['address']) and not (profile['phone_number'])):
+        profile["prefers_email"] = True
+    # if both email address and phone number are configured, ask
+    # which the user prefers
+    elif((profile['phone_number']) and (profile['email']['address'])):
+        print(
+            "    "
+            + t.bold_blue
+            + _("Would you prefer to have notifications sent by")
+        )
+        print(
+            "    "
+            + _("email (E) or text message (T)?")
+        )
+        print("")
+        if(get_profile_var(profile,"prefers_email")):
+            temp = 'E'
+        else:
+            temp = "T"
+        response = simple_input(
+            format_prompt( 
+                "?",
+                _("Email (E) or Text message (T)?")
+            ),
+            temp
+        )
+        
+        while not response or (response[:1] != 'E' and response[:1] != 'T'):
+            print("")
+            response = simple_input(
+                t.red
+                + _("Please choose email (E) or text message (T)!")
+                + t.bold_white,
+                response
+            )
+        profile['prefers_email'] = (response == 'E')
+    else:
+        # if no email address is configured, just set this to false
+        profile['prefers_email'] = False
+
+    # Weather
+    print("")
+    print("")
+    print("")
+    print(
+        "    "
+        + t.bold_blue
+        + _("For weather information, please enter your 5-digit zipcode (e.g., 08544).")
+    )
+    print(
+        "    "
+        + _("If you are outside the US, insert the name of the nearest big town/city.")
+    )
+    print("")
+    location = simple_input(
+        format_prompt( 
+            "?",
+            _("What is your location?")
+        ),
+        get_profile_var(profile,"location")
+    )
+    
     while location and not verifyLocation(location):
-        print(translator.gettext("Weather not found. " +
-                                 "Please try another location."))
-        location = raw_input(translator.gettext("Location: "))
+        print(
+            t.red
+            + _("Weather not found.") + " "
+            + _("Please try another location.")
+        )
+        location = simple_input(
+            format_prompt( 
+                "?",
+                _("What is your location?")
+            ),
+            location
+        )
     if location:
         profile['location'] = location
+    print("")
+    print("")
     print("")
 
     # timezone
     # FIXME AaronC 2018-07-26 Knowing the zip code, you should be
     # able to work out the time zone.
     # Also, sending me to a wikipedia page to configure this? Really?
-    print(translator.gettext(
-          "Please enter a timezone from the list located in the TZ* " +
-          "column at http://en.wikipedia.org/wiki/" +
-          "List_of_tz_database_time_zones, or none at all."))
-    tz = raw_input(translator.gettext("Timezone: "))
+    print(
+        "    "
+        + t.bold_blue
+        + _("Please enter a timezone from the list located in the TZ*")
+    )
+    print(
+        "    "
+        + _("column at") + " "
+        + t.bold_yellow
+        + "http://en.wikipedia.org/wiki/List_of_tz_database_time_zones"
+    )
+    print("    " + t.bold_blue + _("or none at all."))
+    print("")
+    tz = simple_input(
+        format_prompt( 
+            "?",
+            _("What is your timezone?")
+        ),
+        get_profile_var(profile,"timezone")
+    )
     while tz:
         try:
             pytz.timezone(tz)
             profile['timezone'] = tz
             break
         except pytz.exceptions.UnknownTimeZoneError:
-            print(translator.gettext("Not a valid timezone. Try again."))
-            tz = raw_input("Timezone: ")
+            print(t.red+_("Not a valid timezone. Try again."))
+            tz = simple_input(
+                format_prompt( 
+                    "?",
+                    _("What is your timezone?")
+                ),
+                tz
+            )
+    print("")
+    print("")
     print("")
 
-    response = raw_input(translator.gettext(
-        "Would you prefer to have notifications sent by " +
-        "email (E) or text message (T)? "
-    ))
-    while not response or (response != 'E' and response != 'T'):
-        response = raw_input(translator.gettext(
-            "Please choose email (E) or text message (T): "
-        ))
-    profile['prefers_email'] = (response == 'E')
-    print("")
-
+    # Get a list of STT engines
     stt_engines = {
         "PocketSphinx": "sphinx",
+        "DeepSpeech": "deepspeech-stt",
         "Google Voice": "google",
         "Watson": "watson-stt",
         "Kaldi": "kaldigstserver-stt",
         "Julius": "julius-stt"
     }
 
-    # This searches some standard places (/bin, /usr/bin, /usr/local/bin)
-    # for a program name.
-    # This could be updated to search the PATH, and also verify that execute
-    # permissions are set, but for right now this is a quick and dirty
-    # placeholder.
-    def CheckProgramExists(program):
-        standardlocations = ['/usr/local/bin', '/usr/bin', '/bin']
-        response = False
-        for location in standardlocations:
-            if(os.path.isfile(os.path.join(location, program))):
-                response = True
-        return response
-
-    print(translator.gettext(
-        "If you would like to choose a specific speech to text " +
-        "(STT) engine, please specify which."
-    ))
-    response = raw_input(
-        translator.gettext(
-            "Available implementations: %s. " +
-            "(Press Enter to default to PocketSphinx): "
-        ) % stt_engines.keys()
+    print(
+        "    "
+        + t.bold_blue
+        + _("If you would like to choose a specific speech to text(STT) engine, please specify which!")
     )
-    if (response in stt_engines):
-        profile['stt_engine'] = stt_engines[response]
+    print("")
+    response = "PocketSphinx"
+    for engine in stt_engines:
+        if (get_profile_var(profile,'stt_engine')==stt_engines[engine]):
+            response = engine
+            break
+    response = simple_input(
+        "    "
+        + _("Available implementations:") + " "
+        + t.yellow + ("%s. " % stt_engines.keys()) + t.bold_white,
+        response
+    )
+    print("")
+    if (response in stt_engines.keys()):
+        profile['stt_engine'] = response
     else:
-        print(translator.gettext(
-            "Unrecognized option. " +
-            "Setting speech to text engine to Pocketsphinx."
-        ))
+        if response:
+            print(
+                t.red
+                + _("Unrecognized option.")
+            )
+        print(
+            t.bold_white
+            + _("Setting speech to text engine to ")
+            + t.yellow
+            + "Pocketsphinx."
+            + t.bold_white
+        )
         profile['stt_engine'] = 'sphinx'
+    print("")
+    print("")
+    print("")
     # Handle special cases here
     if(profile['stt_engine'] == 'google'):
         # Set the api key (I'm not sure this actually works anymore,
         # need to test)
-        key = raw_input(translator.gettext("Please enter your API key: "))
-        profile["keys"] = {"GOOGLE_SPEECH": key}
+        key = simple_input(
+            format_prompt( 
+                "!",
+                _("Please enter your API key:")
+            ),
+            get_profile_var(profile,"keys","GOOGLE_SPEECH")
+        )
+        print("")
+        print("")
+        print("")
     if(profile['stt_engine'] == 'watson-stt'):
         profile["watson_stt"] = {}
-        username = raw_input(translator.gettext("Enter your watson username:"))
+        username = simple_input(
+            format_prompt( 
+                "!",
+                _("Please enter your watson username:")
+            )
+        )
         profile["watson_stt"]["username"] = username
         # FIXME AaronC 2018-07-29 - another password. Not as crucial as
         # protecting the user's email password but still...
-        profile["watson_stt"]["password"] = getpass()
-    if(profile['stt_engine'] == 'kaldigstserver-stt'):
-        profile['kaldigstserver-stt'] = {}
-        profile['kaldigstserver-stt']['url'] = raw_input(
-            translator.gettext(
-                "Enter your Kaldi g-streamer searver url " +
-                "(default is http://localhost:8888/client/dynamic/recognize)"
-            )
+        profile["watson_stt"]["password"] = getpass(
+            _("Please enter your watson password:")
         )
+        print("")
+        print("")
+        print("")
+    if(profile['stt_engine'] == 'kaldigstserver-stt'):
+        try:
+            temp = profile['kaldigstserver-stt']
+        except KeyError:
+            profile['kaldigstserver-stt'] = {}
+        print(
+            "    "
+            + t.bold_blue
+            + _("I need your Kaldi g-streamer server url to continue")
+        )
+        default = "http://localhost:8888/client/dynamic/recognize"
+        print(
+            "    ("
+            + _("default is")
+            + t.yellow + " %s)" % default
+        )
+        print("")
+        temp = get_profile_var(profile,"kaldigstserver-stt","url")
+        if(not temp):
+            temp = default
+        profile['kaldigstserver-stt']['url'] = simple_input(
+            format_prompt( 
+                "!",
+                _("Please enter your server url:")
+            ),
+            temp
+        )
+        print("")
+        print("")
+        print("")
     if(profile['stt_engine'] == 'julius-stt'):
         # stt_engine: julius
         # julius:
@@ -251,15 +659,33 @@ def run():
         #     lexicon:  '/path/to/your/lexicon.tgz'
         #     lexicon_archive_member: 'VoxForge/VoxForgeDict'
         #           only needed if lexicon is a tar/tar.gz archive
-        profile["julius"] = {}
-        profile["julius"]["hmmdefs"] = raw_input(
-            translator.gettext("Enter path to julius hmm defs:")
+        try:
+            temp = profile["julius"]
+        except KeyError:
+            profile["julius"] = {}
+        # hmmdefs
+        profile["julius"]["hmmdefs"] = simple_input(
+            format_prompt( 
+                "!",
+                _("Enter path to julius hmm defs")
+            ),
+            get_profile_var(profile,"julius","hmmdefs")
         )
-        profile["julius"]["tiedlist"] = raw_input(
-            translator.gettext("Enter path to julius tied list:")
+        # tiedlist
+        profile["julius"]["tiedlist"] = simple_input(
+            format_prompt( 
+                "!",
+                _("Enter path to julius tied list")
+            ),
+            get_profile_var(profile,"julius","tiedlist")
         )
-        profile["julius"]["lexicon"] = raw_input(
-            translator.gettext("Enter path to julius lexicon:")
+        # lexicon
+        profile["julius"]["lexicon"] = simple_input(
+            format_prompt( 
+                "!",
+                _("Enter path to julius lexicon")
+            ),
+            get_profile_var(profile,"julius","lexicon")
         )
         # FIXME AaronC 2018-07-29 So I don't know if I need to check above to
         # see if the julius lexicon is a tar file or if I can just set this.
@@ -269,54 +695,54 @@ def run():
         # something needs to be entered. Someone with experience setting up
         # Julius will need to finish this up.
         profile["julius"]["lexicon_archive_member"] = "VoxForge/VoxForgeDict"
+        print("")
+        print("")
+        print("")
     else:
-        profile["pocketsphinx"] = {}
+        try:
+            temp = profile["pocketsphinx"]
+        except KeyError:
+            profile["pocketsphinx"] = {}
         # AaronC 2018-07-29 Since pocketsphinx/phonetisaurus is assumed, make
         # this the default at the end
         # is the phonetisaurus program phonetisaurus-g2p (old version)
         # or phonetisaurus-g2pfst?
-        phonetisaurus_executable = ''
-        while not(phonetisaurus_executable):
+        phonetisaurus_executable = get_profile_var(profile,'pocketsphinx','phonetisaurus_executable')
+        once = False
+        while not((once) and (phonetisaurus_executable)):
+            once = True
             # Let's check some standard places (this is crunchier than actually
             # using "find" but should work in most cases):
-            if(CheckProgramExists('phonetisaurus-g2pfst')):
-                phonetisaurus_executable = 'phonetisaurus-g2pfst'
-            elif(CheckProgramExists('phonetisaurus-g2p')):
-                phonetisaurus_executable = 'phonetisaurus-g2p'
-            else:
-                # AaronC 2018-07-29
-                # Ask the user
-                # I could force one of those choices, but I would like to leave
-                # it open for the user to select a different option because
-                # they may have renamed the executable. Of course, this
-                # greatly increates the possibility of the user fat-fingering
-                # the name at this point.
-                # Might be good to add an "are you sure?" below if this
-                # response is not one of the two standard responses.
-                print(translator.gettext(
-                    "I cannot locate phonetisaurus-g2p(fst) " +
-                    "in any of the standard locations."
-                ))
-                print(translator.gettext(
-                    "What is the name of your phonetisaurus-g2p program?"
-                ))
-                phonetisaurus_executable = raw_input(translator.gettext(
-                    "(either phonetisaurus-g2p or phonetisaurus-g2pfst, " +
-                    "try using the find command)"
-                ))
+            if(not phonetisaurus_executable):
+                if(CheckProgramExists('phonetisaurus-g2pfst')):
+                    phonetisaurus_executable = 'phonetisaurus-g2pfst'
+                elif(CheckProgramExists('phonetisaurus-g2p')):
+                    phonetisaurus_executable = 'phonetisaurus-g2p'
+            phonetisaurus_executable = simple_input(
+                format_prompt( 
+                    "?",
+                    _("What is the name of your phonetisaurus-g2p program?")
+                ),
+                phonetisaurus_executable
+            )
         profile['pocketsphinx']['phonetisaurus_executable'] = phonetisaurus_executable
+        print("")
+        print("")
+        print("")
         # We have the following things to configure:
-        #  hmm_dir - the default for naomi is "/usr/local/share/pocketsphinx/model/hmm/en_US/hub4wsj_sc_8k"
+        #  hmm_dir - the default for kara is "/usr/local/share/pocketsphinx/model/hmm/en_US/hub4wsj_sc_8k"
         #          - if you install through the pocketsphinx-en-us debian apt package then it is "/usr/share/pocketsphinx/model/en-us/en-us"
         #          - if you install the latest pocketsphinx from source, it should be here: "~/pocketsphinx/model/en-us/en-us"
         #  fst_model -
-        #          - the default for naomi is "~/phonetisaurus/g014b2b.fst"
+        #          - the default for kara is "~/phonetisaurus/g014b2b.fst"
         #          - if you install the latest CMUDict, then it will be at "~/CMUDict/train/model.fst"
-        hmm_dir = ""
-        while not(hmm_dir):
-            if(phonetisaurus_executable == "phonetisaurus-g2pfst"):
-                # The hmm_dir should be under the user's home directory
-                # in the "~/pocketsphinx/model/en-us/en-us" directory
+        hmm_dir=get_profile_var(profile,'pocketsphinx','hmm_dir')
+        once = False
+        while not(once and hmm_dir):
+            once = True
+            # The hmm_dir should be under the user's home directory
+            # in the "~/pocketsphinx/model/en-us/en-us" directory
+            if(not hmm_dir):
                 if(os.path.isdir(os.path.join(
                     os.path.expanduser("~"),
                     "pocketsphinx",
@@ -331,55 +757,60 @@ def run():
                         "en-us",
                         "en-us"
                     )
-            elif(phonetisaurus_executable == "phonetisaurus-g2p"):
-                if(os.path.isdir("/usr/share/pocketsphinx/model/en-us/en-us")):
+                elif(os.path.isdir("/usr/share/pocketsphinx/model/en-us/en-us")):
                     hmm_dir = "/usr/share/pocketsphinx/model/en-us/en-us"
                 elif(os.path.isdir("/usr/local/share/pocketsphinx/model/hmm/en_US/hub4wsj_sc_8k")):
                     hmm_dir = "/usr/local/share/pocketsphinx/model/hmm/en_US/hub4wsj_sc_8k"
-            if not(hmm_dir):
-                print(translator.gettext(
-                    "I could not find your hmm directory in any " +
-                    "of the standard places"
-                ))
-                hmm_dir = raw_input(translator.gettext(
-                    "Please enter the path to your hmm directory:"
-                ))
+            temp = simple_input(
+                format_prompt( 
+                    "!",
+                    _("Please enter the path to your hmm directory")
+                ),
+                hmm_dir
+            )
+            if( temp ):
+                hmm_dir = temp
         profile["pocketsphinx"]["hmm_dir"] = hmm_dir
-        fst_model = ""
-        while not(fst_model):
-            if(phonetisaurus_executable == "phonetisaurus-g2pfst"):
-                if(os.path.isfile(os.path.join(
-                    os.path.expanduser("~"),
-                    "CMUDict",
-                    "train",
-                    "model.fst"
-                ))):
-                    fst_model = os.path.join(
+        # fst_model
+        fst_model = get_profile_var(profile,"pocketsphinx","fst_model")
+        once = False
+        while not (once and fst_model):
+            once = True
+            if(not fst_model):
+                if(phonetisaurus_executable == "phonetisaurus-g2pfst"):
+                    if(os.path.isfile(os.path.join(
                         os.path.expanduser("~"),
-                        "CMUDict",
+                        "cmudict",
                         "train",
                         "model.fst"
-                    )
-            elif(phonetisaurus_executable == "phonetisaurus-g2p"):
-                if(os.path.isfile(os.path.join(
-                    os.path.expanduser("~"),
-                    "phonetisaurus",
-                    "g014b2b.fst"
-                ))):
-                    fst_model = os.path.join(
+                    ))):
+                        fst_model = os.path.join(
+                            os.path.expanduser("~"),
+                            "cmudict",
+                            "train",
+                            "model.fst"
+                        )
+                elif(phonetisaurus_executable == "phonetisaurus-g2p"):
+                    if(os.path.isfile(os.path.join(
                         os.path.expanduser("~"),
                         "phonetisaurus",
                         "g014b2b.fst"
-                    )
-            else:
-                print(translator.gettext(
-                    "I could not find your fst model " +
-                    "(usually either g014b2b.fst or model.fst)"
-                ))
-                fst_model = raw_input(translator.gettext(
-                    "Please enter the path to your fst model:"
-                ))
+                    ))):
+                        fst_model = os.path.join(
+                            os.path.expanduser("~"),
+                            "phonetisaurus",
+                            "g014b2b.fst"
+                        )
+            fst_model = simple_input(
+                format_prompt( 
+                    "!",
+                    _("Please enter the path to your fst model")
+                ),
+                fst_model
+            )
         profile["pocketsphinx"]["fst_model"] = fst_model
+    print("")
+    print("")
     print("")
 
     # Text to speech information
@@ -392,100 +823,270 @@ def run():
         "Ivona": "ivona-tts",
         "Mary": "mary-tts"
     }
-    print(translator.gettext(
-        "If you would like to choose a specific text to speech (TTS) engine, " +
-        "please specify which."
-    ))
-    response = raw_input(translator.gettext(
-        "Available implementations: %s. (Press Enter to default to Festival): "
-    ) % tts_engines.keys())
+    response = "Festival"
+    for engine in tts_engines:
+        if(get_profile_var(profile,"tts_engine")==tts_engines[engine]):
+            response = engine
+    print(
+        "    "
+        + t.bold_blue
+        + _(
+            "If you would like to choose a specific text to speech (TTS) engine,"
+        )
+    )
+    print("    " + _("please specify which."))
+    print("")
+    response = simple_input(
+        format_prompt(
+            "?",
+            t.bold_white + _("Available implementations: ")
+            + t.yellow + ("%s. " % tts_engines.keys()) +t.bold_white
+        ),
+        response
+    )
     if(response in tts_engines.keys()):
         profile['tts_engine'] = tts_engines[response]
     else:
-        print(translator.gettext(
-            "Unrecognized option. Setting text to speech engine to Festival."
-        ))
+        print(
+            t.red+_("Unrecognized option.") +
+            t.bold_white+_("Setting text to speech engine to") + " " +
+            t.yellow+"Festival."
+        )
         profile['tts_engine'] = 'festival-tts'
+        print("")
+        print("")
+        print("")
     # Deal with special cases
     if(profile["tts_engine"] == "espeak-tts"):
         # tts_engine: espeak-tts
-        print(
-            "If you would like to alter the espeak voice, you can use " +
-            "the following options in your config file:"
-        )
-        print("espeak-tts:")
-        print("    voice: 'default+m3'   # optional")
-        print("    pitch_adjustment: 40  # optional")
-        print("    words_per_minute: 160 # optional")
+        print(t.bold_blue+"    If you would like to alter the espeak voice, you can use")
+        print("    the following options in your config file:")
+        print("")
+        print("    espeak-tts:")
+        print("        voice: 'default+m3'   # optional")
+        print("        pitch_adjustment: 40  # optional")
+        print("        words_per_minute: 160 # optional")
+        print("")
+        print("")
+        print("")
     elif(profile["tts_engine"] == "festival-tts"):
         # tts_engine: festival-tts
-        print("Use the festival command to set the default voice.")
+        print(t.bold_blue+"    Use the festival command to set the default voice.")
+        print("")
+        print("")
+        print("")
     elif(profile["tts_engine"] == "flite-tts"):
-        print("You can set the default voice in the config file as so:")
-        print("tts_engine: flite-tts")
-        print("flite-tts:")
-        print("    voice:'slt'")
-    # elif( profile["tts_engine"]=="pico-tts" ):
-    #    # there is nothing to configure, apparently
-    elif(profile["tts_engine"] == "ivona-tts"):
-        print("You will now need to enter your Ivona account information.")
+        try:
+            temp = profile["flite-tts"]
+        except KeyError:
+            profile["flite-tts"] = {}
+        voices = subprocess.check_output(['flite','-lv']).split(" ")[2:-1]
         print(
-            "You will need to create an account at " +
-            "https://www.ivona.com/us/account/speechcloud/creation/ " +
-            "if you haven't already."
+            "    "
+            + _("Available voices: ")
+            + t.yellow + "%s. " % voices
         )
-        profile["ivona-tts"] = {}
-        profile["ivona-tts"]["access_key"] = raw_input("Access key:")
-        profile["ivona-tts"]["secret_key"] = raw_input("Secret key:")
-        profile["ivona-tts"]["voice"] = raw_input("Voice (default is Brian):")
+        profile["flite-tts"]["voice"]=simple_input(
+            format_prompt( 
+                "?",
+                _("Select a voice")
+            ),
+            get_profile_var(profile,"flite-tts","voice")
+        )
+        print("")
+        print("")
+        print("")
+    elif( profile["tts_engine"]=="pico-tts" ):
+        pass
+    elif(profile["tts_engine"] == "ivona-tts"):
+        print(
+            "    "
+            + t.bold_blue
+            + _("You will now need to enter your Ivona account information.")
+        )
+        print("")
+        print(
+            "    "
+            + _("You will need to create an account at")
+        )
+        print(
+            "    " + t.yellow
+            + "https://www.ivona.com/us/account/speechcloud/creation/"
+            + " " + t.bold_blue + _("if you haven't already.")
+        )
+        print("")
+        try:
+            temp = profile["ivona-tts"]
+        except KeyError:
+            profile["ivona-tts"] = {}
+        profile["ivona-tts"]["access_key"] = simple_input(
+            format_prompt( 
+                "?",
+                _("What is your Access key?")
+            ),
+            get_profile_var(profile,"ivona-tts","access_key")
+        )
+        profile["ivona-tts"]["secret_key"] = simple_input(
+            format_prompt( 
+                "?",
+                _("What is your Secret key?")
+            ),
+            get_profile_var(profile,"ivona-tts","secret_key")
+        )
+        # ivona-tts voice
+        temp = get_profile_var(profile,"ivona-tts","voice")
+        if(not temp):
+            temp="Brian"
+        profile["ivona-tts"]["voice"] = simple_input(
+            format_prompt( 
+                "?",
+                _("Which voice do you want")+" "+t.yellow+_("(default is Brian)")+t.bold_white+"?"
+            ),
+            temp
+        )
+        print("")
+        print("")
+        print("")
     elif(profile["tts_engine"] == "mary-tts"):
-        profile["mary-tts"] = {}
-        profile["mary-tts"]["server"] = raw_input("Server:")
-        profile["mary-tts"]["port"] = raw_input("Port:")
-        profile["mary-tts"]["language"] = raw_input("Language:")
-        profile["mary-tts"]["voice"] = raw_input("Voice:")
+        try:
+            temp = profile["mary-tts"]
+        except KeyError:
+            profile["mary-tts"] = {}
+        profile["mary-tts"]["server"] = simple_input(
+            format_prompt( 
+                "?",
+                _("Server?")
+            ),
+            get_profile_var(profile,"mary-tts","server")
+        )
+        profile["mary-tts"]["port"] = simple_input(
+            format_prompt( 
+                "?",
+                "Port?"
+            ),
+            get_profile_var(profile,"mary-tts","port")
+        )
+        profile["mary-tts"]["language"] = simple_input(
+            format_prompt( 
+                "?",
+                _("Language?")
+            ),
+            get_profile_var(profile,"mary-tts","language")
+        )
+        profile["mary-tts"]["voice"] = simple_input(
+            format_prompt( 
+                "?",
+                _("Voice?")
+            ),
+            get_profile_var(profile,"mary-tts","voice")
+        )
+        print("")
+        print("")
+        print("")
     # Getting information to beep or not beep
-    print(translator.gettext(
-        "Naomi's active listener has two modes Beep or Voice."
-    ))
-    response = raw_input(translator.gettext(
-        "Please Choose (B) for beeps or (V) for voice. "
-    ))
-    while not response or (response != 'B' and response != 'V'):
-        response = raw_input(translator.gettext(
-            "Please choose beeps (B) or voice (V): "
-        ))
-    if(response is not "B"):
-        print(translator.gettext(
-            "Type the words that naomi will respond with " +
-            "after its name being called."
-        ))
-        areply = raw_input("Reply: ")
-        print(areply + " Is this correct?")
-        areplyRespon = raw_input("Y/N?")
-        while not(areplyRespon.upper() == 'Y' or areplyRespon.upper() == 'N'):
-            areplyRespon = raw_input("Y/N?")
-        if(areplyRespon != "Y"):
-            areply = raw_input("Reply: ")
+    print(
+        "    "
+        + t.bold_blue
+        + _("I have two ways to let you know I've heard you; Beep or Voice.")
+    )
+    # If there are values for [active-stt][reply] and [active-stt][response]
+    # then use them otherwise use beeps
+    if(get_profile_var(profile, "active-stt", "reply")):
+        temp = "V"
+    else:
+        temp = "B"
+    response = simple_input(
+        format_prompt( 
+            "?",
+            _("(B) for beeps or (V) for voice.")
+        ),
+        temp
+    )
+    while not response or (response.lower()[:1] != 'b' and response.lower()[:1] != 'v'):
+        response = simple_input(
+            t.red + _("Please choose beeps (B) or voice (V):") + t.bold_white
+        )
+    if(response.lower()[:1] is "v"):
+        print("")
+        print("")
+        print("")
+        print(
+            "    "
+            + t.bold_blue
+            + _("Type the words I should say after hearing my wake word: %s") % profile["keyword"]
+        )
+        print("")
+        areplyRespon = None
+        while(areplyRespon.lower()[:1] != affirmative.lower()[:1]):
+            areply = simple_input(
+                format_prompt( 
+                    "?",
+                    "Reply"
+                ),
+                get_profile_var(profile,"active_stt","response")
+            )
+            print("")
+            print(areply + t.bold_blue +" " + _("Is this correct?"))
+            print("")
+            while(not CheckForValue(areplyRespon.lower()[:1],[affirmative.lower()[:1],negative.lower()[:1]])):
+                areplyRespon = simple_input(
+                    format_prompt( 
+                        "?",
+                        affirmative.upper()[:1] + "/" + negative.upper()[:1] +"?"
+                    )
+                )
         profile['active_stt'] = {'reply': areply}
-        print("Type the words that naomi will say after hearing you.")
-        aresponse = raw_input("Response: ")
-        print(aresponse + "\n is this correct?")
-        aresponseRespon = raw_input("Y/N?")
-        while(aresponseRespon != 'Y' and aresponseRespon != 'N'):
-            aresponseRespon = raw_input("Y/N?")
-        if(aresponseRespon is not "Y"):
-            aresponse = raw_input("Response: ")
+        print("")
+        print("")
+        print("")
+        print(
+            "    "
+            + t.bold_blue
+            + _("Type the words I should say after hearing a command")
+        )
+        aresponseRespon = None
+        while(aresponseRespon.lower()[:1] != affirmative.lower()[:1]):
+            aresponse = simple_input(
+                format_prompt( 
+                    "?",
+                    _("Response")
+                ),
+                get_profile_var(profile,"active_stt","response")
+            )
+            print("")
+            print(aresponse + t.bold_blue+" Is this correct?")
+            print("")
+            aresponseRespon = simple_input(
+                format_prompt( 
+                    "?",
+                    affirmative.upper()[:1] + "/" + negative.upper()[:1] + "?"
+                )
+            )
         profile['active_stt'] = {'response': aresponse}
+        print("")
+        print("")
+        print("")
 
     # write to profile
-    print("Writing to profile...")
+    print(
+        "    "
+        + t.bold_magenta + _("Writing to profile...")
+    )
     if not os.path.exists(paths.CONFIG_PATH):
         os.makedirs(paths.CONFIG_PATH)
     outputFile = open(paths.config("profile.yml"), "w")
     yaml.dump(profile, outputFile, default_flow_style=False)
-    print("Done.")
+    print("")
+    print("")
+    print("")
+    print("    " + t.bold_green + _("Done."))
 
 
 if __name__ == "__main__":
-    run()
+    configfile = paths.config('profile.yml')
+    if os.path.exists(configfile):
+        with open(configfile, "r") as f:
+            config = yaml.safe_load(f)
+    else:
+        config = {}
+    run(config)

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -998,9 +998,9 @@ def run(profile):
         + t.bold_blue
         + _("I have two ways to let you know I've heard you; Beep or Voice.")
     )
-    # If there are values for [active-stt][reply] and [active-stt][response]
+    # If there are values for [active_stt][reply] and [active_stt][response]
     # then use them otherwise use beeps
-    if(get_profile_var(profile, "active-stt", "reply")):
+    if(get_profile_var(profile, "active_stt", "reply")):
         temp = "V"
     else:
         temp = "B"

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -23,12 +23,11 @@ import i18n
 import subprocess
 from blessings import Terminal
 
-t = None
 
 # AaronC
 # Get a value from the profile, whether it exists or not
 # If the value does not exist in the profile, returns None
-def get_profile_var(profile,*args):
+def get_profile_var(profile, *args):
     response = profile
     for arg in args:
         try:
@@ -38,9 +37,9 @@ def get_profile_var(profile,*args):
             # break out of the for loop
             break
     return response
-    
-# AaronC - 
-def format_prompt(icon,prompt):
+
+
+def format_prompt(icon, prompt):
     if(icon == "!"):
         prompt = (
             t.bold_white + '['
@@ -57,6 +56,7 @@ def format_prompt(icon,prompt):
         )
     return prompt
 
+
 # AaronC - simple_input is a lot like raw_input, just adds
 # a colon and space at the end. If a default value is
 # passed in, then adds that to the end followed by two slashes.
@@ -65,7 +65,7 @@ def format_prompt(icon,prompt):
 # then that can be done here.
 # Part of the purpose is to provide a way of overriding
 # raw_input easily without hunting down every reference
-def simple_input(prompt, default = None):
+def simple_input(prompt, default=None):
     prompt += ": "
     if(default):
         prompt += default + "// "
@@ -74,8 +74,9 @@ def simple_input(prompt, default = None):
     # if the user pressed enter without entering anything,
     # set the response to default
     if(default and not response):
-         response = default
+        response = default
     return response.strip()
+
 
 # AaronC - simple_request is more complicated, and populates
 # the profile variable directly
@@ -86,9 +87,11 @@ def simple_request(profile, var, prompt, cleanInput=None):
             input = cleanInput(input)
         profile[var] = input
 
+
 # AaronC - This is currently used to clean phone numbers
 def clean_number(s):
     return re.sub(r'[^0-9]', '', s)
+
 
 # AaronC - This searches some standard places (/bin, /usr/bin, /usr/local/bin)
 # for a program name.
@@ -102,6 +105,7 @@ def CheckProgramExists(program):
         if(os.path.isfile(os.path.join(location, program))):
             response = True
     return response
+
 
 # FIXME
 # AaronC - Location. This uses weather underground for verification, which
@@ -126,20 +130,24 @@ def verifyLocation(place):
     if numEntries == 0:
         return False
     else:
-        print( 
+        print(
             _("Location saved as ")
             + feed['feed']['description'][33:]
         )
         return True
 
+
 # If value exists in list, return the index
-# of that value, otherwise return None
+# of that value (+ 1 so that the first item
+# does not return zero which is interpreted
+# as false), otherwise return None
 def CheckForValue(value, list):
     try:
-        temp = list.index(value)+1
+        temp = list.index(value) + 1
     except ValueError:
         temp = None
     return temp
+
 
 def run(profile):
     #
@@ -152,14 +160,14 @@ def run(profile):
     #
     global t, _
     t = Terminal()
-    
-    language = get_profile_var(profile,"language")
+
+    language = get_profile_var(profile, "language")
     if(not language):
         language = 'en-US'
         profile["language"] = language
     translations = i18n.parse_translations(paths.data('locale'))
     translator = i18n.GettextMixin(translations, profile)
-    _ = translator.gettext        
+    _ = translator.gettext
     #
     # AustinC; can't use français due to the special char "ç"
     # it breaks due to it being out of range for ascii
@@ -174,7 +182,7 @@ def run(profile):
         (
             once
         )and(
-            CheckForValue(language,languages.keys())
+            CheckForValue(language, languages.keys())
         )
     ):
         once = True
@@ -194,7 +202,7 @@ def run(profile):
             ),
             language
         ).lower().strip()
-        if(CheckForValue(temp[:2],[key[:2] for key in languages.keys()])):
+        if(CheckForValue(temp[:2], [key[:2] for key in languages.keys()])):
             for key in languages.keys():
                 if(temp[:2] == key[:2]):
                     language = key
@@ -219,18 +227,18 @@ def run(profile):
     print("")
     print("")
     print("")
-    print("    "+t.bold_blue(
+    print("    " + t.bold_blue(
         _("Hello, thank you for selecting me to be your personal assistant.")
     ))
     print("")
-    print("    "+t.bold_blue(
+    print("    " + t.bold_blue(
         _("Let's populate your profile.")
     ))
     print("")
-    print("    "+t.bold_blue(
+    print("    " + t.bold_blue(
         _("If, at any step, you would prefer not to enter the requested information")
     ))
-    print("    "+t.bold_blue(
+    print("    " + t.bold_blue(
         _("just hit 'Enter' with a blank field to continue.")
     ))
     print("")
@@ -239,7 +247,7 @@ def run(profile):
     simple_request(
         profile,
         'keyword',
-        format_prompt( 
+        format_prompt(
             "?",
             _('First, what name would you like to call me by?').decode('utf-8')
         )
@@ -249,14 +257,15 @@ def run(profile):
     print("")
 
     # your name
-    print("    " + t.bold_blue +
-        _("Now please tell me a little about yourself.")
+    print(
+        "    " + t.bold_blue
+        + _("Now please tell me a little about yourself.")
     )
     print("")
     simple_request(
         profile,
         "first_name",
-        format_prompt( 
+        format_prompt(
             "?",
             _("What is your first name?")
         )
@@ -265,7 +274,7 @@ def run(profile):
     simple_request(
         profile,
         'last_name',
-        format_prompt( 
+        format_prompt(
             "?",
             _('What is your last name?').decode('utf-8')
         )
@@ -275,7 +284,7 @@ def run(profile):
     print("")
 
     # email
-    
+
     print(
         "    "
         + t.bold_blue
@@ -289,22 +298,22 @@ def run(profile):
     except KeyError:
         profile["email"] = {}
     # email imap
-    profile["email"]["imap"]=simple_input(
-        format_prompt( 
+    profile["email"]["imap"] = simple_input(
+        format_prompt(
             "?",
             _('Please enter your imap server as "server[:port]"')
         ),
-        get_profile_var(profile,"email","imap")
+        get_profile_var(profile, "email", "imap")
     )
-    
-    profile["email"]["address"]=simple_input(
-        format_prompt( 
+
+    profile["email"]["address"] = simple_input(
+        format_prompt(
             "?",
             _('What is your email address?')
         ),
-        get_profile_var(profile,"email","address")
+        get_profile_var(profile, "email", "address")
     )
-    
+
     # FIXME This needs to be anything but plaintext.
     # AaronC 2018-07-29 I've looked into this and the problem that needs to
     # be solved here is protection from a casual sort of hacker - like if
@@ -318,12 +327,12 @@ def run(profile):
             _('What is your email password?') + ': '
         )
     )
-    if( temp ):
+    if(temp):
         profile['email']['password'] = temp
     print("")
     print("")
     print("")
-    
+
     print(
         "    "
         + t.bold_blue
@@ -348,7 +357,7 @@ def run(profile):
                 "?",
                 _("What is your Phone number?")
             ),
-            get_profile_var(profile,'phone_number')
+            get_profile_var(profile, 'phone_number')
         )
     )
     profile['phone_number'] = phone_number
@@ -373,7 +382,7 @@ def run(profile):
         print(
             "    'AT&T', 'Verizon', 'T-Mobile' "
             + t.red
-            + "(" + _("without the quotes") +")."
+            + "(" + _("without the quotes") + ")."
         )
         print("")
         print(
@@ -394,11 +403,11 @@ def run(profile):
         print("    " + _("'vmobl.com'; for T-Mobile Germany, enter 't-d1-sms.de')."))
         print("")
         carrier = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 _("What is your Carrier? ")
             ),
-            get_profile_var(profile,"carrier")
+            get_profile_var(profile, "carrier")
         )
         if carrier == 'AT&T':
             profile['carrier'] = 'txt.att.net'
@@ -417,7 +426,7 @@ def run(profile):
     # in your profile, then if you have "prefers_email"
     # selected, it will send an article to you via email,
     # otherwise it does not attempt to send anything to you.
-    
+
     # if the user has entered an email address but no phone number
     # go ahead and assume "prefers email"
     if((profile['email']['address']) and not (profile['phone_number'])):
@@ -435,18 +444,18 @@ def run(profile):
             + _("email (E) or text message (T)?")
         )
         print("")
-        if(get_profile_var(profile,"prefers_email")):
+        if(get_profile_var(profile, "prefers_email")):
             temp = 'E'
         else:
             temp = "T"
         response = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 _("Email (E) or Text message (T)?")
             ),
             temp
         )
-        
+
         while not response or (response[:1] != 'E' and response[:1] != 'T'):
             print("")
             response = simple_input(
@@ -475,13 +484,13 @@ def run(profile):
     )
     print("")
     location = simple_input(
-        format_prompt( 
+        format_prompt(
             "?",
             _("What is your location?")
         ),
-        get_profile_var(profile,"location")
+        get_profile_var(profile, "location")
     )
-    
+
     while location and not verifyLocation(location):
         print(
             t.red
@@ -489,7 +498,7 @@ def run(profile):
             + _("Please try another location.")
         )
         location = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 _("What is your location?")
             ),
@@ -519,11 +528,11 @@ def run(profile):
     print("    " + t.bold_blue + _("or none at all."))
     print("")
     tz = simple_input(
-        format_prompt( 
+        format_prompt(
             "?",
             _("What is your timezone?")
         ),
-        get_profile_var(profile,"timezone")
+        get_profile_var(profile, "timezone")
     )
     while tz:
         try:
@@ -531,9 +540,9 @@ def run(profile):
             profile['timezone'] = tz
             break
         except pytz.exceptions.UnknownTimeZoneError:
-            print(t.red+_("Not a valid timezone. Try again."))
+            print(t.red + _("Not a valid timezone. Try again."))
             tz = simple_input(
-                format_prompt( 
+                format_prompt(
                     "?",
                     _("What is your timezone?")
                 ),
@@ -561,7 +570,7 @@ def run(profile):
     print("")
     response = "PocketSphinx"
     for engine in stt_engines:
-        if (get_profile_var(profile,'stt_engine')==stt_engines[engine]):
+        if (get_profile_var(profile, 'stt_engine') == stt_engines[engine]):
             response = engine
             break
     response = simple_input(
@@ -595,11 +604,11 @@ def run(profile):
         # Set the api key (I'm not sure this actually works anymore,
         # need to test)
         key = simple_input(
-            format_prompt( 
+            format_prompt(
                 "!",
                 _("Please enter your API key:")
             ),
-            get_profile_var(profile,"keys","GOOGLE_SPEECH")
+            get_profile_var(profile, "keys", "GOOGLE_SPEECH")
         )
         print("")
         print("")
@@ -607,7 +616,7 @@ def run(profile):
     if(profile['stt_engine'] == 'watson-stt'):
         profile["watson_stt"] = {}
         username = simple_input(
-            format_prompt( 
+            format_prompt(
                 "!",
                 _("Please enter your watson username:")
             )
@@ -638,11 +647,11 @@ def run(profile):
             + t.yellow + " %s)" % default
         )
         print("")
-        temp = get_profile_var(profile,"kaldigstserver-stt","url")
+        temp = get_profile_var(profile, "kaldigstserver-stt", "url")
         if(not temp):
             temp = default
         profile['kaldigstserver-stt']['url'] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "!",
                 _("Please enter your server url:")
             ),
@@ -665,27 +674,27 @@ def run(profile):
             profile["julius"] = {}
         # hmmdefs
         profile["julius"]["hmmdefs"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "!",
                 _("Enter path to julius hmm defs")
             ),
-            get_profile_var(profile,"julius","hmmdefs")
+            get_profile_var(profile, "julius", "hmmdefs")
         )
         # tiedlist
         profile["julius"]["tiedlist"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "!",
                 _("Enter path to julius tied list")
             ),
-            get_profile_var(profile,"julius","tiedlist")
+            get_profile_var(profile, "julius", "tiedlist")
         )
         # lexicon
         profile["julius"]["lexicon"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "!",
                 _("Enter path to julius lexicon")
             ),
-            get_profile_var(profile,"julius","lexicon")
+            get_profile_var(profile, "julius", "lexicon")
         )
         # FIXME AaronC 2018-07-29 So I don't know if I need to check above to
         # see if the julius lexicon is a tar file or if I can just set this.
@@ -707,7 +716,7 @@ def run(profile):
         # this the default at the end
         # is the phonetisaurus program phonetisaurus-g2p (old version)
         # or phonetisaurus-g2pfst?
-        phonetisaurus_executable = get_profile_var(profile,'pocketsphinx','phonetisaurus_executable')
+        phonetisaurus_executable = get_profile_var(profile, 'pocketsphinx', 'phonetisaurus_executable')
         once = False
         while not((once) and (phonetisaurus_executable)):
             once = True
@@ -719,7 +728,7 @@ def run(profile):
                 elif(CheckProgramExists('phonetisaurus-g2p')):
                     phonetisaurus_executable = 'phonetisaurus-g2p'
             phonetisaurus_executable = simple_input(
-                format_prompt( 
+                format_prompt(
                     "?",
                     _("What is the name of your phonetisaurus-g2p program?")
                 ),
@@ -736,7 +745,7 @@ def run(profile):
         #  fst_model -
         #          - the default for kara is "~/phonetisaurus/g014b2b.fst"
         #          - if you install the latest CMUDict, then it will be at "~/CMUDict/train/model.fst"
-        hmm_dir=get_profile_var(profile,'pocketsphinx','hmm_dir')
+        hmm_dir = get_profile_var(profile, 'pocketsphinx', 'hmm_dir')
         once = False
         while not(once and hmm_dir):
             once = True
@@ -762,17 +771,17 @@ def run(profile):
                 elif(os.path.isdir("/usr/local/share/pocketsphinx/model/hmm/en_US/hub4wsj_sc_8k")):
                     hmm_dir = "/usr/local/share/pocketsphinx/model/hmm/en_US/hub4wsj_sc_8k"
             temp = simple_input(
-                format_prompt( 
+                format_prompt(
                     "!",
                     _("Please enter the path to your hmm directory")
                 ),
                 hmm_dir
             )
-            if( temp ):
+            if(temp):
                 hmm_dir = temp
         profile["pocketsphinx"]["hmm_dir"] = hmm_dir
         # fst_model
-        fst_model = get_profile_var(profile,"pocketsphinx","fst_model")
+        fst_model = get_profile_var(profile, "pocketsphinx", "fst_model")
         once = False
         while not (once and fst_model):
             once = True
@@ -802,7 +811,7 @@ def run(profile):
                             "g014b2b.fst"
                         )
             fst_model = simple_input(
-                format_prompt( 
+                format_prompt(
                     "!",
                     _("Please enter the path to your fst model")
                 ),
@@ -825,7 +834,7 @@ def run(profile):
     }
     response = "Festival"
     for engine in tts_engines:
-        if(get_profile_var(profile,"tts_engine")==tts_engines[engine]):
+        if(get_profile_var(profile, "tts_engine") == tts_engines[engine]):
             response = engine
     print(
         "    "
@@ -840,7 +849,7 @@ def run(profile):
         format_prompt(
             "?",
             t.bold_white + _("Available implementations: ")
-            + t.yellow + ("%s. " % tts_engines.keys()) +t.bold_white
+            + t.yellow + ("%s. " % tts_engines.keys()) + t.bold_white
         ),
         response
     )
@@ -848,9 +857,9 @@ def run(profile):
         profile['tts_engine'] = tts_engines[response]
     else:
         print(
-            t.red+_("Unrecognized option.") +
-            t.bold_white+_("Setting text to speech engine to") + " " +
-            t.yellow+"Festival."
+            t.red + _("Unrecognized option.") +
+            t.bold_white + _("Setting text to speech engine to") + " " +
+            t.yellow + "Festival."
         )
         profile['tts_engine'] = 'festival-tts'
         print("")
@@ -859,7 +868,7 @@ def run(profile):
     # Deal with special cases
     if(profile["tts_engine"] == "espeak-tts"):
         # tts_engine: espeak-tts
-        print(t.bold_blue+"    If you would like to alter the espeak voice, you can use")
+        print(t.bold_blue + "    If you would like to alter the espeak voice, you can use")
         print("    the following options in your config file:")
         print("")
         print("    espeak-tts:")
@@ -871,7 +880,7 @@ def run(profile):
         print("")
     elif(profile["tts_engine"] == "festival-tts"):
         # tts_engine: festival-tts
-        print(t.bold_blue+"    Use the festival command to set the default voice.")
+        print(t.bold_blue + "    Use the festival command to set the default voice.")
         print("")
         print("")
         print("")
@@ -880,23 +889,23 @@ def run(profile):
             temp = profile["flite-tts"]
         except KeyError:
             profile["flite-tts"] = {}
-        voices = subprocess.check_output(['flite','-lv']).split(" ")[2:-1]
+        voices = subprocess.check_output(['flite', '-lv']).split(" ")[2:-1]
         print(
             "    "
             + _("Available voices: ")
             + t.yellow + "%s. " % voices
         )
-        profile["flite-tts"]["voice"]=simple_input(
-            format_prompt( 
+        profile["flite-tts"]["voice"] = simple_input(
+            format_prompt(
                 "?",
                 _("Select a voice")
             ),
-            get_profile_var(profile,"flite-tts","voice")
+            get_profile_var(profile, "flite-tts", "voice")
         )
         print("")
         print("")
         print("")
-    elif( profile["tts_engine"]=="pico-tts" ):
+    elif(profile["tts_engine"] == "pico-tts"):
         pass
     elif(profile["tts_engine"] == "ivona-tts"):
         print(
@@ -920,27 +929,27 @@ def run(profile):
         except KeyError:
             profile["ivona-tts"] = {}
         profile["ivona-tts"]["access_key"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 _("What is your Access key?")
             ),
-            get_profile_var(profile,"ivona-tts","access_key")
+            get_profile_var(profile, "ivona-tts", "access_key")
         )
         profile["ivona-tts"]["secret_key"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 _("What is your Secret key?")
             ),
-            get_profile_var(profile,"ivona-tts","secret_key")
+            get_profile_var(profile, "ivona-tts", "secret_key")
         )
         # ivona-tts voice
-        temp = get_profile_var(profile,"ivona-tts","voice")
+        temp = get_profile_var(profile, "ivona-tts", "voice")
         if(not temp):
-            temp="Brian"
+            temp = "Brian"
         profile["ivona-tts"]["voice"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
-                _("Which voice do you want")+" "+t.yellow+_("(default is Brian)")+t.bold_white+"?"
+                _("Which voice do you want") + " " + t.yellow + _("(default is Brian)") + t.bold_white + "?"
             ),
             temp
         )
@@ -953,32 +962,32 @@ def run(profile):
         except KeyError:
             profile["mary-tts"] = {}
         profile["mary-tts"]["server"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 _("Server?")
             ),
-            get_profile_var(profile,"mary-tts","server")
+            get_profile_var(profile, "mary-tts", "server")
         )
         profile["mary-tts"]["port"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 "Port?"
             ),
-            get_profile_var(profile,"mary-tts","port")
+            get_profile_var(profile, "mary-tts", "port")
         )
         profile["mary-tts"]["language"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 _("Language?")
             ),
-            get_profile_var(profile,"mary-tts","language")
+            get_profile_var(profile, "mary-tts", "language")
         )
         profile["mary-tts"]["voice"] = simple_input(
-            format_prompt( 
+            format_prompt(
                 "?",
                 _("Voice?")
             ),
-            get_profile_var(profile,"mary-tts","voice")
+            get_profile_var(profile, "mary-tts", "voice")
         )
         print("")
         print("")
@@ -996,13 +1005,13 @@ def run(profile):
     else:
         temp = "B"
     response = simple_input(
-        format_prompt( 
+        format_prompt(
             "?",
             _("(B) for beeps or (V) for voice.")
         ),
         temp
     )
-    while not response or (response.lower()[:1] != 'b' and response.lower()[:1] != 'v'):
+    while((not response) or (response.lower()[:1] != 'b' and response.lower()[:1] != 'v')):
         response = simple_input(
             t.red + _("Please choose beeps (B) or voice (V):") + t.bold_white
         )
@@ -1019,21 +1028,21 @@ def run(profile):
         areplyRespon = None
         while((not areplyRespon) or (areplyRespon.lower()[:1] != affirmative.lower()[:1])):
             areply = simple_input(
-                format_prompt( 
+                format_prompt(
                     "?",
                     _("Reply")
                 ),
-                get_profile_var(profile,"active_stt","reply")
+                get_profile_var(profile, "active_stt", "reply")
             )
             print("")
-            print(areply + t.bold_blue +" " + _("Is this correct?"))
+            print(areply + t.bold_blue + " " + _("Is this correct?"))
             print("")
             areplyRespon = None
-            while((not areplyRespon) or (not CheckForValue(areplyRespon.lower()[:1],[affirmative.lower()[:1],negative.lower()[:1]]))):
+            while((not areplyRespon) or (not CheckForValue(areplyRespon.lower()[:1], [affirmative.lower()[:1], negative.lower()[:1]]))):
                 areplyRespon = simple_input(
-                    format_prompt( 
+                    format_prompt(
                         "?",
-                        affirmative.upper()[:1] + "/" + negative.upper()[:1] +"?"
+                        affirmative.upper()[:1] + "/" + negative.upper()[:1] + "?"
                     )
                 )
         profile['active_stt']['reply'] = areply
@@ -1048,19 +1057,19 @@ def run(profile):
         aresponseRespon = None
         while((not aresponseRespon) or (aresponseRespon.lower()[:1] != affirmative.lower()[:1])):
             aresponse = simple_input(
-                format_prompt( 
+                format_prompt(
                     "?",
                     _("Response")
                 ),
-                get_profile_var(profile,"active_stt","response")
+                get_profile_var(profile, "active_stt", "response")
             )
             print("")
-            print(aresponse + t.bold_blue+" Is this correct?")
+            print(aresponse + t.bold_blue + " Is this correct?")
             print("")
             aresponseRespon = None
-            while((not aresponseRespon) or (not CheckForValue(aresponseRespon.lower()[:1],[affirmative.lower()[:1],negative.lower()[:1]]))):
+            while((not aresponseRespon) or (not CheckForValue(aresponseRespon.lower()[:1], [affirmative.lower()[:1], negative.lower()[:1]]))):
                 aresponseRespon = simple_input(
-                    format_prompt( 
+                    format_prompt(
                         "?",
                         affirmative.upper()[:1] + "/" + negative.upper()[:1] + "?"
                     )


### PR DESCRIPTION
I started with @Longshotpro2's cli_populate_yaml.py. I fixed some of
the issues related to language around gmail/email and the order of
some of the questions. I fixed the translate.gettext( placement,
since the gettext translator does not like to see any code within
the function argument, including concatenations. I also fixed one
concatenation in the conversation.py file. I changed all the 
translate.gettext() functions in naomi/populate.py to _() which is the 
default for pulling strings for translation using pygettext.py. 

I added the ability to run populate.py from the command line
by passing --repopulate to Naomi.py. You can also run 
naomi/populate.py directly from the command line.

Populate.py now reads the profile, if available, before asking
questions. It defaults to the current contents of the config
file if present.

I regenerated the naomi/data/locale/fr-FR.po file with the new
language in populate.py and conversation.py and tested all the
way through in French. Of course, since I don't actually speak
french, it would be nice if a native speaker like @TuxSeb would
fix my google translate translations. This was done more as a
way of learning how to work with translation files than to make
something a native speaker could use without wincing.

Unfortunately, there is a UnicodeEncodingError issue with
cmuclmtk.text2vocab when attempting to generate the default
vocabulary which includes keywords in French. This issue
is outside the scope of this update and needs to be dealt with
separately. This may be fixed in the process of upgrading to
python3, which apparently has fixed some issues with the way
unicode strings are dealt with. It's also possible, though
unlikely, that I just need to download French acoustic and
audio models instead of trying to use the default english ones.

I also (accidentally) pulled in a change I made to the logging.
I set the default logging level to "warning" instead of "info".
I actually think this makes sense, since the official definition
of how to use the info level is:
"Report events that occur during normal operation of a program 
(e.g. for status monitoring or fault investigation)"
which makes it sound like the info level is really reserved for
developers and allowing it to mix into the normal user output
seems like bad form. Personally, I was just tired of looking at
info messages when the program is running normally.

While the white font showed up okay on my Arch machine,
I was working on my OpenSUSE machine today and the white
text on the white background was barely readable. Since there
doesn't appear to be any way to query the background color
using blessings, we should probably turn all the t.white's to
t.normal's, since it is likely the user will have chosen a forground
color that shows up against the background color. Also, yellow
should probably be replaced with something that shows up a
little easier against a white background.