### PR TITLE
Fix issue where dictionary is lower case

### DIFF
--- a/plugins/stt/pocketsphinx-stt/g2p.py
+++ b/plugins/stt/pocketsphinx-stt/g2p.py
@@ -68,15 +68,11 @@ def execute(executable, fst_model, input, is_file=False, nbest=None):
             logger.debug("NextLine: '%s'" % nextline)
             if(nextline == ''):
                 continue
+            # It is important to raise this error so we can try lower() in sphinxvocab.py
             if(len(RE_ISYMNOTFOUND.findall(nextline)) > 0):
-                # instead of killing the process or raising an error,
-                # just skip the line.
-                # This will create the checksum which will continue
-                # to be valid, while allowing the user to generate
-                # their own language model.
-                # http://www.speech.cs.cmu.edu/tools/lmtool-new.html
-                logger.error('Input symbol not found')
-                continue
+                logger.error('%s - Input symbol not found' % nextline)
+                proc.kill()
+                raise ValueError('Input symbol not found')
         stdoutdata, stderrdata = proc.communicate()
         logger.debug("StdOutData: %s" % stdoutdata)
     except OSError:

--- a/plugins/stt/pocketsphinx-stt/sphinxvocab.py
+++ b/plugins/stt/pocketsphinx-stt/sphinxvocab.py
@@ -74,17 +74,9 @@ def compile_vocabulary(config, directory, phrases):
 
     logger.debug('Languagemodel path: %s' % languagemodel_path)
     logger.debug('Dictionary path:    %s' % dictionary_path)
-    # AJC 2018-05-20
-    # Old phonetisaurus-g2p apparently wanted words in upper case.
-    # New phonetisaurus-g2pfst seems to prefer lower case
-    if(executable == "phonetisaurus-g2pfst"):
-        text = " ".join(
-            [("<s> %s </s>" % phrase.lower()) for phrase in phrases]
-        )
-    else:
-        text = " ".join(
-            [("<s> %s </s>" % phrase.upper()) for phrase in phrases]
-        )
+    text = " ".join(
+        [("<s> %s </s>" % phrase.upper()) for phrase in phrases]
+    )
     # There's some strange issue when text2idngram sometime can't find any
     # input (although it's there). For a reason beyond me, this can be fixed
     # by appending a space char to the string.
@@ -155,8 +147,10 @@ def compile_dictionary(g2pconverter, words, output_file):
     logger.debug("Getting phonemes for %d words..." % len(words))
     try:
         phonemes = g2pconverter.translate(words)
+        logger.debug(phonemes)
     except ValueError as e:
         if e.message == 'Input symbol not found':
+            logger.debug("Upper failed trying lower()")
             phonemes = g2pconverter.translate([word.lower() for word in words])
         else:
             raise e
@@ -165,28 +159,15 @@ def compile_dictionary(g2pconverter, words, output_file):
     with open(output_file, "w") as f:
         for word, pronounciations in phonemes.items():
             for i, pronounciation in enumerate(pronounciations, start=1):
-                if(g2pconverter.executable == "phonetisaurus-g2pfst"):
-                    if i == 1:
-                        line = "%s\t%s\n" % (
-                            word.lower(),
-                            pronounciation
-                        )
-                    else:
-                        line = "%s(%d)\t%s\n" % (
-                            word.lower(),
-                            i,
-                            pronounciation
-                        )
+                if i == 1:
+                    line = "%s\t%s\n" % (
+                        word.upper(),
+                        pronounciation
+                    )
                 else:
-                    if i == 1:
-                        line = "%s\t%s\n" % (
-                            word.upper(),
-                            pronounciation
-                        )
-                    else:
-                        line = "%s(%d)\t%s\n" % (
-                            word.upper(),
-                            i,
-                            pronounciation
-                        )
+                    line = "%s(%d)\t%s\n" % (
+                        word.upper(),
+                        i,
+                        pronounciation
+                    )
                 f.write(line)


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Bug | No |


## Description
When the dictionary is lower case, but the list of words to be
compiled is in upper case, each letter is individually flagged
as "Input symbol not found". At that point, the error handler
in sphinxvocab.py is supposed to kick in and attempt to convert
the list of words to lower case and feed it back in. If the
error occurs at that point, the program dies with an "Input
symbol not found" error and a stack trace.

At some point, while updating the new pocketsphinx module, I
had run into this problem on the second run-through and decided
it would be better to just skip whatever line was having the
issue, since it was not related to the functioning of Naomi.

I changed the error into a continue. This meant that if I used
a lower-case dictionary, none of the words would be compiled.

When I started using the english dictionary that is currently
bundled with the git version of pocketsphinx, it was in lower
case, which no longer worked with my code. I dealt with this
by checking to see which version of pocketsphinx is installed
and upper or lower-casing the dictionary accordingly. Of
course, the version of pocketsphinx has exactly nothing to do
with whether the chosen dictionary is upper or lower case.

A dictionary should be either all upper case or all lower case,
since otherwise Phonetisaurus might end up associating the upper
and lower case letters with different sounds.

This issue was caught by gospodima, who was attempting to use
the older version of phonetisaurus from the original jasper
documentation with a lower-case german dictionary.

This commit reverses those specific changes to sphinxvocab.py
and g2p.py and allows words to be compiled against phoneme
dictionaries regardless of whether the dictionaries are upper
or lower case.


## Additional Information

This does return us to a state where if there really is an odd character in the word list, the dictionary might fail to compile, which can be difficult to troubleshoot. If this becomes a problem in the future, I would solve it by adding a "pass" parameter to the g2p.py translate, _translate_words and execute functions so errors can be handled differently depending on which pass we are on.


## Related Tickets

* [naomi-dev crashes with german #119](https://github.com/NaomiProject/Naomi/issues/119)


## Todos

- [X] Tests - Tested in english and german with g014b2b and git versions of phonetisaurus.
- [X] Documentation - Bugfix, does not require any changes to current documentation.


## Deploy Notes

Bug fix. Does not require any changes to current deployment procedures.