### PR TITLE
Fixed a few issues with Naomi 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ target/
 
 # SublimeLinter config file
 .sublimelinterrc
+
+# Ignore the generated ./Naomi file that starts Naomi.py with the 
+# proper python
+Naomi

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -15,7 +15,7 @@ echo "Updating apt, preparing to install libssl-dev, gettext, portaudio19-dev an
 # install dependencies
 sudo apt-get update
 # libssl-dev required to get the python _ssl module working
-sudo apt-get install libssl-dev gettext portaudio19-dev libasound2-dev -y
+sudo apt-get install libssl-dev gettext libncurses5-dev portaudio19-dev libasound2-dev -y
 
 # installing python 2.7.13
 echo 'Installing python 2.7.13 to ~/.naomi/local'
@@ -53,7 +53,7 @@ cd $NAOMI_DIR
 
 # start the naomi setup process
 echo "#!/bin/bash" > Naomi
-echo "~/.naomi/local/bin/python $NAOMI_DIR/Naomi.py $@" >> Naomi
+echo "~/.naomi/local/bin/python $NAOMI_DIR/Naomi.py \$@" >> Naomi
 chmod a+x Naomi
 echo "In the future, run $NAOMI_DIR/Naomi to start Naomi"
 ./Naomi --repopulate

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -32,9 +32,9 @@ cd ..  # ~/.naomi/local
 
 # install setuptools and pip for package management
 echo 'Installing setuptools'
-wget https://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz#md5=7df2a529a074f613b509fb44feefe74e
-tar xvzf setuptools-0.6c11.tar.gz
-cd setuptools-0.6c11 # ~/.naomi/local/setuptools-0.6c11
+wget https://files.pythonhosted.org/packages/37/1b/b25507861991beeade31473868463dad0e58b1978c209de27384ae541b0b/setuptools-40.6.3.zip
+unzip setuptools-40.6.3.zip
+cd setuptools-40.6.3
 ~/.naomi/local/bin/python setup.py install  # specify the path to the python you installed above
 cd .. # ~/.naomi/local
 

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -363,6 +363,29 @@ def select_language(profile):
     _ = translator.gettext
 
 
+# check and make sure an audio engine is configured before allowing
+# populate.py to continue.
+def precheck(config):
+    global _, affirmative, negative
+    audioengines = get_audio_engines()
+    while(len(audioengines) < 1):
+        print(
+            alert_text(
+                _("You do not appear to have any audio engines configured.")
+            )
+        )
+        print("You should either install the pyaudio or pyalsaaudio")
+        print("python modules. Otherwise Naomi will be unable to speak")
+        print("or listen.")
+        print("")
+        print("Both programs have prerequisites that can most likely")
+        print("be installed using your package manager")
+        if not simple_yes_no(_("Would you like me to check again?")):
+            print("Can't continue, so quitting")
+            quit()
+        audioengines = get_audio_engines()
+
+
 def greet_user():
     print("")
     print("")
@@ -1473,8 +1496,8 @@ def get_beep_or_voice(profile):
         set_profile_var(profile, ['active_stt', 'response'], "")
 
 
-def select_audio_engine(profile):
-    # Audio Engine
+# Return a list of currently installed audio engines.
+def get_audio_engines():
     global audioengine_plugins
     audioengine_plugins = pluginstore.PluginStore(
         [os.path.join(
@@ -1487,6 +1510,12 @@ def select_audio_engine(profile):
     )
     audioengine_plugins.detect_plugins()
     audioengines = [ae_info.name for ae_info in audioengine_plugins.get_plugins_by_category(category='audioengine')]
+    return audioengines
+
+
+def select_audio_engine(profile):
+    # Audio Engine
+    audioengines = get_audio_engines()
 
     print(instruction_text(_("Please select an audio engine.")))
     try:
@@ -1499,6 +1528,7 @@ def select_audio_engine(profile):
         response = "pyaudio"
     once = False
     while not ((once) and (response in audioengines)):
+        audioengines = get_audio_engines()
         once = True
         response = simple_input(
             "    " + _("Available implementations:") + " " + choices_text(
@@ -1803,8 +1833,10 @@ def run(profile):
     # For plugin & general use elsewhere, blessings or
     # coloredformatting.py can be used.
     #
-
     select_language(profile)
+    separator()
+
+    precheck(profile)
     separator()
 
     greet_user()

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -1505,7 +1505,9 @@ def get_audio_engines():
                 os.path.dirname(
                     os.path.abspath(__file__)
                 )
-            )
+            ),
+            "plugins",
+            "audioengine"
         )]
     )
     audioengine_plugins.detect_plugins()

--- a/plugins/stt/pocketsphinx-stt/sphinxvocab.py
+++ b/plugins/stt/pocketsphinx-stt/sphinxvocab.py
@@ -10,7 +10,7 @@ from .g2p import PhonetisaurusG2P
 
 
 def delete_temp_file(file_to_delete):
-    if False:
+    if True:
         os.remove(file_to_delete)
 
 

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -6,8 +6,6 @@ pytz==2018.5
 PyYAML==3.13
 requests==2.20.0
 blessings
-nano
-pip
 pyaudio
 pyalsaaudio
 


### PR DESCRIPTION
## Description
Added the generated Naomi file that uses the local python to the
.gitignore list

Modified naomi-setup.sh and added libncurses5-dev to the list
of apt packages to install. Also fixed a bug that was preventing
the "$@" from writing to the end of the ./Naomi file, so it was
impossible to forward command line arguements to ./Naomi.py

Removed nano and git from python-requirements.txt (duplicating
PR # 131 by redragonx)

Added a check for audio engines to populate.py that runs directly
after the language selection, so the user doesn't get to the end
and suddenly discover they can't complete the install.

Fixed an issue with sphinxvocab.py where temporary files were
not being removed. This was for debugging purposes.

## Related Issue
[#136 Naomi-setup.sh issues](https://github.com/NaomiProject/Naomi/issues/136)

## Motivation and Context


## How Has This Been Tested?
Tested on a clean install of Raspbian 2018-11-13

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
