### PR TITLE
Variable type mismatch in Pico

### DIFF
--- a/plugins/tts/pico-tts/pico.py
+++ b/plugins/tts/pico-tts/pico.py
@@ -40,7 +40,7 @@ class PicoTTSPlugin(plugin.TTSPlugin):
         with tempfile.SpooledTemporaryFile() as f:
             subprocess.call(cmd, stderr=f)
             f.seek(0)
-            output = f.read()
+            output = f.read().decode('utf-8')
         pattern = re.compile(r'Unknown language: NULL\nValid languages:\n' +
                              r'((?:[a-z]{2}-[A-Z]{2}\n)+)')
         matchobj = pattern.match(output)


### PR DESCRIPTION
## Description
In python 3, the output from pico2wave -l (list languages) needs
to be converted from bytes to string before we can check to make
sure the currently selected language is a valid choice.

## Related Issue
[ Problems with unicode #146](https://github.com/NaomiProject/Naomi/issues/146)

## Motivation and Context
Users who want to use Pico for Text to Speech processing get an error message.

## How Has This Been Tested?
Tested on Raspberry Pi 3B+

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
