### PR TITLE
Update German translation for clock plugin

### DIFF
--- a/plugins/speechhandler/clock/locale/de-DE.po
+++ b/plugins/speechhandler/clock/locale/de-DE.po
@@ -23,7 +23,7 @@ msgstr ""
 
 #: clock.py:9 clock.py:35
 msgid "TIME"
-msgstr "UHR"
+msgstr "ZEIT"
 
 #: clock.py:23
 #, python-format


### PR DESCRIPTION
"Uhr" is more like "o'clock" but not "time".