### PR TITLE
Deepspeech model import

### DIFF
--- a/plugins/stt/deepspeech-stt/deepspeechstt.py
+++ b/plugins/stt/deepspeech-stt/deepspeechstt.py
@@ -2,12 +2,17 @@ import logging
 import os
 import scipy.io.wavfile as wav
 from naomi import plugin
+from naomi import profile
 
 try:
     from deepspeech.model import Model
     deepspeech_available = True
 except ImportError:
-    deepspeech_available = False
+    try:
+        from deepspeech import Model # v0.4.1
+        deepspeech_available = True
+    except ImportError:
+        deepspeech_available = False
 
 
 class DeepSpeechSTTPlugin(plugin.STTPlugin):
@@ -26,64 +31,61 @@ class DeepSpeechSTTPlugin(plugin.STTPlugin):
 
         if not deepspeech_available:
             self._logger.warning("DeepSpeech import error!")
-        #    raise ImportError("DeepSpeech not installed!")
+            raise ImportError("DeepSpeech not installed!")
 
         self._logger.warning("This STT plugin doesn't have multilanguage " +
                              "support!")
         # Beam width used in the CTC decoder when building candidate
         # transcriptions
-        try:
-            self._BEAM_WIDTH = self.profile["deepspeech"]["beam_width"]
-        except KeyError:
-            self._BEAM_WIDTH = 500
+        self._BEAM_WIDTH = profile.get_profile_var(
+            self.profile,['deepspeech','beam_width'],500
+        )
 
         # The alpha hyperparameter of the CTC decoder. Language Model weight
-        try:
-            self._LM_WEIGHT = self.profile["deepspeech"]["lm_weight"]
-        except KeyError:
-            self._LM_WEIGHT = 1.75
+        self._LM_WEIGHT = profile.get_profile_var(
+            self.profile,['deepspeech','lm_weight'],1.75
+        )
 
         # The beta hyperparameter of the CTC decoder. Word insertion weight
         # (penalty)
-        try:
-            self._WORD_COUNT_WEIGHT = self.profile["deepspeech"]["word_count_weight"]
-        except KeyError:
-            self._WORD_COUNT_WEIGHT = 1.00
+        self._WORD_COUNT_WEIGHT = profile.get_profile_var(
+            self.profile,['deepspeech','word_count_weight'],1.00
+        )
 
         # Valid word insertion weight. This is used to lessen the word
         # insertion penalty when the inserted word is part of the vocabulary
-        try:
-            self._VALID_WORD_COUNT_WEIGHT = self.profile["deepspeech"]["valid_word_count_weight"]
-        except KeyError:
-            self._VALID_WORD_COUNT_WEIGHT = 1.00
+        self._VALID_WORD_COUNT_WEIGHT = profile.get_profile_var(
+            self.profile,['deepspeech','valid_word_count_weight'],1.00
+        )
 
         # These constants are tied to the shape of the graph used (changing
         # them changes the geometry of the first layer), so make sure you
         # use the same constants that were used during training
 
         # Number of MFCC features to use
-        try:
-            self._N_FEATURES = self.profile["deepspeech"]["n_features"]
-        except KeyError:
-            self._N_FEATURES = 26
+        self._N_FEATURES = profile.get_profile_var(
+            self.profile,['deepspeech','n_features'],26
+        )
 
         # Size of the context window used for producing timesteps in the
         # input vector
-        try:
-            self._N_CONTEXT = self.profile["deepspeech"]["n_context"]
-        except KeyError:
-            self._N_CONTEXT = 9
+        self._N_CONTEXT = profile.get_profile_var(
+            self.profile,['deepspeech','n_context'],9
+        )
 
         # Only 16KHz files are currently supported
-        try:
-            self._FS = self.profile["deepspeech"]["fs"]
-        except KeyError:
-            self._FS = 16000
+        self._FS = profile.get_profile_var(
+            self.profile,['deepspeech','fs'],16000
+        )
 
         # These are paths. They are required
 
         # Path to the model (protocol buffer binary file)
-        self._MODEL = self.profile["deepspeech"]["model"]
+        self._MODEL = os.path.expanduser(
+            profile.get_profile_var(
+                self.profile,['deepspeech','model']
+            )
+        )
         if(not os.path.exists(self._MODEL)):
             msg = (
                 "DeepSpeech model '%s' does not exist! "
@@ -94,7 +96,11 @@ class DeepSpeechSTTPlugin(plugin.STTPlugin):
             raise RuntimeError(msg)
 
         # Path to the configuration file specifying the alphabet used
-        self._ALPHABET = self.profile["deepspeech"]["alphabet"]
+        self._ALPHABET = os.path.expanduser(
+            profile.get_profile_var(
+                self.profile,["deepspeech","alphabet"]
+            )
+        )
         if(not os.path.exists(self._ALPHABET)):
             msg = (
                 "DeepSpeech alphabet '%s' does not exist! "
@@ -105,7 +111,11 @@ class DeepSpeechSTTPlugin(plugin.STTPlugin):
             raise RuntimeError(msg)
 
         # Path to the language model binary file
-        self._LM = self.profile["deepspeech"]["language_model"]
+        self._LM = os.path.expanduser(
+            profile.get_profile_var(
+                self.profile,["deepspeech","language_model"]
+            )
+        )
         if(not os.path.exists(self._LM)):
             msg = (
                 "DeepSpeech language model '%s' does not exist! "
@@ -117,7 +127,11 @@ class DeepSpeechSTTPlugin(plugin.STTPlugin):
 
         # Path to the language model trie file created with
         # native_client/generate_trie
-        self._TRIE = self.profile["deepspeech"]["trie"]
+        self._TRIE = os.path.expanduser(
+            profile.get_profile_var(
+                self.profile,["deepspeech","trie"]
+            )
+        )
         if(not os.path.exists(self._TRIE)):
             msg = (
                 "DeepSpeech trie '%s' does not exist! "
@@ -133,14 +147,25 @@ class DeepSpeechSTTPlugin(plugin.STTPlugin):
             self._ALPHABET,
             self._BEAM_WIDTH
         )
-        self._ds.enableDecoderWithLM(
-            self._ALPHABET,
-            self._LM,
-            self._TRIE,
-            self._LM_WEIGHT,
-            self._WORD_COUNT_WEIGHT,
-            self._VALID_WORD_COUNT_WEIGHT
-        )
+        try:
+            self._ds.enableDecoderWithLM(
+                self._ALPHABET,
+                self._LM,
+                self._TRIE,
+                self._LM_WEIGHT,
+                self._WORD_COUNT_WEIGHT,
+                self._VALID_WORD_COUNT_WEIGHT
+            )
+        except TypeError:
+            # the current PyPi version does not
+            # use the Valid word count weight
+            self._ds.enableDecoderWithLM(
+                self._ALPHABET,
+                self._LM,
+                self._TRIE,
+                self._LM_WEIGHT,
+                self._WORD_COUNT_WEIGHT
+            )
 
     def transcribe(self, fp):
         """
@@ -151,7 +176,7 @@ class DeepSpeechSTTPlugin(plugin.STTPlugin):
         # We can assume 16kHz
         # audio_length = len(audio) * (1 / self._FS)
         assert fs == self._FS, (
-            "Only %dHz input WAV files are supported for now!" % self._FS
+            "Input wav file is %dHz, expecting %dHz" % (fs, self._FS)
         )
 
         text = self._ds.stt(audio, self._FS)


### PR DESCRIPTION
## Description
On version 0.4.1 of deepspeech, the line "from deepspeech.model
import Model" has changed to just "from deepspeech import Model"
This just changes the import to work in both cases.

## Related Issue
[Deepspeech module structure has changed #152](https://github.com/NaomiProject/Naomi/issues/152)

## Motivation and Context
It makes it so the pypi version of deepspeech works with Naomi

## How Has This Been Tested?
Raspbian Stretch on Raspberry Pi 3B+
sudo pip3 install deepspeech
~/Naomi/Naomi

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
