### PR TITLE
Vad plugin

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -345,7 +345,7 @@ class Naomi(object):
         )
 
         # Initialize Voice activity detection
-        vad_slug = profile.get_profile_var(self.config, ['vad_engine'], 'snr')
+        vad_slug = profile.get_profile_var(self.config, ['vad_engine'], 'snr_vad')
         vad_info = self.plugins.get_plugin(
             vad_slug,
             category='vad'

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -42,28 +42,46 @@ class Naomi(object):
 
         # Check if config dir is writable
         if not os.access(paths.CONFIG_PATH, os.W_OK):
-            self._logger.critical("Config dir %s is not writable. Naomi " +
-                                  "won't work correctly.",
-                                  paths.CONFIG_PATH)
-
-        # FIXME: For backwards compatibility, move old config file to newly
-        #        created config dir
+            self._logger.critical(
+                " ".join([
+                    "Config dir {:s} is not writable. Naomi",
+                    "won't work correctly."
+                ]).format(
+                    paths.CONFIG_PATH
+                )
+            )
+        # For backwards compatibility, move old config file to newly
+        # created config dir
         old_configfile = os.path.join(paths.PKG_PATH, 'profile.yml')
         new_configfile = paths.config('profile.yml')
         if os.path.exists(old_configfile):
             if os.path.exists(new_configfile):
-                self._logger.warning("Deprecated profile file found: '%s'. " +
-                                     "Please remove it.", old_configfile)
+                self._logger.warning(
+                    " ".join([
+                        "Deprecated profile file found: '{:s}'. ",
+                        "Please remove it."
+                    ]).config(old_configfile)
+                )
             else:
-                self._logger.warning("Deprecated profile file found: '%s'. " +
-                                     "Trying to copy it to new location '%s'.",
-                                     old_configfile, new_configfile)
+                self._logger.warning(
+                    " ".join([
+                        "Deprecated profile file found: '{:s}'.",
+                        "Trying to copy it to new location '{:s}'."
+                    ]).format(
+                        old_configfile,
+                        new_configfile
+                    )
+                )
                 try:
                     shutil.copy2(old_configfile, new_configfile)
                 except shutil.Error:
-                    self._logger.error("Unable to copy config file. " +
-                                       "Please copy it manually.",
-                                       exc_info=True)
+                    self._logger.error(
+                        " ".join([
+                            "Unable to copy config file.",
+                            "Please copy it manually."
+                        ]),
+                        exc_info=True
+                    )
                     raise
 
         # Read config
@@ -88,8 +106,10 @@ class Naomi(object):
                 # raise
                 print("Your config file does not exist.")
                 text_input = input(
-                    "Would you like to answer a few " +
-                    "questions to create a new one? "
+                    " ".join([
+                        "Would you like to answer a few ",
+                        "questions to create a new one? "
+                    ])
                 )
                 if(re.match(r'\s*[Yy]', text_input)):
                     populate.run({})
@@ -101,7 +121,7 @@ class Naomi(object):
                                 e.problem.strip(), str(e.problem_mark).strip())
                 raise
 
-        language = profile.get_profile_var(self.config,['language'])
+        language = profile.get_profile_var(self.config, ['language'])
         if(not language):
             language = 'en-US'
             self._logger.warn(
@@ -112,7 +132,10 @@ class Naomi(object):
             )
         self._logger.info("Using Language '{}'".format(language))
 
-        audio_engine_slug = profile.get_profile_var(self.config,['audio_engine'])
+        audio_engine_slug = profile.get_profile_var(
+            self.config,
+            ['audio_engine']
+        )
         if(not audio_engine_slug):
             audio_engine_slug = 'pyaudio'
             self._logger.warn(
@@ -125,7 +148,7 @@ class Naomi(object):
 
         active_stt_slug = profile.get_profile_var(
             self.config,
-            ['active_stt','engine']
+            ['active_stt', 'engine']
         )
         if(not active_stt_slug):
             active_stt_slug = 'sphinx'
@@ -141,7 +164,7 @@ class Naomi(object):
 
         active_stt_reply = profile.get_profile_var(
             self.config,
-            ['active_stt','reply']
+            ['active_stt', 'reply']
         )
         if(active_stt_reply):
             self._logger.info(
@@ -150,7 +173,7 @@ class Naomi(object):
 
         active_stt_response = profile.get_profile_var(
             self.config,
-            ['active_stt','response']
+            ['active_stt', 'response']
         )
         if(active_stt_response):
             self._logger.info(
@@ -161,25 +184,25 @@ class Naomi(object):
 
         passive_stt_slug = profile.get_profile_var(
             self.config,
-            ['passive_stt','engine'],
+            ['passive_stt', 'engine'],
             active_stt_slug
         )
         self._logger.info(
             "Using passive STT engine '{}'".format(passive_stt_slug)
         )
 
-        tts_slug = profile.get_profile_var(self.config,['tts_engine'])
+        tts_slug = profile.get_profile_var(self.config, ['tts_engine'])
         if(not tts_slug):
             tts_slug = 'espeak-tts'
             self._logger.warning(
                 " ".join([
-                    "tts_engine not specified in profile, using" +
+                    "tts_engine not specified in profile, using",
                     "defaults."
                 ])
             )
         self._logger.info("Using TTS engine '{}'".format(tts_slug))
 
-        keyword = profile.get_profile_var(self.config,['keyword'],'NAOMI')
+        keyword = profile.get_profile_var(self.config, ['keyword'], 'NAOMI')
         self._logger.info("Using keyword '{}'".format(keyword))
 
         if(not print_transcript):
@@ -211,9 +234,15 @@ class Naomi(object):
             device_slug = self.config['audio']['input_device']
         except KeyError:
             device_slug = self.audio.get_default_device(output=False).slug
-            self._logger.warning("input_device not specified in profile, " +
-                                 "defaulting to '%s' (Possible values: %s)",
-                                 device_slug, ', '.join(devices))
+            self._logger.warning(
+                " ".join([
+                    "input_device not specified in profile, ",
+                    "defaulting to '{:s}' (Possible values: {:s})"
+                ]).format(
+                    device_slug,
+                    ', '.join(devices)
+                )
+            )
         try:
             input_device = self.audio.get_device_by_slug(device_slug)
             if audioengine.DEVICE_TYPE_INPUT not in input_device.types:
@@ -222,9 +251,49 @@ class Naomi(object):
                     % input_device.slug)
         except (audioengine.DeviceException) as e:
             self._logger.critical(e.args[0])
-            self._logger.warning('Valid output devices: %s',
+            self._logger.warning('Valid input devices: %s',
                                  ', '.join(devices))
             raise
+        input_device._input_rate = profile.get_profile_var(
+            self.config,
+            ['audio', 'input_samplerate'],
+            16000
+        )
+        input_device._input_bits = profile.get_profile_var(
+            self.config,
+            ['audio', 'input_samplewidth'],
+            16
+        )
+        input_device._input_channels = profile.get_profile_var(
+            self.config,
+            ['audio', 'input_channels'],
+            1
+        )
+        input_device._input_chunksize = profile.get_profile_var(
+            self.config,
+            ['audio', 'input_chunksize'],
+            1024
+        )
+        self._logger.debug(
+            'Input sample rate: {:d} Hz'.format(
+                input_device._input_rate
+            )
+        )
+        self._logger.debug(
+            'Input sample width: {:d} bit'.format(
+                input_device._input_bits
+            )
+        )
+        self._logger.debug(
+            'Input channels: {:d}'.format(
+                input_device._input_channels
+            )
+        )
+        self._logger.debug(
+            'Input chunksize: {:d} frames'.format(
+                input_device._input_chunksize
+            )
+        )
 
         # Initialize audio output device
         devices = [device.slug for device in self.audio.get_devices(
@@ -233,20 +302,55 @@ class Naomi(object):
             device_slug = self.config['audio']['output_device']
         except KeyError:
             device_slug = self.audio.get_default_device(output=True).slug
-            self._logger.warning("output_device not specified in profile, " +
-                                 "defaulting to '%s' (Possible values: %s)",
-                                 device_slug, ', '.join(devices))
+            self._logger.warning(
+                " ".join([
+                    "output_device not specified in profile,",
+                    "defaulting to '{0:s}' (Possible values: {1:s})"
+                ]).format(device_slug, ', '.join(devices))
+            )
         try:
             output_device = self.audio.get_device_by_slug(device_slug)
             if audioengine.DEVICE_TYPE_OUTPUT not in output_device.types:
                 raise audioengine.UnsupportedFormat(
-                    "Audio device with slug '%s' is not an output device"
-                    % output_device.slug)
+                    " ".join([
+                        "Audio device with slug '{:s}'",
+                        "is not an output device"
+                    ]).format(output_device.slug)
+                )
         except (audioengine.DeviceException) as e:
             self._logger.critical(e.args[0])
-            self._logger.warning('Valid output devices: %s',
-                                 ', '.join(devices))
+            self._logger.warning(
+                'Valid output devices: {:s}'.format(', '.join(devices))
+            )
             raise
+        output_device._output_chunksize = profile.get_profile_var(
+            self.config,
+            ['audio', 'output_chunksize'],
+            1024
+        )
+        output_device._output_padding = profile.get_profile_flag(
+            self.config,
+            ['audio', 'output_padding'],
+            False
+        )
+        self._logger.debug(
+            'Output chunksize: {:d} frames'.format(
+                output_device._output_chunksize
+            )
+        )
+        self._logger.debug(
+            'Output padding: {:s}'.format(
+                'yes' if output_device._output_padding else 'no'
+            )
+        )
+
+        # Initialize Voice activity detection
+        vad_slug = profile.get_profile_var(self.config, ['vad_engine'], 'snr')
+        vad_info = self.plugins.get_plugin(
+            vad_slug,
+            category='vad'
+        )
+        vad_plugin = vad_info.plugin_class(input_device)
 
         # Initialize Brain
         self.brain = brain.Brain(self.config)
@@ -347,6 +451,7 @@ class Naomi(object):
                 passive_stt_plugin,
                 active_stt_plugin,
                 tts_plugin,
+                vad_plugin,
                 self.config,
                 keyword=keyword,
                 print_transcript=print_transcript

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -350,7 +350,10 @@ class Naomi(object):
             vad_slug,
             category='vad'
         )
-        vad_plugin = vad_info.plugin_class(input_device)
+        vad_config = {}
+        if(vad_slug in self.config):
+            vad_config = self.config[vad_slug]
+        vad_plugin = vad_info.plugin_class(input_device,**vad_config)
 
         # Initialize Brain
         self.brain = brain.Brain(self.config)

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -3,19 +3,10 @@ import logging
 import tempfile
 import wave
 import audioop
-import collections
 import contextlib
-import threading
-import math
-import sys
-if sys.version_info < (3, 0):  # NOQA
-    import Queue as queue
-else:  # NOQA
-    import queue
 
 from . import alteration
 from . import paths
-from . import profile
 
 
 class Mic(object):
@@ -32,6 +23,7 @@ class Mic(object):
         passive_stt_engine,
         active_stt_engine,
         tts_engine,
+        vad_plugin,
         config,
         keyword='NAOMI',
         print_transcript=False
@@ -43,50 +35,10 @@ class Mic(object):
         self.active_stt_engine = active_stt_engine
         self._input_device = input_device
         self._output_device = output_device
+        self._vad_plugin = vad_plugin
         self._active_stt_reply = active_stt_reply
         self._active_stt_response = active_stt_response
-        self._input_rate = profile.get_profile_var(
-            config,
-            ['audio','input_samplerate'],
-            16000
-        )
-        self._input_bits = profile.get_profile_var(
-            config,
-            ['audio','input_samplewidth'],
-            16
-        )
-        self._input_channels = profile.get_profile_var(
-            config,
-            ['audio','input_channels'],
-            1
-        )
-        self._input_chunksize = profile.get_profile_var(
-            config,
-            ['audio','input_chunksize'],
-            1024
-        )
-        self._output_chunksize = profile.get_profile_var(
-            config,
-            ['audio','output_chunksize'],
-            1024
-        )
-        self._output_padding = profile.get_profile_flag(
-            config,
-            ['audio','output_padding'],
-            False
-        )
         self._print_transcript = print_transcript
-
-        self._logger.debug('Input sample rate: %d Hz', self._input_rate)
-        self._logger.debug('Input sample width: %d bit', self._input_bits)
-        self._logger.debug('Input channels: %d', self._input_channels)
-        self._logger.debug('Input chunksize: %d frames', self._input_chunksize)
-        self._logger.debug('Output chunksize: %d frames',
-                           self._output_chunksize)
-        self._logger.debug('Output padding: %s',
-                           'yes' if self._output_padding else 'no')
-
-        self._threshold = 2.0 ** self._input_bits
 
     @contextlib.contextmanager
     def special_mode(self, name, phrases):
@@ -103,168 +55,109 @@ class Mic(object):
         finally:
             self.active_stt_engine = original_stt_engine
 
-    def _snr(self, frames):
-        rms = audioop.rms(b''.join(frames), int(self._input_bits / 8))
-        if rms > 0 and self._threshold > 0:
-            return 20.0 * math.log(rms / self._threshold, 10)
-        else:
-            return 0
-
     @contextlib.contextmanager
     def _write_frames_to_file(self, frames, framerate, volume):
         with tempfile.NamedTemporaryFile(mode='w+b') as f:
             wav_fp = wave.open(f, 'wb')
-            wav_fp.setnchannels(self._input_channels)
-            wav_fp.setsampwidth(int(self._input_bits / 8))
+            wav_fp.setnchannels(self._input_device._input_channels)
+            wav_fp.setsampwidth(int(self._input_device._input_bits / 8))
             wav_fp.setframerate(framerate)
-            if self._input_rate == framerate:
+            if self._input_device._input_rate == framerate:
                 fragment = b''.join(frames)
             else:
-                fragment = audioop.ratecv(''.join(frames),
-                                          int(self._input_bits / 8),
-                                          self._input_channels,
-                                          self._input_rate,
-                                          framerate, None)[0]
+                fragment = audioop.ratecv(
+                    ''.join(frames),
+                    int(self._input_device._input_bits / 8),
+                    self._input_device._input_channels,
+                    self._input_device._input_rate,
+                    framerate,
+                    None
+                )[0]
             if volume is not None:
-                maxvolume = audioop.minmax(fragment, self._input_bits / 8)[1]
+                maxvolume = audioop.minmax(
+                    fragment,
+                    self._input_device._input_bits / 8
+                )[1]
                 fragment = audioop.mul(
-                    fragment, int(self._input_bits / 8),
-                    volume * (2. ** 15) / maxvolume)
+                    fragment,
+                    int(self._input_device._input_bits / 8),
+                    volume * (2. ** 15) / maxvolume
+                )
 
             wav_fp.writeframes(fragment)
             wav_fp.close()
             f.seek(0)
             yield f
 
-    def check_for_keyword(self, frame_queue, keyword_uttered, keyword):
-        while True:
-            frames = frame_queue.get()
-            with self._write_frames_to_file(
-                    frames, self.passive_stt_engine._samplerate,
-                    self.passive_stt_engine._volume_normalization) as f:
-                try:
-                    transcribed = self.passive_stt_engine.transcribe(f)
-                except:
-                    dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
-                    self._logger.error("Transcription failed!", exc_info=dbg)
-                else:
-                    if transcribed:
-                        if(self._print_transcript):
-                            print("<  {}".format(transcribed))
-                        if any([keyword.lower() in t.lower()
-                                            for t in transcribed if t]):
-                            keyword_uttered.set()
-                finally:
-                    frame_queue.task_done()
-
     def wait_for_keyword(self, keyword=None):
         if not keyword:
             keyword = self._keyword
-        frame_queue = queue.Queue()
-        keyword_uttered = threading.Event()
-
-        # FIXME: not configurable yet
-        num_worker_threads = 2
-
-        for i in range(num_worker_threads):
-            t = threading.Thread(target=self.check_for_keyword,
-                                 args=(frame_queue, keyword_uttered, keyword))
-            t.daemon = True
-            t.start()
-
-        frames = collections.deque([], 30)
-        recording = False
-        recording_frames = []
-        self._logger.info("Waiting for keyword '%s'...", keyword)
-        for frame in self._input_device.record(self._input_chunksize,
-                                               self._input_bits,
-                                               self._input_channels,
-                                               self._input_rate):
-            if keyword_uttered.is_set():
-                self._logger.info("Keyword %s has been uttered", keyword)
-                return
-            frames.append(frame)
-            if not recording:
-                snr = self._snr([frame])
-                if snr >= 10:  # 10dB
-                    # Loudness is higher than normal, start recording and use
-                    # the last 10 frames to start
-                    self._logger.debug("Started recording on device '%s'",
-                                       self._input_device.slug)
-                    self._logger.debug("Triggered on SNR of %sdB", snr)
-                    recording = True
-                    recording_frames = list(frames)[-10:]
-                elif len(frames) >= frames.maxlen:
-                    # Threshold SNR not reached. Update threshold with
-                    # background noise.
-                    self._threshold = float(audioop.rms(b"".join(frames), 2))
-            else:
-                # We're recording
-                recording_frames.append(frame)
-                if len(recording_frames) > 20:
-                    # If we recorded at least 20 frames, check if we're below
-                    # threshold again
-                    last_snr = self._snr(recording_frames[-10:])
-                    self._logger.debug(
-                        "Recording's SNR dB: %f", last_snr)
-                    if last_snr <= 3 or len(recording_frames) >= 60:
-                        # The loudness of the sound is not at least as high as
-                        # the the threshold, or we've been waiting too long
-                        # we'll stop recording now
-                        recording = False
-                        self._logger.debug("Recorded %d frames",
-                                           len(recording_frames))
-                        frame_queue.put(tuple(recording_frames))
-                        self._threshold = float(
-                            audioop.rms(b"".join(frames), 2))
-
-    def listen(self):
-        self.wait_for_keyword(self._keyword)
-        return self.active_listen()
+        while True:
+            with self._write_frames_to_file(
+                self._vad_plugin.get_audio(),
+                self.passive_stt_engine._samplerate,
+                self.passive_stt_engine._volume_normalization
+            ) as f:
+                try:
+                    transcribed = self.passive_stt_engine.transcribe(f)
+                except Exception:
+                    dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
+                    self._logger.error(
+                        "Passive transcription failed!",
+                        exc_info=dbg
+                    )
+                else:
+                    if(len(transcribed)):
+                        if(self._print_transcript):
+                            print("<  {}".format(transcribed))
+                        if any([
+                            keyword.lower() in t.lower()
+                            for t in transcribed if t
+                        ]):
+                            return
+                    else:
+                        if(self._print_transcript):
+                            print("<  <noise>")
 
     def active_listen(self, timeout=3):
-        # record until <timeout> second of silence or double <timeout>.
-        n = int(round((self._input_rate / self._input_chunksize) * timeout))
+        transcribed = []
+        # let the user know we are listening
         if self._active_stt_reply:
             self.say(self._active_stt_reply)
         else:
             self._logger.debug("No text to respond with using beep")
             self.play_file(paths.data('audio', 'beep_hi.wav'))
-
-        frames = []
-        for frame in self._input_device.record(
-            self._input_chunksize,
-            self._input_bits,
-            self._input_channels,
-            self._input_rate
-        ):
-            frames.append(frame)
-            if(
-                len(frames) >= 2 * n
-            )or(
-                    len(frames) > n and self._snr(frames[-n:]) <= 3
-            ):
-                break
-
-        if self._active_stt_response:
-            self.say(self._active_stt_response)
-        else:
-            self._logger.debug("No text to respond with using beep")
-            self.play_file(paths.data('audio', 'beep_lo.wav'))
-
         with self._write_frames_to_file(
-                frames, self.active_stt_engine._samplerate,
-                self.active_stt_engine._volume_normalization) as f:
-            transcription = self.active_stt_engine.transcribe(f)
-            if(self._print_transcript):
-                print("<< {}".format(transcription))
-            return transcription
+            self._vad_plugin.get_audio(),
+            self.active_stt_engine._samplerate,
+            self.active_stt_engine._volume_normalization
+        ) as f:
+            if self._active_stt_reply:
+                self.say(self._active_stt_reply)
+            else:
+                self._logger.debug("No text to respond with using beep")
+                self.play_file(paths.data('audio', 'beep_hi.wav'))
+            try:
+                transcribed = self.active_stt_engine.transcribe(f)
+            except Exception:
+                dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
+                self._logger.error("Active transcription failed!", exc_info=dbg)
+            else:
+                if(self._print_transcript):
+                    print("<< {}".format(transcribed))
+        return transcribed
+
+    def listen(self):
+        self.wait_for_keyword(self._keyword)
+        return self.active_listen()
 
     # Output methods
     def play_file(self, filename):
-        self._output_device.play_file(filename,
-                                      chunksize=self._output_chunksize,
-                                      add_padding=self._output_padding)
+        self._output_device.play_file(
+            filename,
+            chunksize=self._output_device._output_chunksize,
+            add_padding=self._output_device._output_padding
+        )
 
     def say(self, phrase):
         if(self._print_transcript):

--- a/naomi/pluginstore.py
+++ b/naomi/pluginstore.py
@@ -145,7 +145,8 @@ class PluginStore(object):
             'audioengine': plugin.AudioEnginePlugin,
             'speechhandler': plugin.SpeechHandlerPlugin,
             'tts': plugin.TTSPlugin,
-            'stt': plugin.STTPlugin
+            'stt': plugin.STTPlugin,
+            'vad': plugin.VADPlugin
         }
 
     def detect_plugins(self):

--- a/naomi/testutils.py
+++ b/naomi/testutils.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from . import paths
+import contextlib
 import gettext
+import logging
+import sys
+import unittest
+import wave
 import yaml
 
 
@@ -47,13 +52,90 @@ class TestMic(object):
         self.outputs.append(phrase)
 
 
-class TestInput:
+# This class is required to create a fake input_device object
+# when performing tests on VAD plugins below.
+class TestInput(object):
     def __init__(self, input_rate, input_bits, input_chunksize):
         self._input_rate = input_rate
         self._input_bits = input_bits
         self._input_chunksize = input_chunksize
 
 
+class Test_VADPlugin(unittest.TestCase):
+    # attributes of the sample we are using
+    # These are standard defaults for Naomi
+    sample_file = "naomi/data/audio/naomi.wav"
+    sample_channels = 1
+    sample_rate = 16000  # Hz
+    sample_width = 16    # bits
+    # Standard lengths for an audio clip used for VAD in webrtc are
+    # 10ms, 20ms, or 30ms
+    # It is not necessary to use the same clip length here, but we
+    # will for consistancy.
+    clip_duration = 30   # ms
+    clip_bytes = int((sample_width / 8) * (sample_rate * clip_duration / 1000))
+
+    def setUp(self, *args, **kwargs):
+        self._logger = logging.getLogger(__name__)
+        # Uncomment the following line to see detection timeline for sample
+        # audio file
+        self._logger.setLevel(logging.INFO)
+        # This is necessary because the VAD plugin requires an input
+        # device to initialize. These values are only used in the
+        # get_audio method, so shouldn't have any real effect on these
+        # tests.
+        self._test_input = TestInput(
+            self.sample_rate,
+            self.sample_width,
+            (self.clip_duration / 1000) * self.sample_rate
+        )
+
+    def map_file(self):
+        with contextlib.closing(
+            wave.open(self.sample_file, "rb")
+        ) as wf:
+            audio = wf.readframes(wf.getnframes())
+            clip_detect = ""
+            offset = 0
+            while offset + self.clip_bytes < len(audio):
+                result = self.plugin._voice_detected(
+                    audio[offset:offset + self.clip_bytes]
+                )
+                clip_detect += "+" if result else "-"
+                offset += self.clip_bytes
+            # unittest appears to do something odd to stderr
+            # to see logger output, have to do this:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            self._logger.addHandler(stream_handler)
+            self._logger.info("")
+            self._logger.info(clip_detect)
+            self._logger.removeHandler(stream_handler)
+
+    def test_silence(self):
+        self.assertFalse(self.plugin._voice_detected(
+            b'\x00' * self.clip_bytes
+        ))
+
+    def test_voice(self):
+        # Get a sample of voice from a known sample
+        # (naomi/data/audio/naomi.wav)
+        # Voice data starts at .8 seconds
+        with contextlib.closing(
+            wave.open("naomi/data/audio/naomi.wav", "rb")
+        ) as wf:
+            # Go to the position of the clip I want to test (0.84 seconds)
+            # measured in frames
+            position = int(0.84 * wf.getframerate())
+            wf.setpos(position)
+            clip = wf.readframes(
+                int(((self.clip_duration / 1000) * self.sample_rate))
+            )
+        self.assertTrue(self.plugin._voice_detected(
+            clip
+        ))
+
+
+# Return an instance of the plugin.
 def get_plugin_instance(plugin_class, *extra_args):
     info = type(
         '',

--- a/naomi/testutils.py
+++ b/naomi/testutils.py
@@ -47,6 +47,13 @@ class TestMic(object):
         self.outputs.append(phrase)
 
 
+class TestInput:
+    def __init__(self, input_rate, input_bits, input_chunksize):
+        self._input_rate = input_rate
+        self._input_bits = input_bits
+        self._input_chunksize = input_chunksize
+
+
 def get_plugin_instance(plugin_class, *extra_args):
     info = type('', (object,),
                 {

--- a/naomi/testutils.py
+++ b/naomi/testutils.py
@@ -75,11 +75,12 @@ class Test_VADPlugin(unittest.TestCase):
     clip_duration = 30   # ms
     clip_bytes = int((sample_width / 8) * (sample_rate * clip_duration / 1000))
 
-    def setUp(self, *args, **kwargs):
+    def setUp(self):
+        super(Test_VADPlugin, self).setUp()
         self._logger = logging.getLogger(__name__)
         # Uncomment the following line to see detection timeline for sample
         # audio file
-        self._logger.setLevel(logging.INFO)
+        # self._logger.setLevel(logging.INFO)
         # This is necessary because the VAD plugin requires an input
         # device to initialize. These values are only used in the
         # get_audio method, so shouldn't have any real effect on these

--- a/naomi/testutils.py
+++ b/naomi/testutils.py
@@ -55,13 +55,15 @@ class TestInput:
 
 
 def get_plugin_instance(plugin_class, *extra_args):
-    info = type('', (object,),
-                {
-                    'name': 'pluginunittest',
-                    'translations': {
-                        'en-US': gettext.NullTranslations()
-                    }
-                }
-            )()
+    info = type(
+        '',
+        (object,),
+        {
+            'name': 'pluginunittest',
+            'translations': {
+                'en-US': gettext.NullTranslations()
+            }
+        }
+    )()
     args = tuple(extra_args) + (info, test_profile())
     return plugin_class(*args)

--- a/plugins/vad/snr_vad/__init__.py
+++ b/plugins/vad/snr_vad/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .snr_vad import SNRPlugin

--- a/plugins/vad/snr_vad/plugin.info
+++ b/plugins/vad/snr_vad/plugin.info
@@ -1,0 +1,10 @@
+[Plugin]
+Name = snr_vad
+Version = 1.0.0
+License = MIT
+URL = http://naomiproject.github.io/
+Description = VAD using Signal to Noise Ratio
+
+[Author]
+Name = Naomi Project
+URL = http://naomiproject.github.io/

--- a/plugins/vad/snr_vad/snr_vad.py
+++ b/plugins/vad/snr_vad/snr_vad.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# This is a really simple voice activity detector
+# based on what Naomi currently uses. When you create it,
+# you can pass in a decibel level which defaults to 30dB.
+# The optimal value for decibel level appears to be
+# affected not only by noise levels where you are, but
+# also the specific sound card or even microphone you
+# are using.
+# Once the audio level goes above this level, recording
+# starts. Once the level goes below this for timeout
+# seconds (floating point, can be fractional), then
+# recording stops. If the total length of the recording is
+# over twice the length of timeout, then the recorded audio
+# is returned for processing.
+from naomi import plugin
+import audioop
+import logging
+import math
+
+
+class SNRPlugin(plugin.VADPlugin):
+    def __init__(
+        self,
+        input_device,
+        timeout=1,
+        minimum_capture=0.5,
+        threshold=30
+    ):
+        super(SNRPlugin, self).__init__(input_device, timeout, minimum_capture)
+        # if the audio decibel is greater than threshold, then consider this
+        # having detected a voice.
+        self._threshold = threshold
+        # Keep track of the number of audio levels
+        self.distribution = {}
+
+    def _voice_detected(self, frame):
+        rms = audioop.rms(frame, int(self._input_device._input_bits / 8))
+        if rms > 0 and self._threshold > 0:
+            snr = round(20.0 * math.log(rms / self._threshold, 10))
+        else:
+            snr = 0
+        if snr in self.distribution:
+            self.distribution[snr] += 1
+        else:
+            self.distribution[snr] = 1
+        # calculate the mean and standard deviation
+        sum1 = sum([
+            value * (key ** 2) for key, value in self.distribution.items()
+        ])
+        items = sum([value for value in self.distribution.values()])
+        if items > 1:
+            # mean = sum( value * freq )/items
+            mean = sum(
+                [key * value for key, value in self.distribution.items()]
+            ) / items
+            stddev = math.sqrt((sum1 - (items * (mean ** 2))) / (items - 1))
+            self._threshold = mean + (stddev * 1.5)
+            if(self._logger.getEffectiveLevel() < logging.ERROR):
+                print(
+                    "\t".join([
+                        "snr: {}",
+                        "threshold: {}",
+                        "mean: {}",
+                        "deviation: {}"
+                    ]).format(
+                        snr,
+                        round(self._threshold),
+                        round(mean),
+                        round(stddev)
+                    )
+                )
+        if(items > 100):
+            # Every 100 samples, rescale, allowing changes in
+            # the environment to be recognized more quickly.
+            self.distribution = {
+                key: (
+                    (value + 1) / 2
+                ) for key, value in self.distribution.items()
+            }
+        if(snr < self._threshold):
+            response = False
+        else:
+            self._logger.info("Voice Detected: {}".format(snr))
+            response = True
+        return response

--- a/plugins/vad/snr_vad/snr_vad.py
+++ b/plugins/vad/snr_vad/snr_vad.py
@@ -13,19 +13,21 @@
 # over twice the length of timeout, then the recorded audio
 # is returned for processing.
 from naomi import plugin
+from naomi import profile
 import audioop
 import logging
 import math
 
 
 class SNRPlugin(plugin.VADPlugin):
-    def __init__(
-        self,
-        input_device,
-        timeout=1,
-        minimum_capture=0.5,
-        threshold=30
-    ):
+    def __init__(self, input_device, **kwargs):
+        timeout = profile.get_profile_var(kwargs, ["timeout"], 1)
+        minimum_capture = profile.get_profile_var(
+            kwargs,
+            ["minimum_capture"],
+            0.5
+        )
+        threshold = profile.get_profile_var(kwargs, ["threshold"], 30)
         super(SNRPlugin, self).__init__(input_device, timeout, minimum_capture)
         # if the audio decibel is greater than threshold, then consider this
         # having detected a voice.

--- a/plugins/vad/snr_vad/snr_vad.py
+++ b/plugins/vad/snr_vad/snr_vad.py
@@ -20,7 +20,8 @@ import math
 
 
 class SNRPlugin(plugin.VADPlugin):
-    def __init__(self, input_device, **kwargs):
+    def __init__(self, *args, **kwargs):
+        input_device = args[0]
         timeout = profile.get_profile_var(kwargs, ["timeout"], 1)
         minimum_capture = profile.get_profile_var(
             kwargs,
@@ -57,7 +58,7 @@ class SNRPlugin(plugin.VADPlugin):
             ) / items
             stddev = math.sqrt((sum1 - (items * (mean ** 2))) / (items - 1))
             self._threshold = mean + (stddev * 1.5)
-            if(self._logger.getEffectiveLevel() < logging.ERROR):
+            if(self._logger.getEffectiveLevel() < logging.WARN):
                 print(
                     "\t".join([
                         "snr: {}",

--- a/plugins/vad/snr_vad/test_snr_vad.py
+++ b/plugins/vad/snr_vad/test_snr_vad.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+import collections
+import contextlib
+import logging
+import os
+import unittest
+import wave
+from naomi import testutils, diagnose
+from . import snr_vad
+
+
+class TestSNR_VADPlugin(unittest.TestCase):
+    channels = 1
+    sample_rate = 16000 # Hz
+    sample_width = 16 # bits
+    clip_duration = 30 # ms
+    clip_bytes = int((sample_width / 8) * (sample_rate * clip_duration / 1000))
+
+    def setUp(self):
+        self._logger = logging.getLogger(__name__)
+        _test_input = testutils.TestInput(self.sample_rate,self.sample_width,480)
+        self.plugin = testutils.get_plugin_instance(
+            snr_vad.SNRPlugin,
+            _test_input
+        )
+        # prime by running through one wav file
+        with contextlib.closing(wave.open("naomi/data/audio/naomi.wav","rb")) as wf:
+            assert wf.getnchannels() == self.channels
+            assert wf.getsampwidth() == self.sample_width / 8
+            assert wf.getframerate() == self.sample_rate
+            audio = wf.readframes(wf.getnframes())
+            clip_detect = ""
+            offset = 0
+            while offset + self.clip_bytes < len(audio):
+                result = self.plugin._voice_detected(audio[offset:offset + self.clip_bytes])
+                clip_detect += "+" if result else "-"
+                offset += self.clip_bytes
+            self._logger.info(clip_detect)
+
+    def test_silence(self):
+        self.assertFalse(self.plugin._voice_detected(
+            b'\x00' * self.clip_bytes
+        ))
+
+    def test_voice(self):
+        # Get a sample of voice from a known sample
+        # (naomi/data/audio/naomi.wav)
+        # Voice data starts at .8 seconds
+        with contextlib.closing(wave.open("naomi/data/audio/naomi.wav","rb")) as wf:
+            bytes_per_frame = self.channels * self.sample_width / 8
+            bytes_per_clip = int(((self.clip_duration / 1000) * self.sample_rate * self.sample_width / 8))
+            if False:
+                # Read the whole file into memory
+                wf.rewind()
+                audio_data = wf.readframes(wf.getnframes())
+                # Grab the bytes I need
+                position = int((0.84 * self.clip_bytes) / ((self.clip_duration / 1000)))
+                clip = audio_data[position:int(position + (bytes_per_clip))]
+            else:
+                # Go to the position of the clip I want to test (0.84 seconds)
+                # measured in frames
+                #position = int((0.84 * self.clip_bytes) / ((self.clip_duration / 1000) * bytes_per_frame))
+                position = int(0.84 * wf.getframerate())
+                wf.setpos(position)
+                clip = wf.readframes(int(((self.clip_duration / 1000) * self.sample_rate)))
+        self.assertTrue(self.plugin._voice_detected(
+            clip
+        ))

--- a/plugins/vad/snr_vad/test_snr_vad.py
+++ b/plugins/vad/snr_vad/test_snr_vad.py
@@ -5,8 +5,8 @@ from . import snr_vad
 
 class TestSNR_VADPlugin(testutils.Test_VADPlugin):
 
-    def setUp(self, *args, **kwargs):
-        super(TestSNR_VADPlugin, self).setUp(*args, **kwargs)
+    def setUp(self):
+        super(TestSNR_VADPlugin, self).setUp()
         self.plugin = testutils.get_plugin_instance(
             snr_vad.SNRPlugin,
             self._test_input

--- a/plugins/vad/snr_vad/test_snr_vad.py
+++ b/plugins/vad/snr_vad/test_snr_vad.py
@@ -1,30 +1,34 @@
 # -*- coding: utf-8 -*-
-import collections
 import contextlib
 import logging
-import os
 import unittest
 import wave
-from naomi import testutils, diagnose
+from naomi import testutils
 from . import snr_vad
 
 
 class TestSNR_VADPlugin(unittest.TestCase):
     channels = 1
-    sample_rate = 16000 # Hz
-    sample_width = 16 # bits
-    clip_duration = 30 # ms
+    sample_rate = 16000  # Hz
+    sample_width = 16    # bits
+    clip_duration = 30   # ms
     clip_bytes = int((sample_width / 8) * (sample_rate * clip_duration / 1000))
 
     def setUp(self):
         self._logger = logging.getLogger(__name__)
-        _test_input = testutils.TestInput(self.sample_rate,self.sample_width,480)
+        _test_input = testutils.TestInput(
+            self.sample_rate,
+            self.sample_width,
+            (self.clip_duration / 1000) * self.sample_rate
+        )
         self.plugin = testutils.get_plugin_instance(
             snr_vad.SNRPlugin,
             _test_input
         )
         # prime by running through one wav file
-        with contextlib.closing(wave.open("naomi/data/audio/naomi.wav","rb")) as wf:
+        with contextlib.closing(
+            wave.open("naomi/data/audio/naomi.wav", "rb")
+        ) as wf:
             assert wf.getnchannels() == self.channels
             assert wf.getsampwidth() == self.sample_width / 8
             assert wf.getframerate() == self.sample_rate
@@ -32,7 +36,9 @@ class TestSNR_VADPlugin(unittest.TestCase):
             clip_detect = ""
             offset = 0
             while offset + self.clip_bytes < len(audio):
-                result = self.plugin._voice_detected(audio[offset:offset + self.clip_bytes])
+                result = self.plugin._voice_detected(
+                    audio[offset:offset + self.clip_bytes]
+                )
                 clip_detect += "+" if result else "-"
                 offset += self.clip_bytes
             self._logger.info(clip_detect)
@@ -46,23 +52,29 @@ class TestSNR_VADPlugin(unittest.TestCase):
         # Get a sample of voice from a known sample
         # (naomi/data/audio/naomi.wav)
         # Voice data starts at .8 seconds
-        with contextlib.closing(wave.open("naomi/data/audio/naomi.wav","rb")) as wf:
-            bytes_per_frame = self.channels * self.sample_width / 8
-            bytes_per_clip = int(((self.clip_duration / 1000) * self.sample_rate * self.sample_width / 8))
+        with contextlib.closing(
+            wave.open("naomi/data/audio/naomi.wav", "rb")
+        ) as wf:
+            bytes_per_clip = int(((
+                self.clip_duration / 1000
+            ) * self.sample_rate * self.sample_width / 8))
             if False:
                 # Read the whole file into memory
                 wf.rewind()
                 audio_data = wf.readframes(wf.getnframes())
                 # Grab the bytes I need
-                position = int((0.84 * self.clip_bytes) / ((self.clip_duration / 1000)))
+                position = int(
+                    (0.84 * self.clip_bytes) / ((self.clip_duration / 1000))
+                )
                 clip = audio_data[position:int(position + (bytes_per_clip))]
             else:
                 # Go to the position of the clip I want to test (0.84 seconds)
                 # measured in frames
-                #position = int((0.84 * self.clip_bytes) / ((self.clip_duration / 1000) * bytes_per_frame))
                 position = int(0.84 * wf.getframerate())
                 wf.setpos(position)
-                clip = wf.readframes(int(((self.clip_duration / 1000) * self.sample_rate)))
+                clip = wf.readframes(
+                    int(((self.clip_duration / 1000) * self.sample_rate))
+                )
         self.assertTrue(self.plugin._voice_detected(
             clip
         ))

--- a/plugins/vad/snr_vad/test_snr_vad.py
+++ b/plugins/vad/snr_vad/test_snr_vad.py
@@ -1,80 +1,15 @@
 # -*- coding: utf-8 -*-
-import contextlib
-import logging
-import sys
-import unittest
-import wave
 from naomi import testutils
 from . import snr_vad
 
 
-class TestSNR_VADPlugin(unittest.TestCase):
-    # attributes of the sample we are using
-    # These are standard defaults for Naomi
-    sample_channels = 1
-    sample_rate = 16000  # Hz
-    sample_width = 16    # bits
-    # Standard lengths for an audio clip used for VAD in webrtc are
-    # 10ms, 20ms, or 30ms
-    # It is not necessary to use the same clip length here, but we
-    # will for consistancy.
-    clip_duration = 30   # ms
-    clip_bytes = int((sample_width / 8) * (sample_rate * clip_duration / 1000))
+class TestSNR_VADPlugin(testutils.Test_VADPlugin):
 
-    def setUp(self):
-        self._logger = logging.getLogger(__name__)
-        # Uncomment the following line to see detection timeline for sample
-        # audio file
-        # self._logger.setLevel(logging.INFO)
-        _test_input = testutils.TestInput(
-            self.sample_rate,
-            self.sample_width,
-            (self.clip_duration / 1000) * self.sample_rate
-        )
+    def setUp(self, *args, **kwargs):
+        super(TestSNR_VADPlugin, self).setUp(*args, **kwargs)
         self.plugin = testutils.get_plugin_instance(
             snr_vad.SNRPlugin,
-            _test_input
+            self._test_input
         )
         # prime by running through one wav file
-        with contextlib.closing(
-            wave.open("naomi/data/audio/naomi.wav", "rb")
-        ) as wf:
-            audio = wf.readframes(wf.getnframes())
-            clip_detect = ""
-            offset = 0
-            while offset + self.clip_bytes < len(audio):
-                result = self.plugin._voice_detected(
-                    audio[offset:offset + self.clip_bytes]
-                )
-                clip_detect += "+" if result else "-"
-                offset += self.clip_bytes
-            # unittest appears to do something odd to stderr
-            # to see logger output, have to do this:
-            stream_handler = logging.StreamHandler(sys.stdout)
-            self._logger.addHandler(stream_handler)
-            self._logger.info("")
-            self._logger.info(clip_detect)
-            self._logger.removeHandler(stream_handler)
-
-    def test_silence(self):
-        self.assertFalse(self.plugin._voice_detected(
-            b'\x00' * self.clip_bytes
-        ))
-
-    def test_voice(self):
-        # Get a sample of voice from a known sample
-        # (naomi/data/audio/naomi.wav)
-        # Voice data starts at .8 seconds
-        with contextlib.closing(
-            wave.open("naomi/data/audio/naomi.wav", "rb")
-        ) as wf:
-            # Go to the position of the clip I want to test (0.84 seconds)
-            # measured in frames
-            position = int(0.84 * wf.getframerate())
-            wf.setpos(position)
-            clip = wf.readframes(
-                int(((self.clip_duration / 1000) * self.sample_rate))
-            )
-        self.assertTrue(self.plugin._voice_detected(
-            clip
-        ))
+        self.map_file()

--- a/plugins/vad/webrtc_vad/__init__.py
+++ b/plugins/vad/webrtc_vad/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .webrtc_vad import WebRTCPlugin

--- a/plugins/vad/webrtc_vad/plugin.info
+++ b/plugins/vad/webrtc_vad/plugin.info
@@ -1,0 +1,10 @@
+[Plugin]
+Name = webrtc_vad
+Version = 1.0.0
+License = MIT
+URL = http://naomiproject.github.io/
+Description = VAD using WebRTC VAD module
+
+[Author]
+Name = Naomi Project
+URL = http://naomiproject.github.io/

--- a/plugins/vad/webrtc_vad/test_webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/test_webrtc_vad.py
@@ -6,8 +6,8 @@ from . import webrtc_vad
 
 class TestWebRTC_VADPlugin(testutils.Test_VADPlugin):
 
-    def setUp(self, *args, **kwargs):
-        super(TestWebRTC_VADPlugin, self).setUp(*args, **kwargs)
+    def setUp(self):
+        super(TestWebRTC_VADPlugin, self).setUp()
         self.plugin = testutils.get_plugin_instance(
             webrtc_vad.WebRTCPlugin,
             self._test_input

--- a/plugins/vad/webrtc_vad/test_webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/test_webrtc_vad.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import collections
+import contextlib
+import logging
+import os
+import unittest
+import wave
+from naomi import testutils, diagnose
+from . import webrtc_vad
+
+
+class TestWebRTCPlugin(unittest.TestCase):
+    sample_rate = 16000 # Hz
+    sample_width = 16 # bits
+    clip_duration = 30 # ms
+    clip_bytes = int((sample_width / 8) * (sample_rate * clip_duration / 1000))
+
+    def setUp(self):
+        self._logger = logging.getLogger(__name__)
+        _test_input = testutils.TestInput(self.sample_rate,self.sample_width,480)
+        self.plugin = testutils.get_plugin_instance(
+            webrtc_vad.WebRTCPlugin,
+            _test_input
+        )
+        # This is just for comparison to see how VAD engines compare in
+        # detecting audio. Skip if not in INFO logging level.
+        if(self._logger.getEffectiveLevel() < logging.WARN):
+            with contextlib.closing(wave.open("naomi/data/audio/naomi.wav","rb")) as wf:
+                assert wf.getnchannels() == 1
+                assert wf.getsampwidth() == 2
+                assert wf.getframerate() == 16000
+                audio_data = wf.readframes(wf.getnframes())
+                clip_detect = ""
+                offset = 0
+                while offset + self.clip_bytes < len(audio_data):
+                    result = self.plugin._voice_detected(audio_data[offset:offset + self.clip_bytes])
+                    clip_detect += "+" if result else "-"
+                    offset += self.clip_bytes
+                self._logger.info(clip_detect)
+
+    def test_silence(self):
+        self.assertFalse(self.plugin._voice_detected(
+            b'\x00' * self.clip_bytes
+        ))
+
+    def test_voice(self):
+        # Get a sample of voice from a known sample
+        # (naomi/data/audio/naomi.wav)
+        # Voice data starts at .8 seconds
+        with contextlib.closing(wave.open("naomi/data/audio/naomi.wav","rb")) as wf:
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getframerate() == 16000
+            position = int(0.84 * wf.getframerate())
+            wf.setpos(position)
+            clip = wf.readframes(int(((self.clip_duration / 1000) * self.sample_rate)))
+        self.assertTrue(self.plugin._voice_detected(
+            clip
+        ))

--- a/plugins/vad/webrtc_vad/test_webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/test_webrtc_vad.py
@@ -1,78 +1,18 @@
 # -*- coding: utf-8 -*-
-import contextlib
 import logging
-import sys
-import unittest
-import wave
 from naomi import testutils
 from . import webrtc_vad
 
 
-class TestWebRTCPlugin(unittest.TestCase):
-    # attributes of the sample we are using
-    # These are standard defaults for Naomi
-    sample_channels = 1  # Mono
-    sample_rate = 16000  # Hz
-    sample_width = 16    # bits
-    # Standard lengths for an audio clip used for VAD in webrtc are
-    # 10ms, 20ms, or 30ms
-    clip_duration = 30   # ms
-    clip_bytes = int((sample_width / 8) * (sample_rate * clip_duration / 1000))
+class TestWebRTC_VADPlugin(testutils.Test_VADPlugin):
 
-    def setUp(self):
-        self._logger = logging.getLogger(__name__)
-        # Uncomment the following line to see detection timeline for sample
-        # audio file
-        # self._logger.setLevel(logging.INFO)
-        _test_input = testutils.TestInput(
-            self.sample_rate,
-            self.sample_width,
-            (self.clip_duration / 1000) * self.sample_rate
-        )
+    def setUp(self, *args, **kwargs):
+        super(TestWebRTC_VADPlugin, self).setUp(*args, **kwargs)
         self.plugin = testutils.get_plugin_instance(
             webrtc_vad.WebRTCPlugin,
-            _test_input
+            self._test_input
         )
         # This is just for comparison to see how VAD engines compare in
         # detecting audio. Skip if not in INFO logging level.
         if(self._logger.getEffectiveLevel() < logging.WARN):
-            with contextlib.closing(
-                wave.open("naomi/data/audio/naomi.wav", "rb")
-            ) as wf:
-                audio_data = wf.readframes(wf.getnframes())
-                clip_detect = "\n"
-                offset = 0
-                while offset + self.clip_bytes < len(audio_data):
-                    result = self.plugin._voice_detected(
-                        audio_data[offset:offset + self.clip_bytes]
-                    )
-                    clip_detect += "+" if result else "-"
-                    offset += self.clip_bytes
-                # unittest appears to do something odd to stderr
-                # to see logger output, have to do this:
-                stream_handler = logging.StreamHandler(sys.stdout)
-                self._logger.addHandler(stream_handler)
-                self._logger.info("")
-                self._logger.info(clip_detect)
-                self._logger.removeHandler(stream_handler)
-
-    def test_silence(self):
-        self.assertFalse(self.plugin._voice_detected(
-            b'\x00' * self.clip_bytes
-        ))
-
-    def test_voice(self):
-        # Get a sample of voice from a known sample
-        # (naomi/data/audio/naomi.wav)
-        # Voice data starts at .8 seconds
-        with contextlib.closing(
-            wave.open("naomi/data/audio/naomi.wav", "rb")
-        ) as wf:
-            position = int(0.84 * wf.getframerate())
-            wf.setpos(position)
-            clip = wf.readframes(
-                int(((self.clip_duration / 1000) * self.sample_rate))
-            )
-        self.assertTrue(self.plugin._voice_detected(
-            clip
-        ))
+            self.map_file()

--- a/plugins/vad/webrtc_vad/test_webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/test_webrtc_vad.py
@@ -1,23 +1,25 @@
 # -*- coding: utf-8 -*-
-import collections
 import contextlib
 import logging
-import os
 import unittest
 import wave
-from naomi import testutils, diagnose
+from naomi import testutils
 from . import webrtc_vad
 
 
 class TestWebRTCPlugin(unittest.TestCase):
-    sample_rate = 16000 # Hz
-    sample_width = 16 # bits
-    clip_duration = 30 # ms
+    sample_rate = 16000  # Hz
+    sample_width = 16    # bits
+    clip_duration = 30   # ms
     clip_bytes = int((sample_width / 8) * (sample_rate * clip_duration / 1000))
 
     def setUp(self):
         self._logger = logging.getLogger(__name__)
-        _test_input = testutils.TestInput(self.sample_rate,self.sample_width,480)
+        _test_input = testutils.TestInput(
+            self.sample_rate,
+            self.sample_width,
+            (self.clip_duration / 1000) * self.sample_rate
+        )
         self.plugin = testutils.get_plugin_instance(
             webrtc_vad.WebRTCPlugin,
             _test_input
@@ -25,7 +27,9 @@ class TestWebRTCPlugin(unittest.TestCase):
         # This is just for comparison to see how VAD engines compare in
         # detecting audio. Skip if not in INFO logging level.
         if(self._logger.getEffectiveLevel() < logging.WARN):
-            with contextlib.closing(wave.open("naomi/data/audio/naomi.wav","rb")) as wf:
+            with contextlib.closing(
+                wave.open("naomi/data/audio/naomi.wav", "rb")
+            ) as wf:
                 assert wf.getnchannels() == 1
                 assert wf.getsampwidth() == 2
                 assert wf.getframerate() == 16000
@@ -33,7 +37,9 @@ class TestWebRTCPlugin(unittest.TestCase):
                 clip_detect = ""
                 offset = 0
                 while offset + self.clip_bytes < len(audio_data):
-                    result = self.plugin._voice_detected(audio_data[offset:offset + self.clip_bytes])
+                    result = self.plugin._voice_detected(
+                        audio_data[offset:offset + self.clip_bytes]
+                    )
                     clip_detect += "+" if result else "-"
                     offset += self.clip_bytes
                 self._logger.info(clip_detect)
@@ -47,13 +53,17 @@ class TestWebRTCPlugin(unittest.TestCase):
         # Get a sample of voice from a known sample
         # (naomi/data/audio/naomi.wav)
         # Voice data starts at .8 seconds
-        with contextlib.closing(wave.open("naomi/data/audio/naomi.wav","rb")) as wf:
+        with contextlib.closing(
+            wave.open("naomi/data/audio/naomi.wav", "rb")
+        ) as wf:
             assert wf.getnchannels() == 1
             assert wf.getsampwidth() == 2
             assert wf.getframerate() == 16000
             position = int(0.84 * wf.getframerate())
             wf.setpos(position)
-            clip = wf.readframes(int(((self.clip_duration / 1000) * self.sample_rate)))
+            clip = wf.readframes(
+                int(((self.clip_duration / 1000) * self.sample_rate))
+            )
         self.assertTrue(self.plugin._voice_detected(
             clip
         ))

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# This allows you to use the webrtcvad plugin.
+# You should be able to install it with a simple
+# pip install webrtcvad
+from naomi import plugin
+import webrtcvad
+
+
+class WebRTCPlugin(plugin.VADPlugin):
+    # Timeout in seconds
+    def __init__(self, input_device, timeout=1, minimum_capture=0.5):
+        super(WebRTCPlugin, self).__init__(
+            input_device,
+            timeout,
+            minimum_capture
+        )
+        self._vad = webrtcvad.Vad(1)
+        if(self._chunktime not in [0.01, 0.02, 0.03]):
+            # From the website:
+            #
+            # https://github.com/wiseman/py-webrtcvad
+            #
+            # The WebRTC VAD only accepts 16-bit mono PCM audio, sampled at
+            # 8000, 16000, 32000 or 48000 Hz. A frame must be either 10, 20,
+            # or 30 ms in duration:
+            raise ValueError(
+                "\n".join([
+                    "When using WebRTCVAD, chunks are limited to 10, 20,",
+                    "or 30 millisends in length.",
+                    "At current input rate of {}, the allowed chunk sizes are",
+                    "{} (10ms), {} (20ms) or {} (30 ms).",
+                    "Please adjust the value of",
+                    "audio: ",
+                    "  input_chunksize:",
+                    "in your ~/.naomi/profile.yml file."
+                ]).format(
+                    input_device._input_rate,
+                    input_device._input_rate * 0.01,
+                    input_device._input_rate * 0.02,
+                    input_device._input_rate * 0.03
+                )
+            )
+
+    def _voice_detected(self, frame):
+        if(self._vad.is_speech(frame, self._input_device._input_rate)):
+            response = True
+        else:
+            response = False
+        return response

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -2,6 +2,7 @@
 # This allows you to use the webrtcvad plugin.
 # You should be able to install it with a simple
 # pip install webrtcvad
+import logging
 from naomi import plugin
 from naomi import profile
 import webrtcvad
@@ -9,19 +10,21 @@ import webrtcvad
 
 class WebRTCPlugin(plugin.VADPlugin):
     # Timeout in seconds
-    def __init__(self, input_device, **kwargs):
+    def __init__(self, *args, **kwargs):
+        self._logger = logging.getLogger(__name__)
+        input_device = args[0]
         timeout = profile.get_profile_var(kwargs, ["timeout"], 1)
         minimum_capture = profile.get_profile_var(kwargs, ["minimum_capture"], 0.25)
         aggressiveness = profile.get_profile_var(kwargs, ["aggressiveness"], 1)
-        print("timeout: {}".format(timeout))
-        print("minimum_capture: {}".format(minimum_capture))
-        print("aggressiveness: {}".format(aggressiveness))
+        self._logger.info("timeout: {}".format(timeout))
+        self._logger.info("minimum_capture: {}".format(minimum_capture))
+        self._logger.info("aggressiveness: {}".format(aggressiveness))
         super(WebRTCPlugin, self).__init__(
             input_device,
             timeout,
             minimum_capture
         )
-        if aggressiveness not in [2, 3]:
+        if aggressiveness not in [0, 2, 3]:
             aggressiveness = 1
         self._vad = webrtcvad.Vad(aggressiveness)
         if(self._chunktime not in [0.01, 0.02, 0.03]):

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -3,18 +3,27 @@
 # You should be able to install it with a simple
 # pip install webrtcvad
 from naomi import plugin
+from naomi import profile
 import webrtcvad
 
 
 class WebRTCPlugin(plugin.VADPlugin):
     # Timeout in seconds
-    def __init__(self, input_device, timeout=1, minimum_capture=0.5):
+    def __init__(self, input_device, **kwargs):
+        timeout = profile.get_profile_var(kwargs, ["timeout"], 1)
+        minimum_capture = profile.get_profile_var(kwargs, ["minimum_capture"], 0.25)
+        aggressiveness = profile.get_profile_var(kwargs, ["aggressiveness"], 1)
+        print("timeout: {}".format(timeout))
+        print("minimum_capture: {}".format(minimum_capture))
+        print("aggressiveness: {}".format(aggressiveness))
         super(WebRTCPlugin, self).__init__(
             input_device,
             timeout,
             minimum_capture
         )
-        self._vad = webrtcvad.Vad(1)
+        if aggressiveness not in [2, 3]:
+            aggressiveness = 1
+        self._vad = webrtcvad.Vad(aggressiveness)
         if(self._chunktime not in [0.01, 0.02, 0.03]):
             # From the website:
             #

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -14,7 +14,11 @@ class WebRTCPlugin(plugin.VADPlugin):
         self._logger = logging.getLogger(__name__)
         input_device = args[0]
         timeout = profile.get_profile_var(kwargs, ["timeout"], 1)
-        minimum_capture = profile.get_profile_var(kwargs, ["minimum_capture"], 0.25)
+        minimum_capture = profile.get_profile_var(
+            kwargs,
+            ["minimum_capture"],
+            0.25
+        )
         aggressiveness = profile.get_profile_var(kwargs, ["aggressiveness"], 1)
         self._logger.info("timeout: {}".format(timeout))
         self._logger.info("minimum_capture: {}".format(minimum_capture))


### PR DESCRIPTION
## Description
VAD Plugin

naomi/application.py
--------------------
Attached input device parameters (input_samplerate, input_samplewidth, input_channels, input_chunksize) to the input_device object so they are all available to the mic and vad objects as the input_device object is passed around.

For consistency, also moved the output_chunksize and output_padding parameters to the output_device object.

Added initialization of Voice Activity Detection object and passed it to the initialization of the mic object.

naomi/mic.py
------------
Removed the main logic around listen and active listen so I could move it into the VADPlugin class. This should make it easier to implement the "Passive Listen for Commands" project, because once
the passive listener identifies a keyword in the audio returned, we can just pass the same block of audio to the active listener for transcription. Simplified a lot of stuff. The original authors
were running two threads constantly scanning the audio input for keywords, and it appears that the only reason was to speed up keyword detection. The new VAD method works much differently, but
I'm interested in hearing whether anyone notices a difference.

naomi/plugin.py
---------------
Added skeleton for VADPlugin class

naomi/pluginstore.py
--------------------
Added the VADPlugin as a new plugin class

naomi/testutils.py
----------------------
Added a test audio_device class for my VAD tests

plugins/vad
-----------
Added two new plugins, snr_vad and webrtc_vad.

plugins/vad/snr_vad
-------------------
This is based on the way voice activity currently works with naomi, which is basically just waiting for audio levels to go above a certain threshold and below a certain threshold.

I have always had trouble with this method, as different sound cards and different microphones register sound quite differently, so choosing a proper threshold level is often problematic.

I am now saying that anything over the mean plus one and a half times the standard deviation should be considered audio to pay attention to. I also reset every 100 samples by cutting all the
counts in half, thus ensuring that we aren't counting to ridiculous numbers over time and allowing noise levels to adjust fairly quickly to changes in the environment.

plugins/webrtc_vad
------------------
Uses the webrtcvad module, which can be installed via pip. This module requires that all chunks be 10, 20, or 30 ms. The default chunk size for Naomi is 64 ms, so you have to adjust the value of
```
audio:
  input_chunksize:
```
to either 160 (10ms), 320 (20ms), or 480 (30ms) in profile.yml, assuming a rate of 16000 samples/sec.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[VAD plugin #144](https://github.com/NaomiProject/Naomi/issues/144)
[[Feature-Request] - Passive Listening for commands #48](https://github.com/NaomiProject/Naomi/issues/48)
[Automate STT training #103](https://github.com/NaomiProject/Naomi/issues/103)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows us to quickly and easily write and test Voice Activity Detection plugins without having to modify the main structure of Naomi. It also simplifies some handling of audio which should make some other projects simpler. And all of this should allow us to improve overall speech capture for building catalogs of data samples for training the STT engines.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested both plugins on both my x86 Raspbian Stretch VirtualBox machine and my Raspberry Pi 3B+.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (In fact, I fixed a bunch of flake8 complaints)
- [X] My change requires a change to the documentation. (Need to explain the new plugin type)
- [X] I have updated the documentation accordingly. ([Added VAD Plugin documentation #4](https://github.com/NaomiProject/naomi-docs/pull/4))
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed. (or at least didn't get worse)
