### PR TITLE
Naomi salutation

### DIFF
--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -21,16 +21,18 @@ class Conversation(i18n.GettextMixin):
     # Add way for the system to ask for name if is not found in the config
     def askName(self):
         if 'keyword' in self.profile:
-            salutation = (self.gettext("My name is, %s.")
-                          % self.profile['keyword'])
+            salutation = self.gettext("My name is {}.").config(
+                self.profile['keyword']
+            )
         else:
             salutation = self.gettext("My name is Naomi")
         self.mic.say(salutation)
 
     def greet(self):
         if 'first_name' in self.profile:
-            salutation = (self.gettext("How can I be of service, %s?")
-                          % self.profile["first_name"])
+            salutation = self.gettext("How can I be of service, {}?").config(
+                self.profile["first_name"]
+            )
         else:
             salutation = self.gettext("How can I be of service?")
         self.mic.say(salutation)
@@ -62,8 +64,14 @@ class Conversation(i18n.GettextMixin):
                             "operation. Please try again later.")
                         )
                     else:
-                        self._logger.debug("Handling of phrase '%s' by " +
-                                           "module '%s' completed", text,
-                                           plugin.info.name)
+                        self._logger.debug(
+                            " ".join([
+                                "Handling of phrase '{}'",
+                                "by module '{}' completed"
+                            ]).config(
+                                text,
+                                plugin.info.name
+                            )
+                        )
             else:
                 self.mic.say(self.gettext("Pardon?"))

--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -21,7 +21,7 @@ class Conversation(i18n.GettextMixin):
     # Add way for the system to ask for name if is not found in the config
     def askName(self):
         if 'keyword' in self.profile:
-            salutation = self.gettext("My name is {}.").config(
+            salutation = self.gettext("My name is {}.").format(
                 self.profile['keyword']
             )
         else:
@@ -30,7 +30,7 @@ class Conversation(i18n.GettextMixin):
 
     def greet(self):
         if 'first_name' in self.profile:
-            salutation = self.gettext("How can I be of service, {}?").config(
+            salutation = self.gettext("How can I be of service, {}?").format(
                 self.profile["first_name"]
             )
         else:
@@ -68,7 +68,7 @@ class Conversation(i18n.GettextMixin):
                             " ".join([
                                 "Handling of phrase '{}'",
                                 "by module '{}' completed"
-                            ]).config(
+                            ]).format(
                                 text,
                                 plugin.info.name
                             )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This just removes the comma before the keyword when Naomi introduces itself. This eliminates the dramatic pause before Naomi says the primary keyword. It also reformats a couple of things to make flake8 happy and use python3 styles.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Remove comma from introduction #164](https://github.com/NaomiProject/Naomi/issues/164)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It just bothers me that Naomi pauses before stating the wakeword. This does not happen if you have not defined a wakeword, so it defaults to "Naomi"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested on a Raspberry Pi 3B+ running the latest version of Raspbian Stretch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed (or at least did not get worse).
