### PR TITLE
Naobian Prep & Organization

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -72,14 +72,14 @@ class Naomi(object):
         # For backwards compatibility, move old profile.yml to newly
         # created config dir
         old_configfile = paths.sub('profile.yml')
-        new_configfile = os.path.join('configs','profile.yml')
+        new_configfile = paths.sub(os.path.join('configs','profile.yml'))
         if os.path.exists(old_configfile):
             if os.path.exists(new_configfile):
                 self._logger.warning(
                     " ".join([
                         "Deprecated profile file found: '{:s}'. ",
                         "Please remove it."
-                    ]).sub(old_configfile)
+                    ]).format(old_configfile)
                 )
             else:
                 self._logger.warning(
@@ -98,7 +98,7 @@ class Naomi(object):
                         " ".join([
                             "Unable to move config file.",
                             "Please move it manually.",
-                            "~/.naomi/profile.yml -> ~/.naomi/configs/profile.yml"
+                            “{} → {}”.format(old_configfile,new_configfile)
                         ]),
                         exc_info=True
                     )

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -70,7 +70,6 @@ class Naomi(object):
                     paths.CONFIG_PATH
                 )
             )
-        
         # For backwards compatibility, move old profile.yml to newly
         # created config dir
         old_configfile = paths.sub('profile.yml')

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -52,8 +52,8 @@ class Naomi(object):
             )
         # For backwards compatibility, move old config file to newly
         # created config dir
-        old_configfile = os.path.join(paths.PKG_PATH, 'profile.yml')
-        new_configfile = paths.config('profile.yml')
+        old_configfile = paths.config('profile.yml')
+        new_configfile = paths.config('configs/profile.yml')
         if os.path.exists(old_configfile):
             if os.path.exists(new_configfile):
                 self._logger.warning(
@@ -66,19 +66,20 @@ class Naomi(object):
                 self._logger.warning(
                     " ".join([
                         "Deprecated profile file found: '{:s}'.",
-                        "Trying to copy it to new location '{:s}'."
+                        "Trying to move it to new location '{:s}'."
                     ]).format(
                         old_configfile,
                         new_configfile
                     )
                 )
                 try:
-                    shutil.copy2(old_configfile, new_configfile)
+                    shutil.move(old_configfile, new_configfile)
                 except shutil.Error:
                     self._logger.error(
                         " ".join([
-                            "Unable to copy config file.",
-                            "Please copy it manually."
+                            "Unable to move config file.",
+                            "Please move it manually.",
+                            "~/.naomi/profile.yml -> ~/.naomi/configs/profile.yml"
                         ]),
                         exc_info=True
                     )

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -50,7 +50,6 @@ class Naomi(object):
                     paths.SUB_PATH
                 )
             )
-        
         # Create .naomi/configs dir if it does not exist yet
         if not os.path.exists(paths.CONFIG_PATH):
             try:

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -98,7 +98,7 @@ class Naomi(object):
                         " ".join([
                             "Unable to move config file.",
                             "Please move it manually.",
-                            “{} → {}”.format(old_configfile,new_configfile)
+                            "“{} → {}”".format(old_configfile,new_configfile)
                         ]),
                         exc_info=True
                     )

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -31,36 +31,57 @@ class Naomi(object):
         print_transcript=False
     ):
         self._logger = logging.getLogger(__name__)
-        # Create config dir if it does not exist yet
+        # Create .naomi dir if it does not exist yet
+        if not os.path.exists(paths.SUB_PATH):
+            try:
+                os.makedirs(paths.SUB_PATH)
+            except OSError:
+                self._logger.error("Could not create .naomi dir: '%s'",
+                                   paths.SUB_PATH, exc_info=True)
+                raise
+
+        # Check if .naomi dir is writable
+        if not os.access(paths.SUB_PATH, os.W_OK):
+            self._logger.critical(
+                " ".join([
+                    ".naomi dir {:s} is not writable. Naomi",
+                    "won't work correctly."
+                ]).format(
+                    paths.SUB_PATH
+                )
+            )
+        
+        # Create .naomi/configs dir if it does not exist yet
         if not os.path.exists(paths.CONFIG_PATH):
             try:
                 os.makedirs(paths.CONFIG_PATH)
             except OSError:
-                self._logger.error("Could not create config dir: '%s'",
+                self._logger.error("Could not create .naomi/configs dir: '%s'",
                                    paths.CONFIG_PATH, exc_info=True)
                 raise
 
-        # Check if config dir is writable
+        # Check if .naomi/configs dir is writable
         if not os.access(paths.CONFIG_PATH, os.W_OK):
             self._logger.critical(
                 " ".join([
-                    "Config dir {:s} is not writable. Naomi",
+                    ".naomi/configs dir {:s} is not writable. Naomi",
                     "won't work correctly."
                 ]).format(
                     paths.CONFIG_PATH
                 )
             )
-        # For backwards compatibility, move old config file to newly
+        
+        # For backwards compatibility, move old profile.yml to newly
         # created config dir
-        old_configfile = paths.config('profile.yml')
-        new_configfile = paths.config('configs/profile.yml')
+        old_configfile = paths.sub('profile.yml')
+        new_configfile = os.path.join('configs','profile.yml')
         if os.path.exists(old_configfile):
             if os.path.exists(new_configfile):
                 self._logger.warning(
                     " ".join([
                         "Deprecated profile file found: '{:s}'. ",
                         "Please remove it."
-                    ]).config(old_configfile)
+                    ]).sub(old_configfile)
                 )
             else:
                 self._logger.warning(

--- a/naomi/paths.py
+++ b/naomi/paths.py
@@ -7,12 +7,15 @@ PKG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 DATA_PATH = os.path.join(PKG_PATH, "data")
 PLUGIN_PATH = os.path.normpath(os.path.join(PKG_PATH, os.pardir, "plugins"))
 
-CONFIG_PATH = os.path.expanduser(os.getenv('NAOMI_CONFIG', '~/.naomi'))
+SUB_PATH = os.path.expanduser(os.getenv('NAOMI_SUB', '~/.naomi'))
+CONFIG_PATH = os.path.expanduser(os.getenv('NAOMI_CONFIG', '~/.naomi/configs'))
 
 
 def config(*fname):
     return os.path.join(CONFIG_PATH, *fname)
 
+def sub(*fname):
+    return os.path.join(SUB_PATH, *fname)
 
 def data(*fname):
     return os.path.join(DATA_PATH, *fname)

--- a/naomi/paths.py
+++ b/naomi/paths.py
@@ -7,8 +7,8 @@ PKG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 DATA_PATH = os.path.join(PKG_PATH, "data")
 PLUGIN_PATH = os.path.normpath(os.path.join(PKG_PATH, os.pardir, "plugins"))
 
-SUB_PATH = os.path.expanduser(os.getenv('NAOMI_SUB', '~/.naomi'))
-CONFIG_PATH = os.path.expanduser(os.getenv('NAOMI_CONFIG', '~/.naomi/configs'))
+SUB_PATH = os.path.expanduser(os.getenv(‘NAOMI_SUB’,os.getenv(‘JASPER_CONFIG’,”~/.naomi”)))
+CONFIG_PATH = os.path.join(SUB_PATH, 'configs')
 
 
 def config(*fname):

--- a/naomi/paths.py
+++ b/naomi/paths.py
@@ -7,7 +7,7 @@ PKG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 DATA_PATH = os.path.join(PKG_PATH, "data")
 PLUGIN_PATH = os.path.normpath(os.path.join(PKG_PATH, os.pardir, "plugins"))
 
-SUB_PATH = os.path.expanduser(os.getenv(‘NAOMI_SUB’,os.getenv(‘JASPER_CONFIG’,”~/.naomi”)))
+SUB_PATH = os.path.expanduser(os.getenv('NAOMI_SUB', os.getenv('JASPER_CONFIG', '~/.naomi')))
 CONFIG_PATH = os.path.join(SUB_PATH, 'configs')
 
 

--- a/naomi/paths.py
+++ b/naomi/paths.py
@@ -7,7 +7,7 @@ PKG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 DATA_PATH = os.path.join(PKG_PATH, "data")
 PLUGIN_PATH = os.path.normpath(os.path.join(PKG_PATH, os.pardir, "plugins"))
 
-CONFIG_PATH = os.path.expanduser(os.getenv('JASPER_CONFIG', '~/.naomi'))
+CONFIG_PATH = os.path.expanduser(os.getenv('NAOMI_CONFIG', '~/.naomi/configs'))
 
 
 def config(*fname):

--- a/naomi/paths.py
+++ b/naomi/paths.py
@@ -7,7 +7,7 @@ PKG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 DATA_PATH = os.path.join(PKG_PATH, "data")
 PLUGIN_PATH = os.path.normpath(os.path.join(PKG_PATH, os.pardir, "plugins"))
 
-CONFIG_PATH = os.path.expanduser(os.getenv('NAOMI_CONFIG', '~/.naomi/configs'))
+CONFIG_PATH = os.path.expanduser(os.getenv('NAOMI_CONFIG', '~/.naomi'))
 
 
 def config(*fname):

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -77,7 +77,7 @@ class STTPlugin(GenericPlugin):
 
         vocabulary = vocabcompiler.VocabularyCompiler(
             self.info.name, self._vocabulary_name,
-            path=paths.config('vocabularies', language))
+            path=paths.sub('vocabularies', language))
 
         if not vocabulary.matches_phrases(self._vocabulary_phrases):
             vocabulary.compile(

--- a/naomi/vocabcompiler.py
+++ b/naomi/vocabcompiler.py
@@ -98,7 +98,7 @@ class VocabularyCompiler(object):
         """
         return (self.compiled_revision == phrases_to_revision(phrases))
 
-    def compile(self, config, compilation_func, phrases, force=False):
+    def compile(self, sub, compilation_func, phrases, force=False):
         """
         Compiles this vocabulary. If the force argument is True, compilation
         will be forced regardless of necessity (which means that the
@@ -138,7 +138,7 @@ class VocabularyCompiler(object):
         else:
             self._logger.info('Starting compilation...')
             try:
-                compilation_func(config, self.path, phrases)
+                compilation_func(sub, self.path, phrases)
             except Exception as e:
                 msg = "Fatal compilation error occured"
                 if hasattr(e, 'message') and len(e.message) > 0:

--- a/naomi/vocabcompiler.py
+++ b/naomi/vocabcompiler.py
@@ -98,7 +98,7 @@ class VocabularyCompiler(object):
         """
         return (self.compiled_revision == phrases_to_revision(phrases))
 
-    def compile(self, sub, compilation_func, phrases, force=False):
+    def compile(self, config, compilation_func, phrases, force=False):
         """
         Compiles this vocabulary. If the force argument is True, compilation
         will be forced regardless of necessity (which means that the
@@ -138,7 +138,7 @@ class VocabularyCompiler(object):
         else:
             self._logger.info('Starting compilation...')
             try:
-                compilation_func(sub, self.path, phrases)
+                compilation_func(config, self.path, phrases)
             except Exception as e:
                 msg = "Fatal compilation error occured"
                 if hasattr(e, 'message') and len(e.message) > 0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adjusted the naming of "JASPER_CONFIG" to "NAOMI_CONFIG" as well as moved the config path one dir further from just ~/.naomi/ to ~/.naomi/configs/

>NOTE: This change effects the location of the profile.yml thus breaking naomi if you update but do not move your profile.yml to the new location. Populate can be rerun to place a new profile.yml in the correct location if one does not want to move their configs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Jasper to Naomi change is not required but preferred for continuity. The config path adjustment is to help organize the Naomi sub dir. Naomi does not directly use the sub dir much unless it is setup to have a virtual or local environments in which a python dir is placed in it. With the coming soon addition of the Naobian img, there are dedicated scripts & configs that need to be stored properly, thus the sub dir needs to be organized.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through countless testing while developing Naobian.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
