### PR TITLE
Passive Listen

### DIFF
--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -9,6 +9,7 @@ from . import alteration
 from . import paths
 from . import profile
 
+
 class Mic(object):
     """
     The Mic class handles all interactions with the microphone and speaker.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This allows the user to set an "passive_listen" value in profile.yml
to True (or "Yes") in order to change Naomi's listening behavior.

Normally, you speak Naomi's keyphrase, Naomi responds with a high
beep noise, then you speak your query, Naomi response with a low
beep noise, then processes the request.

Using passive listen, Naomi listens for your voice, then scans the
entire block of audio for the keyword. If it detects the keyword,
it passes the audio to the active listener, then finally returns
the transcription.

This pull request also fixes the issue that at some point the low
beep got replaced with the high beep. I think it was when I was
working on the Voice Activity Detector plugin.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue #48 - Passive Listening for commands](https://github.com/NaomiProject/Naomi/issues/48)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows the user to interact with Naomi more naturally, by directly asking questions, rather than stating the wakeword, waiting for Naomi to answer, then stating the question.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Raspberry Pi 3B+ running Raspbian Stretch using Pocketsphinx for both passive and active listening, WebRTC VAD for voice activity detection, and Flite SLT for text to speech.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
