### PR TITLE
Hotfix for passive listen

### DIFF
--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -115,9 +115,11 @@ class Mic(object):
                             keyword.lower() in t.lower()
                             for t in transcribed if t
                         ]):
+                            self._logger.debug("Passive listen: {}".format(profile.get_profile_flag(["passive_listen"])))
                             if(profile.get_profile_flag(["passive_listen"])):
                                 # Take the same block of audio and put it
                                 # through the active listener
+                                f.seek(0)
                                 try:
                                     transcribed = self.active_stt_engine.transcribe(f)
                                 except Exception:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When testing today I discovered that using the google stt plugin
no audio was being transcribed due to the fact that that plugin
does not seek a location in the passed file handle, which the
pocketsphinx and deepspeech plugins I tested against before do.
Since it is not a requirement that stt plugins set the file
location, and it is reasonable to assume that the file handle is
currently pointed to the beginning of the file, it seemed
reasonable to fix this in the naomi/mic.py module.

This patch just sets the file pointer back to the beginning of
the file before calling active_stt_engine.transcribe() on the
active file handle when using passive_listen mode.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue #48 - Passive Listening for commands](https://github.com/NaomiProject/Naomi/issues/48)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In passive listen mode, the passive listener is used to check the audio for the keyword. If the keyword is found, then the same block of audio is passed directly to the active listener. The active listener might, rightly, assume that the file handle should be pointed to the beginning of a file that was just opened. When the file handle is still set to the end of the file, then it appears to the plugin as if the file itself is empty, resulting in an empty transcription.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using pocketsphinx for passive listening and google stt plugin for active listening.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
