### PR TITLE
Updated run_command

### DIFF
--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -14,7 +14,7 @@ try:
     from . import profile
     import pytz
     import re
-    from . import run_command
+    from .run_command import run_command
     import tempfile
     import wave
     from . import i18n
@@ -531,7 +531,10 @@ def get_timezone():
     tz = profile.get_profile_var(["timezone"])
     if not tz:
         try:
-            tz = run_command.run_command(["/bin/cat", "/etc/timezone"])
+            tz = run_command(
+                ["/bin/cat", "/etc/timezone"],
+                capture=1
+            ).stdout.decode('utf-8').strip()
         except OSError:
             tz = None
     tz = interface.simple_input(
@@ -1049,7 +1052,7 @@ def get_tts_engine():
                 )
             ]
         except (KeyError, ValueError):
-            response = "Festival"
+            response = "Flite"
         print(
             "    " + interface.instruction_text(
                 _("Please select a text to speech (TTS) engine.")

--- a/naomi/run_command.py
+++ b/naomi/run_command.py
@@ -1,8 +1,45 @@
 # -*- coding: utf-8 -*-
 import subprocess
 
-def run_command(command):
-    return subprocess.run(
-        command,
-        stdout=subprocess.PIPE
-    ).stdout.decode('utf-8').strip()
+
+# This program is just so we can avoid calling subprocess directly, which
+# always causes Codacy to flag the pull request. 
+# The first parameter is an array containing a command, flags and arguments.
+# The second, optional parameter determines how the output of the command is
+# handled:
+#  0 (default) - don't capture output
+#  1 - only capture stdout
+#  2 - only capture stderr
+#  3 - pipe stdout into stderr and capture stdout
+# The response is the raw CompletedProcess instance, containing the command,
+# returncode, stdout and stderr properties and the check_returncode() method
+# The subprocess.run command takes a wide variety of arguments, so I
+# considered just making this a wrapper around the run() method, but since
+# the different capture methods require referencing attributes of the
+# subprocess module anyway, I decided to try simplifying it to these four
+# use cases. This module is currently only used in populate.py (for capturing
+# the system timezone) but I will need to use it a lot in my STT model
+# training plugins.
+def run_command(command, capture=0):
+    completedprocess = None
+    if(capture == 1):
+        completedprocess = subprocess.run(
+            command,
+            stdout=subprocess.PIPE
+        )
+    elif(capture == 2):
+        completedprocess = subprocess.run(
+            command,
+            stderr=subprocess.PIPE
+        )
+    elif(capture == 3):
+        completedprocess = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT
+        )
+    else:
+        completedprocess = subprocess.run(
+            command
+        )
+    return completedprocess

--- a/naomi/run_command.py
+++ b/naomi/run_command.py
@@ -3,7 +3,7 @@ import subprocess
 
 
 # This program is just so we can avoid calling subprocess directly, which
-# always causes Codacy to flag the pull request. 
+# always causes Codacy to flag the pull request.
 # The first parameter is an array containing a command, flags and arguments.
 # The second, optional parameter determines how the output of the command is
 # handled:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated run_command so that you can specify which output streams
you would like to capture. This is currently only used for getting
the list of voices available to Flite in populate.py, but I am
using it a lot in my Speech to Text training stuff.

Another small change is changing the default Text to Speech engine to Flite.

Codacy will not validate this pull request. That is by design so that hopefully we can continue to use subprocess to interact with external commands on the server without constantly being flagged. It should also provide a nice central function to update if someone can ever tell us what the correct solution is.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#103 Automate Speech to Text training](https://github.com/NaomiProject/Naomi/issues/103)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The run_command() function was created as a way to avoid pulling subprocess into packages because Codacy hates it but doesn't have any good suggestions about how to avoid using it. The original version of this took a command broken down into a list containing the command, flags, and arguments and returned the STDOUT output. It turns out that there are times when I want to capture STDOUT, STDERR, both or neither depending on the circumstance.

This new version takes the command and an optional "capture" parameter and returns a completedprocess object.

capture can have the following values:
    0) (default) don't capture any output
    1) capture STDOUT
    2) capture STDERR
    3) capture both STDOUT and STDERR as STDOUT.
completedprocess has the following structure:
```
(
    args = [<the original command>],
    returncode = <the returncode from the command, 0=SUCCESS>,
    [stdout = b'<the STDOUT output of the command>',]
    [stderr = b'<the STDERR output of the command>']
)
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Raspbian x86 in a Virtualbox VM

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
