### PR TITLE
NaomiSTTTrainer

### DIFF
--- a/NaomiSTTTrainer.py
+++ b/NaomiSTTTrainer.py
@@ -842,7 +842,6 @@ if __name__ == '__main__':
     p_args = parser.parse_args()
     if p_args.debug:
         Debug = True
-        profile.set_arg
         print("Setting logging level to DEBUG")
         logging.basicConfig(
             level=logging.DEBUG

--- a/NaomiSTTTrainer.py
+++ b/NaomiSTTTrainer.py
@@ -1,0 +1,869 @@
+#!/usr/bin/env python3
+
+# This version of NaomiSTTTrainer allows the user to step through one sample
+# at a time, instead of returning a table full of samples.
+# My assumption is that for the most part, you only need to validate the record
+# once, after that it should automatically skip all the records that have
+# already been verified.
+
+# -*- coding: utf-8 -*-
+import argparse
+import json
+import logging
+import os
+import pkg_resources
+import re
+import socket
+import sqlite3
+import webbrowser
+import wsgiref.simple_server
+from datetime import datetime
+from jiwer import wer
+from naomi import paths
+from naomi import profile
+from naomi import pluginstore
+from socketserver import ThreadingMixIn
+from threading import Thread
+from urllib.parse import unquote
+
+
+# Set Debug to True to see debugging information
+Debug = False
+_logger = logging.getLogger(__name__)
+
+
+def Get_row(c, rowID):
+    c.execute(
+        " ".join([
+            "select",
+            " datetime,",
+            " filename,",
+            " type,",
+            " transcription,",
+            " verified_transcription,",
+            " speaker,",
+            " reviewed,",
+            " wer",
+            "from audiolog where rowid=:RowID"
+        ]),
+        ({"RowID": rowID})
+    )
+    row = c.fetchone()
+    if(row is None):
+        Record = None
+    else:
+        if(Debug):
+            print("Recorded Type=%s" % type(row[0]))
+            print("Filename Type=%s" % type(row[1]))
+            print("Type Type=%s" % type(row[2]))
+            print("Transcription Type=%s" % type(row[3]))
+            print("Verified_transcription Type=%s" % type(row[4]))
+            print("Speaker Type=%s" % type(row[5]))
+            print("Reviewed Type=%s" % type(row[6]))
+            print("WER Type=%s" % type(row[7]))
+        Record = {
+            "Recorded": str(row[0]),
+            "Filename": str(row[1]),
+            "Type": str(row[2]),
+            "Transcription": str(row[3]),
+            "Verified_transcription": str(row[4]),
+            "Speaker": str(row[5]),
+            "Reviewed": str(row[6]),
+            "WER": str(row[7])
+        }
+    return Record
+
+
+def verify_row_id(c, rowID):
+    Ret = True
+    c.execute("select RowID from audiolog where RowID=:RowID", {"RowID": rowID})
+    row = c.fetchone()
+    if(row is None):
+        Ret = False
+    return Ret
+
+
+def fetch_first_rowID(c):
+    c.execute("select RowID from audiolog order by RowID asc limit 1")
+    row = c.fetchone()
+    if(row is None):
+        rowID = None
+    else:
+        rowID = str(row[0])
+    return rowID
+
+
+def fetch_first_unreviewed_rowID(c):
+    return fetch_next_unreviewed_rowID(c, "0")
+
+
+def fetch_prev_rowID(c, rowID):
+    # get the previous rowid
+    c.execute(
+        " ".join([
+            "select",
+            " RowID",
+            "from audiolog",
+            "where RowID<:RowID",
+            "order by RowID desc",
+            "limit 1"
+        ]),
+        {"RowID": rowID}
+    )
+    row = c.fetchone()
+    if(row is None):
+        prev_rowID = None
+    else:
+        prev_rowID = str(row[0])
+    return prev_rowID
+
+
+def fetch_current_rowID(c, rowID):
+    if(rowID):
+        c.execute(
+            "select RowID from audiolog where RowID=:RowID",
+            {"RowID": rowID}
+        )
+        row = c.fetchone()
+        if(row is None):
+            raise ValueError("RowID %s not found" % rowID)
+        else:
+            rowID = str(row[0])
+    else:
+        rowID = fetch_first_unreviewed_rowID(c)
+    if(not rowID):
+        # if there are no unreviewed row ID's, set to the last rowid
+        rowID = fetch_last_rowID(c)
+    return rowID
+
+
+def fetch_next_rowID(c, rowID):
+    # get the previous rowid
+    print("rowID={}".format(rowID))
+    c.execute(
+        " ".join([
+            "select",
+            " RowID",
+            "from audiolog",
+            "where RowID>:RowID",
+            "order by RowID asc",
+            "limit 1"
+        ]),
+        {
+            "RowID": rowID
+        }
+    )
+    row = c.fetchone()
+    if(row is None):
+        next_rowID = None
+    else:
+        next_rowID = str(row[0])
+    return next_rowID
+
+
+def fetch_next_unreviewed_rowID(c, rowID):
+    c.execute(
+        " ".join([
+            "select",
+            " RowID",
+            "from audiolog",
+            "where RowID>:RowID and reviewed=''",
+            "order by RowID asc",
+            "limit 1"
+        ]),
+        {"RowID": rowID}
+    )
+    row = c.fetchone()
+    if(row is None):
+        next_rowID = None
+    else:
+        next_rowID = str(row[0])
+    return next_rowID
+
+
+def fetch_last_rowID(c):
+    c.execute("select RowID from audiolog order by RowID desc limit 1")
+    row = c.fetchone()
+    if(row is None):
+        rowID = None
+    else:
+        rowID = str(row[0])
+    return rowID
+
+
+# Replaces any punctuation characters with spaces and converts to upper case
+def clean_transcription(transcription):
+    print("transcription type={}".format(type(transcription)))
+    return transcription.translate(
+        dict((ord(char), None) for char in """][}{!@#$%^&*)(,."'></?\\|=+-_""")
+    ).upper()
+
+
+def application(environ, start_response):
+    keyword = profile.get_profile_var(["keyword"], "Naomi")
+    print("PATH_INFO=%s" % environ["PATH_INFO"])
+    if(environ["PATH_INFO"] == "/favicon.ico"):
+        start_response(
+            '404 Not Found',
+            [('content-type', 'text/plain;charset=utf-8')]
+        )
+        ret = ["404 Not Found".encode("UTF-8")]
+        return ret
+    else:
+        audiolog_dir = paths.sub("audiolog")
+        audiolog_db = os.path.join(audiolog_dir, "audiolog.db")
+        wavfile = ""
+        rowID = ""
+        first_rowID = ""
+        prev_rowID = ""
+        next_rowID = ""
+        result = ""
+        verified_transcription = ""
+        post_data = ""
+        engine = ""
+        description = []
+        reQS = re.compile("([^=]+)=([^&]*)&?")
+
+        # gather parameters from GET
+        if(environ["QUERY_STRING"]):
+            for namevalue in reQS.findall(environ["QUERY_STRING"]):
+                if(namevalue[0].lower() == "wavfile"):
+                    wavfile = os.path.join(audiolog_dir, namevalue[1])
+                if(namevalue[0].lower() == "rowid"):
+                    rowID = namevalue[1]
+
+        # gather parameters from POST
+        content_length = 0
+        if(environ['CONTENT_LENGTH']):
+            content_length = int(environ['CONTENT_LENGTH'])
+            post_data = environ['wsgi.input'].read(
+                content_length
+            ).decode("UTF-8")
+            # Parse it out
+            for namevalue in reQS.findall(post_data):
+                if(namevalue[0].lower() == "rowid"):
+                    rowID = namevalue[1].lower()
+                if(namevalue[0].lower() == "result"):
+                    result = namevalue[1].lower()
+                if(namevalue[0].lower() == "verified_transcription"):
+                    verified_transcription = unquote(
+                        namevalue[1].replace('+', ' ')
+                    )
+                if(namevalue[0].lower() == "engine"):
+                    engine = namevalue[1]
+                if(namevalue[0].lower() == "command"):
+                    command = namevalue[1].lower()
+                if(namevalue[0].lower() == "description"):
+                    description.append(namevalue[1])
+
+        # Handle the request
+        # serve a .wav file
+        ErrorMessage = None
+        if(len(wavfile) and os.path.isfile(wavfile)):
+            start_response('200 OK', [('content-type', 'audio/wav')])
+            with open(wavfile, "rb") as w:
+                ret = [w.read()]
+            return ret
+        # open a connection to the database
+        conn = sqlite3.connect(audiolog_db)
+        c = conn.cursor()
+        # Start the html response
+        ret = []
+        # serve a train response. We will put this in a div on the Train
+        # tab, so we don't have to regenerate everything.
+        if(len(engine)):
+            start_response(
+                '200 OK',
+                [('content-type', 'text/json;charset=utf-8')]
+            )
+            continue_next = True
+            nextcommand = ""
+            response = []
+            found_plugin = False
+            for info in plugins.get_plugins_by_category('stt_trainer'):
+                if(info.name == engine):
+                    found_plugin = True
+                    try:
+                        plugin = info.plugin_class(info, profile.get_profile())
+                        print("plugin.HandleCommand({}, {})".format(command, description))
+                        response, nextcommand, description = plugin.HandleCommand(command, description)
+                    except Exception as e:
+                        _logger.warn(
+                            "Plugin '{}' skipped! (Reason: {})".format(
+                                info.name,
+                                e.message if hasattr(e, 'message') else 'Unknown'
+                            ),
+                            exc_info=True
+                        )
+            if(not found_plugin):
+                response = ["Unknown STT Trainer: {}".format(engine)]
+            # Prepare the json response
+            messagetext = "<br /><br />\n".join(response)
+            if(not continue_next):
+                nextcommand = ""
+            jsonstr = json.dumps({
+                'message': messagetext,
+                'engine': engine,
+                'command': nextcommand,
+                'description': description
+            })
+            ret.append(jsonstr.encode("UTF-8"))
+        else:
+            start_response(
+                '200 OK',
+                [('content-type', 'text/html;charset=utf-8')]
+            )
+            ret.append(
+                '<html><head><title>{} STT Training</title>'.format(
+                    keyword
+                ).encode("utf-8")
+            )
+            # Return the main page
+            try:
+                # If we are performing an update,
+                # do so and fetch the next row id
+                if(result and rowID):
+                    print("Result: {}".format(result))
+                    # rowid should have been passed in
+                    # if the rowid that was passed in does not exist,
+                    # the following lines will have no effect
+                    # FIXME: in this case, an error should be returned.
+                    Update_record = Get_row(c, rowID)
+                    now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+                    if(Update_record):
+                        # Since an audio file can be associated with more
+                        # than one transcription (since both a passive and
+                        # active transcription can be run on the same audio
+                        # file) we need to update each record with the same
+                        # transcription with its own WER.
+                        # Get a list of records that have the same filename
+                        result = result.lower()
+                        if(result == "correct"):
+                            # if the current result matches the transcription,
+                            # then verified transcription = transcription
+                            # and the type should remain unchanged
+                            verified_transcription = Update_record['Transcription']
+                        if(result == "noise"):
+                            # If the user selected "noise" then the verified
+                            # transcription is blank
+                            verified_transcription = ""
+                        if(result == "unclear"):
+                            # Unclear means that there is no verified
+                            # transcription and the sample is unusable
+                            # for either training the speech recognition
+                            # or the noise detection. We can go ahead
+                            # and run WER on it, but it is unlikely to
+                            # be used.
+                            verified_transcription = ""
+                            recording_type = "unclear"
+                        verified_transcription = verified_transcription.strip()
+                        filename = Update_record["Filename"]
+                        c.execute(
+                            " ".join([
+                                "select",
+                                " RowID,",
+                                " transcription,",
+                                " type",
+                                "from audiolog",
+                                "where RowID=:RowID or (",
+                                " filename=:filename and reviewed=''",
+                                ")"
+                            ]),
+                            {
+                                'RowID': rowID,
+                                'filename': filename
+                            }
+                        )
+                        for row in c.fetchall():
+                            rowID = row[0]
+                            transcription = row[1]
+                            recording_type = row[2]
+                            if(len(verified_transcription) == 0):
+                                recording_type = "noise"
+                                print("Setting recording_type to noise")
+                                if(result == "unclear"):
+                                    recording_type = "unclear"
+                                    print("Setting recording_type to unclear")
+                            # calculate the word error rate
+                            WER = wer(
+                                transcription,
+                                verified_transcription
+                            )
+                            c.execute(
+                                " ".join([
+                                    "update audiolog set ",
+                                    " type=:type,",
+                                    " verified_transcription=:vt,",
+                                    " reviewed=:reviewed,",
+                                    " wer=:wer",
+                                    "where RowID=:RowID"
+                                ]),
+                                {
+                                    "type": recording_type,
+                                    "vt": verified_transcription,
+                                    "reviewed": now,
+                                    "wer": WER,
+                                    "RowID": rowID
+                                }
+                            )
+                            conn.commit()
+                        # fetch the next unreviewed rowid
+                        rowID = fetch_next_unreviewed_rowID(c, rowID)
+                    else:
+                        ErrorMessage = "Row ID {} does not exist".format(
+                            str(rowID)
+                        )
+                # get the first rowID
+                first_rowID = fetch_first_rowID(c)
+                # get the current rowID
+                try:
+                    rowID = fetch_current_rowID(c, rowID)
+                except ValueError:
+                    ErrorMessage = "Row {} not found".format(rowID)
+                    rowID = fetch_current_rowID(c, None)
+                # get the previous rowid
+                prev_rowID = fetch_prev_rowID(c, rowID)
+                # get the next rowid
+                next_rowID = fetch_next_rowID(c, rowID)
+
+                if(len(first_rowID)):
+                    ret.append("""
+<meta charset="utf-8"/>
+<style type="text/css">
+ /* Style the tab */
+.tab {
+  overflow: hidden;
+  border: 1px solid #ccc;
+  background-color: #f1f1f1;
+}
+/* Style the buttons that are used to open the tab content */
+.tab button {
+  background-color: inherit;
+  float: left;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  transition: 0.3s;
+}
+/* Change background color of buttons on hover */
+.tab button:hover {
+  background-color: #ddd;
+}
+/* Create an active/current tablink class */
+.tab button.active {
+  background-color: #ccc;
+}
+/* Style the tab content */
+.tabcontent {
+  display: none;
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-top: none;
+}
+.tabcontent.active {
+  display: block;
+}
+.success {
+  color: #0f0; /* green */
+}
+.failure {
+  color: #f00; /* red */
+}
+</style>
+<script language="javascript">
+    var spin=0; // global spinner control
+    function startSpinner(){
+        // wait for any old spinners to exit before starting a new spinner.
+        spintimer=window.setTimeout(function(){spin=1;moveSpinner(0)},250);
+    }
+    function moveSpinner(position){
+        var s=document.getElementById("spinner");
+        switch(position){
+            case 0:
+                s.innerHTML="-";
+                break;
+            case 1:
+                s.innerHTML="\\\\";
+                break;
+            case 2:
+                s.innerHTML="|";
+                break;
+            case 3:
+                s.innerHTML="/";
+                break;
+        }
+        if(spin){
+            spintimer=window.setTimeout(function(){moveSpinner((position+1)%4)},250);
+        }else{
+            s.innerHTML="";
+        }
+    }
+    function stopSpinner(){
+        spin=0;
+    }
+    function openTab(evt, tabName) {
+        // Declare all variables
+        var i, tabcontent, tablinks;
+        // Get all elements with class="tabcontent" and hide them
+        tabcontent = document.getElementsByClassName("tabcontent");
+        for (i = 0; i < tabcontent.length; i++) {
+            tabcontent[i].className = "tabcontent";
+        }
+        // Get all elements with class="tablinks" and remove the class "active"
+        tablinks = document.getElementsByClassName("tablinks");
+        for (i = 0; i < tablinks.length; i++) {
+            tablinks[i].className = tablinks[i].className.replace(" active", "");
+        }
+        // Show the current tab, and add an "active" class to the button that opened the tab
+        document.getElementById(tabName).className = "tabcontent active";
+        evt.currentTarget.className += " active";
+    }
+
+    // Submit an updated transcription to the server. Upon success,
+    // make the "revert" button inactive
+    function UpdateTranscription(RowID){
+        var Transcription=document.getElementById("transcription_"+RowID).value;
+        alert( "Transcription="+Transcription );
+        var xhttp=new XMLHttpRequest();
+        xhttp.onreadystatechange=function(){
+            if( this.readyState==4 && this.status==200 ){
+                // Check this.responseText
+                var message=JSON.parse(this.responseText).message;
+                if( message=="SUCCESS;Updated "+RowID ){
+                    // disable reset button
+                    document.getElementById("reset_"+RowID).disabled=true;
+                }else{
+                    //alert( "message="+message );
+                }
+            }else{
+                //alert( "responseText="+this.responseText );
+            }
+        }
+        xhttp.open("POST",window.location.href.split(/[?#]/)[0],true);
+        var request=JSON.stringify({"action":"update","RowID":RowID,"Transcription":Transcription});
+        xhttp.send(request);
+    }
+
+    // Delete a line from the database and, if the response is success,
+    // delete the line from the page also.
+    function DeleteAudio(RowID){
+        var xhttp=new XMLHttpRequest();
+        xhttp.onreadystatechange=function(){
+            if( this.readyState==4 && this.status==200 ){
+                // Check this.responseText to make sure it contains a success message
+                var message=JSON.parse(this.responseText).message;
+                if( message=="SUCCESS;Deleted "+RowID ){
+                    document.getElementById("r"+RowID).parentNode.removeChild(document.getElementById("r"+RowID));
+                }else{
+                    //alert(message);
+                }
+            }
+        };
+        xhttp.open("POST",window.location.href.split(/[?#]/)[0],true);
+        var request='{"action":"delete","RowID":"'+RowID+'"}';
+        xhttp.send(request);
+    }
+
+    function GoRowID(RowID){
+        document.location.href="http://"+window.location.host+window.location.pathname+"?RowID="+RowID;
+    }
+
+    function ValidateForm(){
+        var Checked=document.querySelector("input[name='result']:checked");
+        var Ret=true;
+        if( !Checked ){
+            Ret=false;
+            alert("Please select an option");
+        }
+        return Ret;
+    }
+
+    function Train(clear,engine,command){
+        stopSpinner();
+        if(clear){
+            document.getElementById("Result").innerHTML = "";
+        }
+        var xhttp = new XMLHttpRequest();
+        xhttp.onreadystatechange = function(){
+            if(this.readyState==4){
+                stopSpinner();
+                if(this.status==200){
+                    var response=JSON.parse(this.responseText);
+                    document.getElementById("Result").innerHTML += response.message + '<br /><br />';
+                    if(response.command){
+                        var description = "";
+                        if(response.description){
+                            description = response.description;
+                        }
+                        Train(false,response.engine,response.command,description);
+                    }else{
+                        document.getElementById("Result").innerHTML += "<h2>Training Complete</h2>";
+                    }
+                }else{
+                    document.getElementById("Result").innerHTML += "An error occurred. ReadyState: "+this.readyState+" Status: "+this.status+"<br />"+this.responseText;
+                }
+            }
+        };
+        url = location.toString().replace(location.search, "");
+
+        xhttp.open("POST",url,true);
+        xhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+        xhttp.send("engine="+engine+"&command="+command);
+        startSpinner();
+    }
+</script>""".encode("utf-8"))
+                    ret.append('''
+</head>
+<body>
+<!-- Tab links -->
+<div class="tab">
+  <button class="tablinks active" onclick="openTab(event, 'Verify')">Verify transciptions</button>
+  <button class="tablinks" onclick="openTab(event, 'Train')">Train STT Engines</button>
+</div>
+<!-- Tab content -->
+<div id="Verify" class="tabcontent active">
+'''.encode("utf-8")
+                    )
+
+                    Current_record = Get_row(c, rowID)
+
+                    # if this has been reviewed, figure out
+                    # what option was selected
+                    Checked = 'checked="checked"'
+                    Unchecked = ''
+                    Disabled = 'disabled="disabled"'
+                    Enabled = ''
+                    Result_correct = Unchecked
+                    Result_update = Unchecked
+                    Result_nothing = Unchecked
+                    Result_unclear = Unchecked
+                    Verified_transcription_state = Disabled
+                    if(len(Current_record["Reviewed"])):
+                        if(Current_record["Verified_transcription"]):
+                            if(Current_record[
+                                "Transcription"
+                            ] == Current_record[
+                                "Verified_transcription"
+                            ]):
+                                Result_correct = Checked
+                            else:
+                                Result_update = Checked
+                                Verified_transcription_state = Enabled
+                        else:
+                            if(Current_record["Type"] == "noise"):
+                                Result_nothing = Checked
+                            else:
+                                Result_unclear = Checked
+
+                    if(not Current_record["Verified_transcription"]):
+                        Current_record[
+                            "Verified_transcription"
+                        ] = Current_record[
+                            "Transcription"
+                        ]
+
+                    # Serve the body of the page
+                    if(Debug):
+                        # Debug info
+                        ret.append("""<ul>""".encode("utf-8"))
+                        ret.append("""<li>post_data: {}</li>""".format(
+                            post_data
+                        ).encode("utf-8"))
+                        ret.append("""<li>Result: {}</li>""".format(
+                            result
+                        ).encode("utf-8"))
+
+                        if(result == "update"):
+                            ret.append(
+                                "<li>Verified_transcription: {}</li>".format(
+                                    verified_transcription
+                                ).encode("utf-8")
+                            )
+                        ret.append("</ul>".encode("utf-8"))
+
+                        ret.append("<ul>".encode("utf-8"))
+                        ret.append("<li>Recorded: {}</li>".format(
+                            Current_record["Recorded"]
+                        ).encode("utf-8"))
+                        ret.append("<li>Filename: {}</li>".format(
+                            Current_record["Filename"]
+                        ).encode("utf-8"))
+                        ret.append("<li>Type: {}</li>".format(
+                            Current_record["Type"]
+                        ).encode("utf-8"))
+                        ret.append("<li>Transcription: {}</li>".format(
+                            Current_record["Transcription"]
+                        ).encode("utf-8"))
+                        ret.append("<li>Verified_transcription: {}</li>".format(
+                            Current_record["Verified_transcription"]
+                        ).encode("utf-8"))
+                        ret.append("<li>Speaker: {}</li>".format(
+                            Current_record["Speaker"]
+                        ).encode("utf-8"))
+                        ret.append("<li>Reviewed: {}</li>".format(
+                            Current_record["Reviewed"]
+                        ).encode("utf-8"))
+                        ret.append("<li>Wer: {}</li>".format(
+                            Current_record["WER"]
+                        ).encode("utf-8"))
+                        ret.append("<li>Result_correct: {}</li>".format(
+                            Result_correct
+                        ).encode("utf-8"))
+                        ret.append("""<li>Result_update: {}</li>""".format(
+                            Result_update
+                        ).encode("utf-8"))
+                        ret.append("""<li>Result_nothing: {}</li>""".format(
+                            Result_nothing
+                        ).encode("utf-8"))
+                        ret.append("""</ul>""".encode("utf-8"))
+
+                    ret.append("""<h1>{} transcription {} ({})</h1>""".format(
+                        keyword,
+                        rowID,
+                        Current_record["Type"]).encode("utf-8")
+                    )
+                    if(ErrorMessage):
+                        ret.append("""<p class="Error">{}</p>""".format(
+                            ErrorMessage
+                        ).encode("utf-8"))
+                    ret.append(
+                        " ".join([
+                            '<audio',
+                            'controls="controls"',
+                            'type="audio/wav"',
+                            'style="width:100%%">',
+                            '<source src="?wavfile={}" />',
+                            '</audio><br />'
+                        ]).format(Current_record["Filename"]).encode("utf-8")
+                    )
+                    ret.append(
+                        ' '.join([
+                            '{} heard',
+                            '"<span style="font-weight:bold">{}</span>"<br />'
+                        ]).format(
+                            keyword,
+                            Current_record["Transcription"]
+                        ).encode("utf-8"))
+                    ret.append("What did you hear?<br />".encode("utf-8"))
+                    ret.append(' '.join([
+                        '<form method="POST"',
+                        'onsubmit="return ValidateForm()">'
+                    ]).encode("utf-8"))
+                    ret.append(
+                        '<input type="hidden" name="RowID" value="{}"/>'.format(
+                            rowID
+                        ).encode("utf-8")
+                    )
+                    ret.append("""<input type="radio" id="update_result_correct" name="result" value="correct" {} onclick="document.getElementById('update_verified_transcription').disabled=true"/> <label for="update_result_correct">The transcription is correct. I heard the same thing</label><br />""".format(
+                        Result_correct
+                    ).encode("utf-8"))
+                    ret.append("""<input type="radio" id="update_result_update" name="result" value="update" {} onclick="document.getElementById('update_verified_transcription').disabled=false"/> <label for="update_result_update">The transcription is not correct. This is what I heard:</label><br /><textarea id="update_verified_transcription" name="verified_transcription" style="margin-left: 20px" {}>{}</textarea><br />""".format(
+                        Result_update,
+                        Verified_transcription_state,
+                        Current_record["Verified_transcription"]
+                    ).encode("utf-8"))
+                    ret.append("""<input type="radio" id="update_result_nothing" name="result" value="noise" {} onclick="document.getElementById('update_verified_transcription').disabled=true"/> <label for="update_result_nothing">This was just noise with no voices.</label><br />""".format(
+                        Result_nothing
+                    ).encode("utf-8"))
+                    ret.append("""<input type="radio" id="update_result_unclear" name="result" value="unclear" {} onclick="document.getElementById('update_verified_transcription').disabled=true"/> <label for="update_result_unclear">This was too unclear to understand.</label><br />""".format(
+                        Result_unclear
+                    ).encode("utf-8"))
+                    ret.append(
+                        '<input type="submit" value="Submit"/><br />'.encode(
+                            "utf-8"
+                        )
+                    )
+                    if(prev_rowID):
+                        ret.append(
+                            ' '.join([
+                                '<input type="button" value="Prev"',
+                                'onclick="GoRowID({})"/>'
+                            ]).format(prev_rowID).encode("utf-8")
+                        )
+                    if(next_rowID):
+                        ret.append(
+                            ' '.join([
+                                '<input type="button" value="Next"',
+                                'onclick="GoRowID({})"/>'
+                            ]).format(next_rowID).encode("utf-8")
+                        )
+                    else:
+                        ret.append("""All transcriptions verified""".encode(
+                            "utf-8"
+                        ))
+                    ret.append('''
+</div><!-- Verify -->
+<div id="Train" class="tabcontent">
+<form name="Train">
+'''.encode('utf-8')
+                    )
+                    for info in plugins.get_plugins_by_category('stt_trainer'):
+                        ret.append('''<input type="button" value="{plugin_name}" onclick="Train(true,'{plugin_name}','checkenviron')"><br />'''.format(plugin_name=info.name).encode("utf-8"))
+                    ret.append('''
+</form>
+<div id="Result">
+</div>
+<div id="spinner">
+</div>
+</div><!-- Train -->
+'''.encode('UTF-8')
+                    )
+                    ret.append("""</body></html>""".encode("utf-8"))
+                else:
+                    ret = [
+                        "".join([
+                            "<html>",
+                            "<head><title>Nothing to validate</title></head>",
+                            "<body><h1>Nothing to validate</h1></body></html>"
+                        ]).encode("utf-8")
+                    ]
+            except sqlite3.OperationalError as e:
+                ret.append(
+                    "".join([
+                        '</head>',
+                        '<body>SQLite error: {}</body>',
+                        '</html>'
+                    ]).format(e).encode("utf-8"))
+        return ret
+
+
+class ThreadingWSGIServer(ThreadingMixIn, wsgiref.simple_server.WSGIServer):
+    pass
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Naomi Voice Control Center')
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Show debug messages'
+    )
+    p_args = parser.parse_args()
+    if p_args.debug:
+        Debug = True
+        profile.set_arg
+        print("Setting logging level to DEBUG")
+        logging.basicConfig(
+            level=logging.DEBUG
+        )
+    # Load the STT_Trainer plugins
+    plugin_directories = [
+        paths.config('plugins', 'stt_trainer'),
+        pkg_resources.resource_filename(__name__, os.path.join('plugins', 'stt_trainer'))
+    ]
+    plugins = pluginstore.PluginStore(plugin_directories)
+    plugins.detect_plugins()
+    port = 8080
+    url = "http://{}:{}".format(socket.getfqdn(), str(port))
+    print("Listening on port {}".format(str(port)))
+    print("Point your browser to {}".format(url))
+    server = wsgiref.simple_server.make_server(
+        '',
+        port,
+        application,
+        ThreadingWSGIServer
+    )
+    thread = Thread(target=webbrowser.open, args=([url]))
+    thread.start()
+    server.serve_forever()

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -3,7 +3,6 @@ import logging
 import pkg_resources
 from . import audioengine
 from . import brain
-from . import commandline
 from . import paths
 from . import pluginstore
 from . import populate
@@ -34,6 +33,21 @@ class Naomi(object):
         self._logger = logging.getLogger(__name__)
         if repopulate:
             populate.run()
+        if(profile.get_arg("Profile_missing", False)):
+            print("Your config file does not exist.")
+            text_input = input(
+                " ".join([
+                    "Would you like to answer a few ",
+                    "questions to create a new one? (y/N): "
+                ])
+            )
+            if(text_input.strip()[:1].upper() == "Y"):
+                populate.run()
+            else:
+                print("Cannot continue. Exiting.")
+                quit()
+        # FIXME We still need this next line because a lot of
+        # plugins still use self.config
         self.config = profile.get_profile()
         language = profile.get_profile_var(['language'])
         if(not language):
@@ -315,9 +329,7 @@ class Naomi(object):
             active_stt_slug,
             category='stt'
         )
-        active_phrases = self.brain.get_plugin_phrases()
-        if(passive_listen):
-            active_phrases.append(keyword)
+        active_phrases = self.brain.get_plugin_phrases(passive_listen)
         active_stt_plugin = active_stt_plugin_info.plugin_class(
             'default',
             active_phrases,

--- a/naomi/brain.py
+++ b/naomi/brain.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
 from . import paths
+from . import profile
 
 
 class Brain(object):
-    def __init__(self, config):
+    def __init__(self, *args, **kwargs):
         """
         Instantiates a new Brain object, which cross-references user
         input with a list of modules. Note that the order of brain.modules
@@ -14,7 +16,6 @@ class Brain(object):
 
         self._plugins = []
         self._logger = logging.getLogger(__name__)
-        self._config = config
 
     def add_plugin(self, plugin):
         self._plugins.append(plugin)
@@ -35,25 +36,42 @@ class Brain(object):
         Returns:
             A list of standard phrases.
         """
-        try:
-            language = self._config['language']
-        except KeyError:
-            language = None
-        if not language:
-            language = 'en-US'
+        language = profile.get(['language'], 'en-US')
 
-        phrases = []
+        phrases = [profile.get(['keyword'])]
 
-        with open(paths.data('standard_phrases', "%s.txt" % language),
-                  mode="r") as f:
-            for line in f:
-                phrase = line.strip()
-                if phrase:
-                    phrases.append(phrase)
+        # Get the contents of the
+        # .naomi/data/standard_phrases/{language}.txt
+        # file
+        # The purpose of this file is to provide some
+        # words that Naomi can recognize rather than only
+        # recognizing wakeword. If the only word it knows
+        # is the wake word, you will get a lot of false
+        # positives.
+        custom_standard_phrases_file = paths.sub(os.path.join(
+            "data",
+            "standard_phrases",
+            "{}.txt".format(language)
+        ))
+        if(os.path.isfile(custom_standard_phrases_file)):
+            with open(custom_standard_phrases_file, mode='r') as f:
+                for line in f:
+                    phrase = line.strip()
+                    if phrase:
+                        phrases.append(phrase)
+        if(len(phrases) < 10):
+            # Get the contents of the naomi/data/standard_phrases/{language}.txt
+            # file. This file is built from words you actually say to Naomi
+            # that are not the wakeword or in the plugin phrases.
+            with open(paths.data('standard_phrases', "%s.txt" % language),
+                    mode="r") as f:
+                for line in f:
+                    phrase = line.strip()
+                    if phrase:
+                        phrases.append(phrase)
+        return sorted(list(set(phrases)))
 
-        return phrases
-
-    def get_plugin_phrases(self):
+    def get_plugin_phrases(self, passive_listen=False):
         """
         Gets phrases from all plugins.
 
@@ -61,10 +79,31 @@ class Brain(object):
             A list of phrases from all plugins.
         """
         phrases = []
+        # include the keyword, otherwise
+        if(passive_listen):
+            phrases = [profile.get(["keyword"])]
+        # Include any custom phrases (things you say to Naomi
+        # that don't match plugin phrases. Otherwise, there is
+        # a high probability that something you say will be
+        # interpreted as a command. For instance, the
+        # "check_email" plugin has only "EMAIL" and "INBOX" as
+        # standard phrases, so every time I would say
+        # "Naomi, check email" Naomi would hear "NAOMI SHUT EMAIL"
+        # and shut down.
+        custom_standard_phrases_file = paths.sub(os.path.join(
+            "data",
+            "standard_phrases",
+            "{}.txt".format(profile.get(['language'], 'en-US'))
+        ))
+        if(os.path.isfile(custom_standard_phrases_file)):
+            with open(custom_standard_phrases_file, mode='r') as f:
+                for line in f:
+                    phrase = line.strip()
+                    if phrase:
+                        phrases.append(phrase)
 
         for plugin in self._plugins:
             phrases.extend(plugin.get_phrases())
-
         return sorted(list(set(phrases)))
 
     def get_all_phrases(self):
@@ -74,7 +113,9 @@ class Brain(object):
         Returns:
             A list of phrases.
         """
-        return self.get_standard_phrases() + self.get_plugin_phrases()
+        phrases = self.get_standard_phrases()
+        phrases.extend(self.get_plugin_phrases())
+        return sorted(list(set(phrases)))
 
     def query(self, texts):
         """
@@ -90,9 +131,16 @@ class Brain(object):
         for plugin in self._plugins:
             for text in texts:
                 if plugin.is_valid(text):
-                    self._logger.debug("'%s' is a valid phrase for module " +
-                                       "'%s'", text, plugin.info.name)
+                    self._logger.debug(
+                        "'{}' is a valid phrase for module '{}'".format(
+                            text,
+                            plugin.info.name
+                        )
+                    )
                     return (plugin, text)
-        self._logger.debug("No module was able to handle any of these " +
-                           "phrases: %r", texts)
+        self._logger.debug(
+            "No module was able to handle any of these phrases: {}".format(
+                str(texts)
+            )
+        )
         return (None, None)

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -99,8 +99,8 @@ class commandline(object):
     # of that value (+ 1 so that the first item
     # does not return zero which is interpreted
     # as false), otherwise return None
-    def check_for_value(self, _value, _list):
-
+    @classmethod
+    def check_for_value(_value, _list):
         try:
             temp = _list.index(_value) + 1
         except ValueError:
@@ -111,63 +111,78 @@ class commandline(object):
     # Colors
     # This returns to whatever the default color is in the terminal
     # properties
-    def normal_text(self, text=""):
+    @classmethod
+    def normal_text(text=""):
         return t.normal + text
 
     # this is for emphasis
-    def strong_text(self, text=""):
+    @classmethod
+    def strong_text(text=""):
         return t.bold_cyan + text
 
     # this is for instructions
-    def instruction_text(self, text=""):
+    @classmethod
+    def instruction_text(text=""):
         return t.bold_blue + text
 
     # This is for the brackets surrounding the icon
-    def icon_text(self, text=""):
+    @classmethod
+    def icon_text(text=""):
         return t.bold_cyan + text
 
     # This is for question text
-    def question_text(self, text=""):
+    @classmethod
+    def question_text(text=""):
         return t.bold_blue + text
 
     # This is for the question icon
-    def question_icon(self, text=""):
+    @classmethod
+    def question_icon(text=""):
         return t.bold_yellow + text
 
     # This is for alert text
-    def alert_text(self, text=""):
+    @classmethod
+    def alert_text(text=""):
         return t.bold_red + text
 
     # This is for the alert icon
-    def alert_icon(self, text=""):
+    @classmethod
+    def alert_icon(text=""):
         return t.bold_cyan + text
 
     # This is for listing choices available to choose from
-    def choices_text(self, text=""):
+    @classmethod
+    def choices_text(text=""):
         return t.bold_cyan + text
 
     # This is for displaying the default choice when there is a default
-    def default_text(self, text=""):
+    @classmethod
+    def default_text(text=""):
         return t.normal + text
 
     # This is for the prompt after the default text
-    def default_prompt(self, text="// "):
+    @classmethod
+    def default_prompt(text="// "):
         return t.bold_blue + text
 
     # This is the color for the text as the user is entering a choice
-    def input_text(self, text=""):
+    @classmethod
+    def input_text(text=""):
         return t.normal + text
 
     # This is text for a url
-    def url_text(self, text=""):
+    @classmethod
+    def url_text(text=""):
         return t.bold_cyan + t.underline + text + t.normal
 
     # This is for a status message
-    def status_text(self, text=""):
+    @classmethod
+    def status_text(text=""):
         return t.bold_magenta + text
 
     # This is a positive alert
-    def success_text(self, text=""):
+    @classmethod
+    def success_text(text=""):
         return t.bold_green + text
 
     def format_prompt(self, icon, prompt):
@@ -212,7 +227,8 @@ class commandline(object):
     # AaronC - simple_password is a lot like simple_input, just uses
     # getpass instead of input. It does not encrypt the password. That
     # happens after the password has been validated.
-    def simple_password(self, prompt, default=None):
+    @classmethod
+    def simple_password(prompt, default=None):
         prompt += ": "
         prompt += self.input_text()
         # don't use print here so no automatic carriage return
@@ -384,7 +400,8 @@ class commandline(object):
 
     # FIXME I should put a default for listboxes here so that by default
     # any value chosen has to be a member of the options.key() list.
-    def validate(self, definition, response):
+    @classmethod
+    def validate(definition, response):
         valid = False
         if(len(response.strip()) == 0):
             valid = True
@@ -424,7 +441,8 @@ class commandline(object):
                         valid = False
         return valid
 
-    def separator(self):
+    @classmethod
+    def separator():
         print("")
         print("")
         print("")

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -99,7 +99,7 @@ class commandline(object):
     # of that value (+ 1 so that the first item
     # does not return zero which is interpreted
     # as false), otherwise return None
-    @classmethod
+    @staticmethod
     def check_for_value(_value, _list):
         try:
             temp = _list.index(_value) + 1
@@ -111,77 +111,77 @@ class commandline(object):
     # Colors
     # This returns to whatever the default color is in the terminal
     # properties
-    @classmethod
+    @staticmethod
     def normal_text(text=""):
         return t.normal + text
 
     # this is for emphasis
-    @classmethod
+    @staticmethod
     def strong_text(text=""):
         return t.bold_cyan + text
 
     # this is for instructions
-    @classmethod
+    @staticmethod
     def instruction_text(text=""):
         return t.bold_blue + text
 
     # This is for the brackets surrounding the icon
-    @classmethod
+    @staticmethod
     def icon_text(text=""):
         return t.bold_cyan + text
 
     # This is for question text
-    @classmethod
+    @staticmethod
     def question_text(text=""):
         return t.bold_blue + text
 
     # This is for the question icon
-    @classmethod
+    @staticmethod
     def question_icon(text=""):
         return t.bold_yellow + text
 
     # This is for alert text
-    @classmethod
+    @staticmethod
     def alert_text(text=""):
         return t.bold_red + text
 
     # This is for the alert icon
-    @classmethod
+    @staticmethod
     def alert_icon(text=""):
         return t.bold_cyan + text
 
     # This is for listing choices available to choose from
-    @classmethod
+    @staticmethod
     def choices_text(text=""):
         return t.bold_cyan + text
 
     # This is for displaying the default choice when there is a default
-    @classmethod
+    @staticmethod
     def default_text(text=""):
         return t.normal + text
 
     # This is for the prompt after the default text
-    @classmethod
+    @staticmethod
     def default_prompt(text="// "):
         return t.bold_blue + text
 
     # This is the color for the text as the user is entering a choice
-    @classmethod
+    @staticmethod
     def input_text(text=""):
         return t.normal + text
 
     # This is text for a url
-    @classmethod
+    @staticmethod
     def url_text(text=""):
         return t.bold_cyan + t.underline + text + t.normal
 
     # This is for a status message
-    @classmethod
+    @staticmethod
     def status_text(text=""):
         return t.bold_magenta + text
 
     # This is a positive alert
-    @classmethod
+    @staticmethod
     def success_text(text=""):
         return t.bold_green + text
 
@@ -227,8 +227,7 @@ class commandline(object):
     # AaronC - simple_password is a lot like simple_input, just uses
     # getpass instead of input. It does not encrypt the password. That
     # happens after the password has been validated.
-    @classmethod
-    def simple_password(prompt, default=None):
+    def simple_password(self, prompt, default=None):
         prompt += ": "
         prompt += self.input_text()
         # don't use print here so no automatic carriage return
@@ -400,7 +399,7 @@ class commandline(object):
 
     # FIXME I should put a default for listboxes here so that by default
     # any value chosen has to be a member of the options.key() list.
-    @classmethod
+    @staticmethod
     def validate(definition, response):
         valid = False
         if(len(response.strip()) == 0):
@@ -441,7 +440,7 @@ class commandline(object):
                         valid = False
         return valid
 
-    @classmethod
+    @staticmethod
     def separator():
         print("")
         print("")

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -1,10 +1,9 @@
-from . import i18n
-from . import paths
-from . import profile
+from naomi import i18n
+from naomi import paths
+from naomi import profile
 from getpass import getpass
 import re
 from blessings import Terminal
-
 
 _ = None
 affirmative = ""
@@ -13,14 +12,30 @@ audioengine_plugins = None
 t = None
 
 
-def get_language(language=None, once=False):
-    global _, t, affirmative, negative
-    t = Terminal()
-    if language is None:
+class commandline(object):
+    def __init__(self):
+        global _, t, affirmative, negative
+        t = Terminal()
+        # If the language has already been set, no need to change it.
+        # If the language has not been set, we will need to set it before
+        # interacting with the user
         translations = i18n.parse_translations(paths.data('locale'))
-        translator = i18n.GettextMixin(translations, profile.get_profile())
-        _ = translator.gettext
+        translator = i18n.GettextMixin(translations)
 
+        _ = translator.gettext
+        language = self.get_language(once=True)
+        if(language == 'fr-FR'):
+            affirmative = 'oui'
+            negative = 'non'
+        elif(language == 'de-DE'):
+            affirmative = "ja"
+            negative = "nein"
+        else:
+            affirmative = 'yes'
+            negative = 'no'
+
+    def get_language(self, language=None, once=False):
+        global _
         languages = {
             u'EN-English': 'en-US',
             u'FR-Français': 'fr-FR',
@@ -34,7 +49,7 @@ def get_language(language=None, once=False):
             (
                 once
             )and(
-                check_for_value(
+                self.check_for_value(
                     selected_language.strip().lower(),
                     [
                         x[:len(selected_language)].lower()
@@ -44,21 +59,21 @@ def get_language(language=None, once=False):
             )
         ):
             once = True
-            print("    " + instruction_text(_("Language Selector")))
+            print("    " + self.instruction_text(_("Language Selector")))
             print("")
             print("")
             for language in languages.keys():
                 print("    {}".format(language))
             print("")
-            selected_language = simple_input(
-                format_prompt(
+            selected_language = self.simple_input(
+                self.format_prompt(
                     "?",
                     _('Select Language')
                 ),
                 selected_language
             ).strip().lower()
             if(len(selected_language) > 0):
-                if(check_for_value(
+                if(self.check_for_value(
                     selected_language,
                     [x[
                         :len(selected_language)
@@ -74,364 +89,342 @@ def get_language(language=None, once=False):
                         )].index(selected_language)]
                     ]
 
-    profile.set_profile_var(['language'], language)
-    if(language == 'fr-FR'):
-        affirmative = 'oui'
-        negative = 'non'
-    elif(language == 'de-DE'):
-        affirmative = "ja"
-        negative = "nein"
-    else:
-        affirmative = 'yes'
-        negative = 'no'
-    translations = i18n.parse_translations(paths.data('locale'))
-    translator = i18n.GettextMixin(translations, profile.get_profile())
-    _ = translator.gettext
+        profile.set_profile_var(['language'], language)
+        translations = i18n.parse_translations(paths.data('locale'))
+        translator = i18n.GettextMixin(translations)
+        _ = translator.gettext
+        return language
 
+    # If value exists in list, return the index
+    # of that value (+ 1 so that the first item
+    # does not return zero which is interpreted
+    # as false), otherwise return None
+    def check_for_value(self, _value, _list):
 
-# If value exists in list, return the index
-# of that value (+ 1 so that the first item
-# does not return zero which is interpreted
-# as false), otherwise return None
-def check_for_value(_value, _list):
-    try:
-        temp = _list.index(_value) + 1
-    except ValueError:
-        temp = None
-    return temp
-
-
-# AaronC 2018-09-14
-# Colors
-# This returns to whatever the default color is in the terminal
-# properties
-def normal_text(text=""):
-    return t.normal + text
-
-
-# this is for emphasis
-def strong_text(text=""):
-    return t.bold_cyan + text
-
-
-# this is for instructions
-def instruction_text(text=""):
-    return t.bold_blue + text
-
-
-# This is for the brackets surrounding the icon
-def icon_text(text=""):
-    return t.bold_cyan + text
-
-
-# This is for question text
-def question_text(text=""):
-    return t.bold_blue + text
-
-
-# This is for the question icon
-def question_icon(text=""):
-    return t.bold_yellow + text
-
-
-# This is for alert text
-def alert_text(text=""):
-    return t.bold_red + text
-
-
-# This is for the alert icon
-def alert_icon(text=""):
-    return t.bold_cyan + text
-
-
-# This is for listing choices available to choose from
-def choices_text(text=""):
-    return t.bold_cyan + text
-
-
-# This is for displaying the default choice when there is a default
-def default_text(text=""):
-    return t.normal + text
-
-
-# This is for the prompt after the default text
-def default_prompt(text="// "):
-    return t.bold_blue + text
-
-
-# This is the color for the text as the user is entering a choice
-def input_text(text=""):
-    return t.normal + text
-
-
-# This is text for a url
-def url_text(text=""):
-    return t.bold_cyan + t.underline + text + t.normal
-
-
-# This is for a status message
-def status_text(text=""):
-    return t.bold_magenta + text
-
-
-# This is a positive alert
-def success_text(text=""):
-    return t.bold_green + text
-
-
-def format_prompt(icon, prompt):
-    if(icon == "!"):
-        prompt = "".join([
-            icon_text('['),
-            alert_icon('!'),
-            icon_text('] '),
-            question_text(prompt)
-        ])
-    elif(icon == "?"):
-        prompt = "".join([
-            icon_text('['),
-            question_icon('?'),
-            icon_text('] '),
-            question_text(prompt)
-        ])
-    return prompt
-
-
-# AaronC - simple_input is a lot like raw_input, just adds
-# a colon and space at the end. If a default value is
-# passed in, then adds that to the end followed by two slashes.
-# This used to be one of several standard ways of indicating
-# a default. If you want to override the behavior, of course,
-# then that can be done here.
-# Part of the purpose is to provide a way of overriding
-# raw_input easily without hunting down every reference
-def simple_input(prompt, default=None):
-    prompt += ": "
-    if(default):
-        prompt += default_text(default) + default_prompt()
-    prompt += input_text()
-    # don't use print here so no automatic carriage return
-    # sys.stdout.write(prompt)
-    response = input(prompt)
-    # if the user pressed enter without entering anything,
-    # set the response to default
-    if(default and not response):
-        response = default
-    return response.strip()
-
-
-# AaronC - simple_password is a lot like simple_input, just uses
-# getpass instead of input. It does not encrypt the password. That
-# happens after the password has been validated.
-def simple_password(prompt, default=None):
-    prompt += ": "
-    prompt += input_text()
-    # don't use print here so no automatic carriage return
-    # sys.stdout.write(prompt)
-    response = getpass(prompt)
-    # if the user pressed enter without entering anything,
-    # set the response to default
-    if(default and not response):
-        response = default
-    return response.strip()
-
-
-# AaronC - simple_request is more complicated, and populates
-# the profile variable directly
-def simple_request(path, prompt, cleanInput=None):
-    input_str = simple_input(prompt, profile.get_profile_var(path))
-    if input_str:
-        if cleanInput:
-            input_str = cleanInput(input_str)
-        profile.set_profile_var(path, input_str)
-
-
-# AaronC Sept 18 2018 This uses affirmative/negative to ask
-# a yes/no question. Returns True for yes and False for no.
-def simple_yes_no(prompt):
-    response = ""
-    while(response not in (affirmative.lower()[:1], negative.lower()[:1])):
-        response = simple_input(
-            format_prompt(
-                "?",
-                prompt + instruction_text(" (") + choices_text(
-                    affirmative.upper()[:1]
-                ) + instruction_text("/") + choices_text(
-                    negative.upper()[:1]
-                ) + instruction_text(")")
-            )
-        ).strip().lower()[:1]
-        if response not in (affirmative.lower()[:1], negative.lower()[:1]):
-            print(alert_text("Please select '{}' or '{}'.").format(
-                affirmative.upper()[:1],
-                negative.upper()[:1]
-            ))
-    if response == affirmative.lower()[:1]:
-        return True
-    else:
-        return False
-
-
-# This is a higher level control that takes a "setting" as input
-def get_setting(setting, definition):
-    # If the language has already been set, no need to change it.
-    get_language(once=True)
-    active = True
-    if("active" in definition):
         try:
-            active = definition["active"]()
-        except TypeError:
-            active = definition["active"]
-    if(active):
-        description = _("Sorry, no additional information is available about this setting")
-        if("description" in definition):
-            description = definition["description"]
-        default = ""
-        if("default" in definition):
-            default = definition["default"]
-        value = profile.get_profile_var(setting, default)
-        controltype = "textbox"
-        if("type" in definition):
-            controltype = definition["type"].lower()
-        if(controltype == "listbox"):
+            temp = _list.index(_value) + 1
+        except ValueError:
+            temp = None
+        return temp
+
+    # AaronC 2018-09-14
+    # Colors
+    # This returns to whatever the default color is in the terminal
+    # properties
+    def normal_text(self, text=""):
+        return t.normal + text
+
+    # this is for emphasis
+    def strong_text(self, text=""):
+        return t.bold_cyan + text
+
+    # this is for instructions
+    def instruction_text(self, text=""):
+        return t.bold_blue + text
+
+    # This is for the brackets surrounding the icon
+    def icon_text(self, text=""):
+        return t.bold_cyan + text
+
+    # This is for question text
+    def question_text(self, text=""):
+        return t.bold_blue + text
+
+    # This is for the question icon
+    def question_icon(self, text=""):
+        return t.bold_yellow + text
+
+    # This is for alert text
+    def alert_text(self, text=""):
+        return t.bold_red + text
+
+    # This is for the alert icon
+    def alert_icon(self, text=""):
+        return t.bold_cyan + text
+
+    # This is for listing choices available to choose from
+    def choices_text(self, text=""):
+        return t.bold_cyan + text
+
+    # This is for displaying the default choice when there is a default
+    def default_text(self, text=""):
+        return t.normal + text
+
+    # This is for the prompt after the default text
+    def default_prompt(self, text="// "):
+        return t.bold_blue + text
+
+    # This is the color for the text as the user is entering a choice
+    def input_text(self, text=""):
+        return t.normal + text
+
+    # This is text for a url
+    def url_text(self, text=""):
+        return t.bold_cyan + t.underline + text + t.normal
+
+    # This is for a status message
+    def status_text(self, text=""):
+        return t.bold_magenta + text
+
+    # This is a positive alert
+    def success_text(self, text=""):
+        return t.bold_green + text
+
+    def format_prompt(self, icon, prompt):
+        if(icon == "!"):
+            prompt = "".join([
+                self.icon_text('['),
+                self.alert_icon('!'),
+                self.icon_text('] '),
+                self.question_text(prompt)
+            ])
+        elif(icon == "?"):
+            prompt = "".join([
+                self.icon_text('['),
+                self.question_icon('?'),
+                self.icon_text('] '),
+                self.question_text(prompt)
+            ])
+        return prompt
+
+    # AaronC - simple_input is a lot like raw_input, just adds
+    # a colon and space at the end. If a default value is
+    # passed in, then adds that to the end followed by two slashes.
+    # This used to be one of several standard ways of indicating
+    # a default. If you want to override the behavior, of course,
+    # then that can be done here.
+    # Part of the purpose is to provide a way of overriding
+    # raw_input easily without hunting down every reference
+    def simple_input(self, prompt, default=None):
+        prompt += ": "
+        if(default):
+            prompt += self.default_text(default) + self.default_prompt()
+        prompt += self.input_text()
+        # don't use print here so no automatic carriage return
+        # sys.stdout.write(prompt)
+        response = input(prompt)
+        # if the user pressed enter without entering anything,
+        # set the response to default
+        if(default and not response):
+            response = default
+        return response.strip()
+
+    # AaronC - simple_password is a lot like simple_input, just uses
+    # getpass instead of input. It does not encrypt the password. That
+    # happens after the password has been validated.
+    def simple_password(self, prompt, default=None):
+        prompt += ": "
+        prompt += self.input_text()
+        # don't use print here so no automatic carriage return
+        # sys.stdout.write(prompt)
+        response = getpass(prompt)
+        # if the user pressed enter without entering anything,
+        # set the response to default
+        if(default and not response):
+            response = default
+        return response.strip()
+
+    # AaronC - simple_request is, ironically, more complicated, and
+    # populates the profile variable directly.
+    # path is the path within profile.yml
+    # prompt is the prompt that is displayed to the user
+    # cleanInput is a function used to format the text
+    def simple_request(self, path, prompt, cleanInput=None):
+        input_str = self.simple_input(prompt, profile.get_profile_var(path))
+        if input_str:
+            if cleanInput:
+                input_str = cleanInput(input_str)
+            profile.set_profile_var(path, input_str)
+
+    # AaronC Sept 18 2018 This uses affirmative/negative to ask
+    # a yes/no question. Returns True for yes and False for no.
+    def simple_yes_no(self, prompt):
+        response = ""
+        while(response not in (affirmative.lower()[:1], negative.lower()[:1])):
+            response = self.simple_input(
+                self.format_prompt(
+                    "?",
+                    prompt + self.instruction_text(" (") + self.choices_text(
+                        affirmative.upper()[:1]
+                    ) + self.instruction_text("/") + self.choices_text(
+                        negative.upper()[:1]
+                    ) + self.instruction_text(")")
+                )
+            ).strip().lower()[:1]
+            if response not in (affirmative.lower()[:1], negative.lower()[:1]):
+                print(self.alert_text("Please select '{}' or '{}'.").format(
+                    affirmative.upper()[:1],
+                    negative.upper()[:1]
+                ))
+        if response == affirmative.lower()[:1]:
+            return True
+        else:
+            return False
+
+    # This is a higher level control that takes a "setting" as input
+    def get_setting(self, setting, definition):
+        active = True
+        if("active" in definition):
             try:
-                options = definition["options"]()
+                # check if definition["active"] is a function
+                active = definition["active"]()
             except TypeError:
-                options = definition["options"]
-            print(
-                "    " + instruction_text(
-                    definition["title"]
-                )
-            )
-            print("")
-            response = value
-            once = False
-            while not ((once) and (validate(definition, response))):
-                once = True
-                tmp_response = simple_input(
-                    "    " + instruction_text(
-                        _("Available choices:")
-                    ) + " " + choices_text(
-                        ("{}. ".format(", ".join(sorted(list(options.keys())))))
-                    ) + instruction_text('"?" for help'),
-                    response
-                )
-                if(tmp_response.strip() == "?"):
-                    # Print the description plus any help text for the control
-                    print("")
-                    print(instruction_text(description))
-                    once = False
-                    continue
-                response = tmp_response
-                print("")
+                # if not, then take the value of definition["active"]
+                active = definition["active"]
+        if(active):
+            # Set a default description
+            description = _("Sorry, no additional information is available about this setting")
+            # read the description (a value)
+            if("description" in definition):
+                description = definition["description"]
+            # set a default default value
+            default = ""
+            # if default is defined, then use that value as default
+            if("default" in definition):
+                default = definition["default"]
+            # Check if there is a current value
+            value = profile.get(setting, default)
+            # Set a default for the type of control
+            controltype = "textbox"
+            if("type" in definition):
+                controltype = definition["type"].lower()
+            if(controltype == "listbox"):
                 try:
+                    options = definition["options"]()
+                except TypeError:
+                    options = definition["options"]
+                print(
+                    "    " + self.instruction_text(
+                        definition["title"]
+                    )
+                )
+                print("")
+                response = value
+                once = False
+                while not ((once) and (self.validate(definition, response))):
+                    once = True
+                    tmp_response = self.simple_input(
+                        "    " + self.instruction_text(
+                            _("Available choices:")
+                        ) + " " + self.choices_text(
+                            ("{}. ".format(", ".join(sorted(list(options.keys())))))
+                        ) + self.instruction_text('"?" for help'),
+                        response
+                    )
+                    if(tmp_response.strip() == "?"):
+                        # Print the description plus any help text for the control
+                        print("")
+                        print(self.instruction_text(description))
+                        once = False
+                        continue
+                    response = tmp_response
+                    print("")
+                    try:
+                        profile.set_profile_var(
+                            setting,
+                            options[response]
+                        )
+                    except KeyError:
+                        print(
+                            self.alert_text(
+                                _("Unrecognized option.")
+                            )
+                        )
+                print("")
+            elif(controltype == "password"):
+                print("")
+                value = profile.get_profile_password(setting, default)
+                response = value
+                once = False
+                while not ((once) and (self.validate(definition, response))):
+                    once = True
+                    tmp_response = self.simple_password(
+                        "    " + self.instruction_text('{} ("?" for help)'.format(definition["title"])),
+                        response
+                    )
+                    if(tmp_response.strip() == "?"):
+                        # Print the description plus any help text for the control
+                        print("")
+                        print(self.instruction_text(definition["description"]))
+                        once = False
+                        continue
+                    response = tmp_response
+                    print("")
+                    profile.set_profile_password(
+                        setting,
+                        response
+                    )
+            else:
+                # this is the default (textbox)
+                print("")
+                response = value
+                once = False
+                while not ((once) and (self.validate(definition, response))):
+                    once = True
+                    tmp_response = self.simple_input(
+                        "    " + self.instruction_text('{} ("?" for help)'.format(definition["title"])),
+                        response
+                    )
+                    if(tmp_response.strip() == "?"):
+                        # Print the description plus any help text for the control
+                        print("")
+                        print(self.instruction_text(definition["description"]))
+                        once = False
+                        continue
+                    response = tmp_response
+                    print("")
                     profile.set_profile_var(
                         setting,
-                        options[response]
+                        response
                     )
-                except KeyError:
-                    print(
-                        alert_text(
-                            _("Unrecognized option.")
-                        )
-                    )
-            print("")
-        elif(controltype == "password"):
-            print("")
-            value = profile.get_profile_password(setting, default)
-            response = value
-            once = False
-            while not ((once) and (validate(definition, response))):
-                once = True
-                tmp_response = simple_password(
-                    "    " + instruction_text('{} ("?" for help)'.format(definition["title"])),
-                    response
-                )
-                if(tmp_response.strip() == "?"):
-                    # Print the description plus any help text for the control
-                    print("")
-                    print(instruction_text(definition["description"]))
-                    once = False
-                    continue
-                response = tmp_response
-                print("")
-                profile.set_profile_password(
-                    setting,
-                    response
-                )
         else:
-            # this is the default (textbox)
-            print("")
-            response = value
-            once = False
-            while not ((once) and (validate(definition, response))):
-                once = True
-                tmp_response = simple_input(
-                    "    " + instruction_text('{} ("?" for help)'.format(definition["title"])),
-                    response
-                )
-                if(tmp_response.strip() == "?"):
-                    # Print the description plus any help text for the control
-                    print("")
-                    print(instruction_text(definition["description"]))
-                    once = False
-                    continue
-                response = tmp_response
-                print("")
-                profile.set_profile_var(
-                    setting,
-                    response
-                )
-    else:
-        # Just set the value to an empty value so we know we don't need to
-        # address this again.
-        profile.set_profile_var(setting, "")
+            # Just set the value to an empty value so we know we don't need to
+            # address this again.
+            profile.set_profile_var(setting, "")
 
-
-# FIXME I should put a default for listboxes here so that by default
-# any value chosen has to be a member of the options.key() list.
-def validate(definition, response):
-    valid = False
-    if(len(response.strip()) == 0):
-        valid = True
-    else:
-        try:
-            validfunction = definition["validation"]
-            valid = validfunction(response)
-        except KeyError:
+    # FIXME I should put a default for listboxes here so that by default
+    # any value chosen has to be a member of the options.key() list.
+    def validate(self, definition, response):
+        valid = False
+        if(len(response.strip()) == 0):
+            valid = True
+        else:
             try:
-                if(definition["type"] in ["listbox"]):
-                    # Use the default validation, which is to make sure whatever
-                    # is selected is a member of options
-                    try:
-                        valid = response in definition["options"]()
-                    except TypeError:
-                        # must not be a function, assume it is a list
-                        valid = response in definition["options"]
-                else:
-                    valid = True
+                validfunction = definition["validation"]
+                valid = validfunction(response)
             except KeyError:
-                # must be a textbox with no validation
-                valid = True
-        except TypeError:
-            # Not a function
-            validstr = str(definition["validation"]).strip().lower()
-            # Is it a boolean?
-            if validstr in ('true', 'yes', 'on'):
-                valid = True
-            elif validstr in ('false', 'no', 'off'):
-                valid = False
-            elif validstr == 'email':
-                valid = True if re.match('^[^@]+@[^@]+\\.[^@\\.]+$', response) else False
-            elif validstr in ('int', 'integer'):
                 try:
-                    valid = str(int(response)) == response
-                except ValueError:
+                    if(definition["type"] in ["listbox"]):
+                        # Use the default validation, which is to make sure whatever
+                        # is selected is a member of options
+                        try:
+                            valid = response in definition["options"]()
+                        except TypeError:
+                            # must not be a function, assume it is a list
+                            valid = response in definition["options"]
+                    else:
+                        valid = True
+                except KeyError:
+                    # must be a textbox with no validation
+                    valid = True
+            except TypeError:
+                # Not a function
+                validstr = str(definition["validation"]).strip().lower()
+                # Is it a boolean?
+                if validstr in ('true', 'yes', 'on'):
+                    valid = True
+                elif validstr in ('false', 'no', 'off'):
                     valid = False
-    return valid
+                elif validstr == 'email':
+                    valid = True if re.match('^[^@]+@[^@]+\\.[^@\\.]+$', response) else False
+                elif validstr in ('int', 'integer'):
+                    try:
+                        valid = str(int(response)) == response
+                    except ValueError:
+                        valid = False
+        return valid
 
-
-def separator():
-    print("")
-    print("")
-    print("")
+    def separator(self):
+        print("")
+        print("")
+        print("")

--- a/naomi/i18n.py
+++ b/naomi/i18n.py
@@ -1,3 +1,4 @@
+from naomi import profile
 import gettext
 import os.path
 import re
@@ -24,16 +25,14 @@ def parse_translations(translations_path):
 
 
 class GettextMixin(object):
-    def __init__(self, translations, config):
-        self.__config = config
+    # *args below because we used to have to push the profile in each time
+    # the config variable is no longer used, so these can be removed now.
+    def __init__(self, translations, *args):
         self.__translations = translations
         self.__get_translations()
 
     def __get_translations(self):
-        try:
-            language = self.__config['language']
-        except KeyError:
-            language = 'en-US'
+        language = profile.get(['language'], 'en-US')
 
         if language not in self.__translations:
             raise ValueError('Unsupported Language!')

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -128,6 +128,14 @@ class Mic(object):
                 ")"
             ]))
             self._conn.commit()
+            c.execute(" ".join([
+                "create table if not exists trainings(",
+                "   datetime,",
+                "   engine,",
+                "   description",
+                ")"
+            ]))
+            self._conn.commit()
             c.execute(
                 '''insert into audiolog values(?,?,?,?,?,'','','','')''',
                 (

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -9,7 +9,7 @@ from . import paths
 from . import vocabcompiler
 from . import audioengine
 from . import i18n
-from . import commandline as interface
+from . import commandline
 from . import profile
 
 
@@ -17,12 +17,14 @@ class GenericPlugin(object):
     def __init__(self, info, config):
         self._plugin_config = config
         self._plugin_info = info
-        if(not hasattr(self,'_logger')):
+        if(not hasattr(self, '_logger')):
             self._logger = logging.getLogger(__name__)
+        interface = commandline.commandline()
+        self.language = interface.get_language(once=True)
         translations = i18n.parse_translations(paths.data('locale'))
-        translator = i18n.GettextMixin(translations, profile.get_profile())
+        translator = i18n.GettextMixin(translations)
         _ = translator.gettext
-        if hasattr(self,'settings'):
+        if hasattr(self, 'settings'):
             # set a variable here to tell us if all settings are
             # completed or not
             # If all settings do not currently exist, go ahead and
@@ -42,7 +44,7 @@ class GenericPlugin(object):
                     "Configuring {}"
                 ).format(
                     self._plugin_info.name
-                )));
+                )))
                 for setting in self.settings:
                     interface.get_setting(
                         setting, self.settings[setting]
@@ -70,7 +72,9 @@ class SpeechHandlerPlugin(GenericPlugin, i18n.GettextMixin):
     def __init__(self, *args, **kwargs):
         GenericPlugin.__init__(self, *args, **kwargs)
         i18n.GettextMixin.__init__(
-            self, self.info.translations, self.profile)
+            self,
+            self.info.translations
+        )
 
     @abc.abstractmethod
     def get_phrases(self):
@@ -237,3 +241,7 @@ class VADPlugin(GenericPlugin):
                             )
                         )
                         return recording_frames
+
+
+class STTTrainerPlugin(GenericPlugin):
+    pass

--- a/naomi/pluginstore.py
+++ b/naomi/pluginstore.py
@@ -5,18 +5,17 @@ import importlib
 import inspect
 import sys
 import configparser
-
 from . import i18n
 from . import plugin
 
 MANDATORY_OPTIONS = (
     ('Plugin', 'Name'),
-    ('Plugin', 'Version'),
-    ('Plugin', 'License')
+    ('Plugin', 'Version')
 )
-
+LICENSE_OPTION = ('Plugin', 'License')
 PLUGIN_INFO_FILENAME = "plugin.info"
 PLUGIN_TRANSLATIONS_DIRNAME = "locale"
+PLUGIN_LICENSE_FILENAME = "LICENSE"
 
 
 class PluginError(Exception):
@@ -32,9 +31,34 @@ def parse_info_file(infofile_path):
     for option in MANDATORY_OPTIONS:
         if not cp.has_option(*option):
             options_missing = True
-            logger.debug("Plugin info file '%s' missing value '%s'",
-                         infofile_path, option)
-
+            logger.debug(
+                "Plugin info file '{}' missing value '{}'".format(
+                    infofile_path,
+                    option
+                )
+            )
+    # Check to see if the LICENSE.txt file exists
+    # in the plugin directory
+    license_file_full_path = os.path.join(
+        os.path.dirname(infofile_path),
+        PLUGIN_LICENSE_FILENAME
+    )
+    if(
+        not os.path.isfile(license_file_full_path)
+    )and(
+        not os.path.isfile(license_file_full_path + ".md")
+    )and(
+        not os.path.isfile(license_file_full_path + ".txt")
+    )and(
+        not cp.has_option(*LICENSE_OPTION)
+    ):
+        options_missing = True
+        logger.debug(
+            "Missing license. Add file {} or 'License' value to '{}'".format(
+                license_file_full_path,
+                infofile_path
+            )
+        )
     if options_missing:
         raise PluginError("Info file is missing values!")
 
@@ -146,6 +170,7 @@ class PluginStore(object):
             'speechhandler': plugin.SpeechHandlerPlugin,
             'tts': plugin.TTSPlugin,
             'stt': plugin.STTPlugin,
+            'stt_trainer': plugin.STTTrainerPlugin,
             'vad': plugin.VADPlugin
         }
 

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -4,7 +4,7 @@ try:
     import audioop
     from blessings import Terminal
     import collections
-    from . import commandline as interface
+    from . import commandline
     import feedparser
     from getpass import getpass
     import math
@@ -26,15 +26,6 @@ except SystemError:
     print("Please run the Populate.py program from the")
     print("Naomi root directory.")
     quit()
-
-
-# properties
-t = Terminal()
-# given values in select_language()
-_ = None
-affirmative = ""
-negative = ""
-audioengine_plugins = None
 
 
 # AaronC = for detecting audio. Switch to using VAD engine.
@@ -1538,7 +1529,6 @@ def get_output_device():
                 chunksize=output_chunksize,
                 add_padding=output_add_padding
             )
-            # pdb.set_trace()
             heard = interface.simple_yes_no(
                 _("Were you able to hear the beep?")
             )
@@ -1792,7 +1782,7 @@ def run():
     interface.get_language()
     interface.separator()
     translations = i18n.parse_translations(paths.data('locale'))
-    translator = i18n.GettextMixin(translations, profile.get_profile())
+    translator = i18n.GettextMixin(translations)
     _ = translator.gettext
 
     precheck()
@@ -1856,6 +1846,30 @@ def run():
         interface.normal_text()
     )
 
+
+# properties
+t = Terminal()
+# given values in select_language()
+_ = None
+affirmative = ""
+negative = ""
+audioengine_plugins = None
+try:
+    interface = commandline.commandline()
+except FileNotFoundError:
+    # Here I am catching what should be that the
+    # profile.yml file is not found.
+    # The first call to commandline() would have
+    # set up a temporary profile in the catch in
+    # profile.get_profile(), so this second
+    # call should work now and set up the commandline
+    # object so we can interact with the user
+    # Eventually, once all the settings have been
+    # pulled into the settings system, we won't need
+    # to explicitely run populate.run() anymore,
+    # the settings will be requested just because they
+    # are missing.
+    interface = commandline.commandline()
 
 if __name__ == "__main__":
     print("This program can no longer be run directly.")

--- a/naomi/profile.py
+++ b/naomi/profile.py
@@ -289,7 +289,7 @@ def _walk_profile(path, returnValue):
 def set_profile_var(path, value):
     global _profile
     temp = _profile
-    if(type(path) is str):
+    if(isinstance(path, str)):
         path = [path]
     if len(path) > 0:
         last = path[0]

--- a/naomi/profile.py
+++ b/naomi/profile.py
@@ -7,8 +7,6 @@ from cryptography.fernet import Fernet, InvalidToken
 import logging
 from naomi import paths
 import os
-from . import populate
-import re
 import shutil
 import yaml
 
@@ -27,8 +25,8 @@ def set_arg(name, value):
 
 # Retrieve an argument. Return None if the
 # argument is not set.
-def get_arg(name):
-    value = None
+def get_arg(name, default=None):
+    value = default
     if(name in _args.keys()):
         value = _args[name]
     return value
@@ -145,20 +143,15 @@ def get_profile(command=""):
                     _profile_read = True
                     config_read = True
             except IOError:
-                print("Your config file does not exist.")
-                text_input = input(
-                    " ".join([
-                        "Would you like to answer a few ",
-                        "questions to create a new one? "
-                    ])
+                _logger.info(
+                    "{} is missing".format(new_configfile)
                 )
-                if(re.match(r'\s*[Yy]', text_input)):
-                    _profile_read = True
-                    populate.run()
-                    config_read = True
-                else:
-                    print("Cannot continue. Exiting.")
-                    quit()
+                # set up a temporary profile just to be able to ask the
+                # question of which language the user wants.
+                _profile = {'language': 'en-US'}
+                _profile_read = True
+                set_arg("Profile_missing", True)
+                raise
             except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
                 _logger.error(
                     "Unable to parse config file: {} {}".format(
@@ -187,16 +180,26 @@ def save_profile():
         yaml.dump(get_profile(), outputFile, default_flow_style=False)
 
 
+def get(path, default=None):
+    return get_profile_var(path, default)
+
+
 def get_profile_var(path, default=None):
     """
     Get a value from the profile, whether it exists or not
     If the value does not exist in the profile, returns
     either the default value (if there is one) or None.
     """
+    if(type(path) is str):
+        path = [path]
     response = _walk_profile(path, True)
     if response is None:
         response = default
     return response
+
+
+def get_password(path, default=None):
+    return get_profile_password(path, default)
 
 
 def get_profile_password(path, default=None):
@@ -205,13 +208,16 @@ def get_profile_password(path, default=None):
     If the value does not exist in the profile, returns
     either the default value (if there is one) or None.
     """
+    if(type(path) is str):
+        path = [path]
     key = get_profile_key()
     cipher_suite = Fernet(key)
     response = _walk_profile(path, True)
     try:
-        response = cipher_suite.decrypt(
-            response.encode("utf-8")
-        ).decode("utf-8")
+        if(hasattr(response, "encode")):
+            response = cipher_suite.decrypt(
+                response.encode("utf-8")
+            ).decode("utf-8")
     except InvalidToken:
         response = None
     if response is None:
@@ -225,6 +231,8 @@ def get_profile_flag(path, default=None):
     or not. If the value does not exist, returns default or
     None
     """
+    if(type(path) is str):
+        path = [path]
     # Get the variable value
     temp = str(_walk_profile(path, True))
     if(temp is None):
@@ -236,12 +244,18 @@ def get_profile_flag(path, default=None):
     return response
 
 
+def exists(path):
+    return check_profile_var_exists(path)
+
+
 def check_profile_var_exists(path):
     """
     Checks if an option exists in the test_profile it is using.
     Option is passed in as a list so that if we need to check
     if a suboption exists, we can pass the full path to it.
     """
+    if(type(path) is str):
+        path = [path]
     return _walk_profile(path, False)
 
 
@@ -249,10 +263,17 @@ def _walk_profile(path, returnValue):
     """
     Function to walk the profile
     """
+    if(type(path) is str):
+        path = [path]
     profile = get_profile()
     found = True
     for branch in path:
         try:
+            # This happens if a value that was a string
+            # is converted to a list. So overwrite the
+            # string value with an array.
+            if(type(profile) is not dict):
+                profile = {}
             profile = profile[branch]
         except KeyError:
             found = False
@@ -268,6 +289,8 @@ def _walk_profile(path, returnValue):
 def set_profile_var(path, value):
     global _profile
     temp = _profile
+    if(type(path) is str):
+        path = [path]
     if len(path) > 0:
         last = path[0]
         if len(path) > 1:
@@ -292,6 +315,8 @@ def get_profile_key():
 
 def set_profile_password(path, value):
     global _profile
+    if(type(path) is str):
+        path = [path]
     # Encrypt value
     key = get_profile_key()
     cipher_suite = Fernet(key)

--- a/naomi/profile.py
+++ b/naomi/profile.py
@@ -190,7 +190,7 @@ def get_profile_var(path, default=None):
     If the value does not exist in the profile, returns
     either the default value (if there is one) or None.
     """
-    if(type(path) is str):
+    if(isinstance(path, str)):
         path = [path]
     response = _walk_profile(path, True)
     if response is None:
@@ -208,7 +208,7 @@ def get_profile_password(path, default=None):
     If the value does not exist in the profile, returns
     either the default value (if there is one) or None.
     """
-    if(type(path) is str):
+    if(isinstance(path, str)):
         path = [path]
     key = get_profile_key()
     cipher_suite = Fernet(key)
@@ -231,7 +231,7 @@ def get_profile_flag(path, default=None):
     or not. If the value does not exist, returns default or
     None
     """
-    if(type(path) is str):
+    if(isinstance(path, str)):
         path = [path]
     # Get the variable value
     temp = str(_walk_profile(path, True))
@@ -254,7 +254,7 @@ def check_profile_var_exists(path):
     Option is passed in as a list so that if we need to check
     if a suboption exists, we can pass the full path to it.
     """
-    if(type(path) is str):
+    if(isinstance(path, str)):
         path = [path]
     return _walk_profile(path, False)
 
@@ -263,7 +263,7 @@ def _walk_profile(path, returnValue):
     """
     Function to walk the profile
     """
-    if(type(path) is str):
+    if(isinstance(path, str)):
         path = [path]
     profile = get_profile()
     found = True

--- a/naomi/profile.py
+++ b/naomi/profile.py
@@ -272,7 +272,7 @@ def _walk_profile(path, returnValue):
             # This happens if a value that was a string
             # is converted to a list. So overwrite the
             # string value with an array.
-            if(type(profile) is not dict):
+            if(not isinstance(profile, dict)):
                 profile = {}
             profile = profile[branch]
         except KeyError:
@@ -315,7 +315,7 @@ def get_profile_key():
 
 def set_profile_password(path, value):
     global _profile
-    if(type(path) is str):
+    if(isinstance(path, str)):
         path = [path]
     # Encrypt value
     key = get_profile_key()

--- a/plugins/speechhandler/check_email/check_email.py
+++ b/plugins/speechhandler/check_email/check_email.py
@@ -61,19 +61,26 @@ class CheckEmailPlugin(plugin.SpeechHandlerPlugin):
                 }
             ),
             (
-                ("email", "imap"), {
+                ("email", "imap", "server"), {
                     "title": _("Please enter your IMAP email server url"),
                     "description": _("I need to know the url of your email server if you want me to check your emails for you"),
                     "active": lambda: True if len(profile.get_profile_var(["email", "address"]).strip()) > 0 else False
                 }
             ),
             (
-                ("email", "port"), {
+                ("email", "imap", "port"), {
                     "title": _("Please enter your IMAP email server port"),
                     "description": _("I need to know I have the correct port to access your email"),
                     "default": "993",
                     "validation": "int",
                     "active": lambda: True if(len(profile.get_profile_var(["email", "address"]).strip()) > 0) and (len(profile.get_profile_var(["email", "imap"])) > 0) else False
+                }
+            ),
+            (
+                ("email", "username"), {
+                    "title": _("Please enter your IMAP email server username"),
+                    "description": _("Your username is normally either your full email address or just the part before the '@' symbol"),
+                    "active": lambda: True if len(profile.get_profile_var(["email", "address"]).strip()) > 0 else False
                 }
             ),
             (
@@ -88,7 +95,7 @@ class CheckEmailPlugin(plugin.SpeechHandlerPlugin):
     )
 
     def get_phrases(self):
-        return [self.gettext("EMAIL"), self.gettext("INBOX")]
+        return [self.gettext("CHECK EMAIL"), self.gettext("CHECK INBOX")]
 
     def fetch_unread_emails(self, since=None, markRead=False, limit=None):
         """
@@ -102,14 +109,14 @@ class CheckEmailPlugin(plugin.SpeechHandlerPlugin):
             Returns:
             A list of unread email objects.
         """
-        host = profile.get_profile_var(['email', 'imap'])
-        port = int(profile.get_profile_var(['email', 'port'], "993"))
+        host = profile.get_profile_var(['email', 'imap', 'server'])
+        port = int(profile.get_profile_var(['email', 'imap', 'port'], "993"))
         conn = imaplib.IMAP4_SSL(host, port)
         conn.debug = 0
 
         password = profile.get_profile_password(['email', 'password'])
         conn.login(
-            profile.get_profile_var(['email', 'address']),
+            profile.get_profile_var(['email', 'username']),
             password
         )
         conn.select(readonly=(not markRead))
@@ -197,4 +204,4 @@ class CheckEmailPlugin(plugin.SpeechHandlerPlugin):
         Arguments:
         text -- user-input, typically transcribed speech
         """
-        return any(p.lower() in text.lower() for p in self.get_phrases())
+        return any(p.lower() in text.lower() for p in ['EMAIL', 'INBOX'])

--- a/plugins/stt_trainer/pocketsphinx_adapt/LICENSE.txt
+++ b/plugins/stt_trainer/pocketsphinx_adapt/LICENSE.txt
@@ -1,0 +1,19 @@
+# The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/stt_trainer/pocketsphinx_adapt/__init__.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .pocketsphinx_adapt import PocketsphinxAdaptPlugin

--- a/plugins/stt_trainer/pocketsphinx_adapt/plugin.info
+++ b/plugins/stt_trainer/pocketsphinx_adapt/plugin.info
@@ -1,0 +1,9 @@
+[Plugin]
+Name = Adapt Pocketsphinx
+Version = 1.0.0
+URL = http://naomiproject.github.io/
+Description = Adapt a Pockesphinx model to respond to your voice
+
+[Author]
+Name = Naomi Project
+URL = http://naomiproject.github.io/

--- a/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
@@ -405,13 +405,6 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                                 print(word, file=f)
                         table += "</table>"
                         response.append(table)
-                    '''
-                    table="<table><tr><th>old phrase</th></tr>"
-                    for word in phrases:
-                        table+="<tr><td>{}</td></tr>".format(word)
-                    table += "</table>"
-                    response.append(table)
-                    '''
                     # Finally, force naomi to regenerate all of the
                     # pocketsphinx vocabularies by deleting all the
                     # vocabularies/{language}/sphinx/{}/revision

--- a/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
@@ -1,0 +1,455 @@
+# -*- coding: utf-8 -*-
+# workflow adapted from
+# https://cmusphinx.github.io/wiki/tutorialadapt
+import glob
+import logging
+import os
+import pandas as pd
+import re
+import shutil
+import sqlite3
+from datetime import datetime
+from naomi import paths
+from naomi import plugin
+from naomi import pluginstore
+from naomi import profile
+from naomi.run_command import run_command
+
+
+# This checks a directory to make sure the pocketsphinx model files
+# we need are in there.
+def check_pocketsphinx_model(directory):
+    # Start by assuming the files exist. If any file is found to not
+    # exist, then set this to False
+    FilesExist = True
+    if(not os.path.isfile(os.path.join(directory, "mdef.txt"))):
+        if(os.path.isfile(os.path.join(directory, "mdef"))):
+            command = [
+                "pocketsphinx_mdef_convert",
+                "-text",
+                os.path.join(directory, "mdef"),
+                os.path.join(directory, "mdef.txt")
+            ]
+            completedprocess = run_command(command)
+            print("Command {} returned {}".format(
+                " ".join(completedprocess.args),
+                completedprocess.returncode
+            ))
+        if(not os.path.isfile(os.path.join(directory, "mdef.txt"))):
+            FilesExist = False
+    if(not os.path.isfile(os.path.join(directory, "means"))):
+        FilesExist = False
+    if(not os.path.isfile(os.path.join(directory, "mixture_weights"))):
+        FilesExist = False
+    if(not os.path.isfile(os.path.join(directory, "sendump"))):
+        FilesExist = False
+    if(not os.path.isfile(os.path.join(directory, "variances"))):
+        FilesExist = False
+    return FilesExist
+
+
+def process_completedprocess(completedprocess):
+    result = "failure"
+    command = " ".join(completedprocess.args)
+    print('{}...{}'.format(command, completedprocess.returncode))
+    instructions = "<br />Check log for details<br />"
+    if(completedprocess.stdout):
+        instructions += completedprocess.stdout.decode("utf-8").strip()
+    if(completedprocess.returncode == 0):
+        result = "success"
+        instructions = ""
+    return '{}...<span class="{}">{}</span>{}'.format(
+        command,
+        result,
+        result.upper(),
+        instructions
+    )
+
+
+class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
+    def __init__(self, *args, **kwargs):
+        self._logger = logging.getLogger(__name__)
+        self.language = profile.get_profile_var(['language'])
+        self.base_working_dir = paths.sub("pocketsphinx")
+        if not os.path.isdir(self.base_working_dir):
+            os.mkdir(self.base_working_dir)
+        self.standard_dir = os.path.join(self.base_working_dir, "standard")
+        if not os.path.isdir(self.standard_dir):
+            os.mkdir(self.standard_dir)
+        self.standard_dir = os.path.join(self.standard_dir, self.language)
+        if not os.path.isdir(self.standard_dir):
+            os.mkdir(self.standard_dir)
+        self.working_dir = os.path.join(self.base_working_dir, "working")
+        self.model_dir = os.path.join(self.working_dir, self.language)
+        self.adapt_dir = os.path.join(
+            self.base_working_dir,
+            "adapt",
+            self.language
+        )
+        self.formatteddict_path = os.path.join(
+            self.adapt_dir,
+            "cmudict.formatted.dict"
+        )
+        self.audiolog_dir = paths.sub("audiolog")
+        self.audiolog_db = os.path.join(self.audiolog_dir, "audiolog.db")
+        super(PocketsphinxAdaptPlugin, self).__init__(*args, **kwargs)
+
+    def HandleCommand(self, command, description):
+        try:
+            conn = sqlite3.connect(self.audiolog_db)
+            c = conn.cursor()
+            response = []
+            continue_next = True
+            nextcommand = ""
+            if(command == "checkenviron"):
+                response.append(
+                    "<h2>Preparing to adapt Pocketsphinx model</h2>"
+                )
+                description.append(
+                    "Adapting standard {} pocketsphinx model".format(
+                        self.language
+                    )
+                )
+                # Now run through the steps to adapt the standard model
+                # Start by checking to see if we have a copy of the standard
+                # model for this user's chosen language and download it if not.
+                # Check for the files we need
+                if(not check_pocketsphinx_model(self.standard_dir)):
+                    # Check and see if we already have a copy of the standard
+                    # language model
+                    cmd = [
+                        'git',
+                        'clone',
+                        '-b',
+                        self.language,
+                        'git@github.com:aaronchantrill/CMUSphinx_standard_language_models.git',
+                        self.standard_dir
+                    ]
+                    completedprocess = run_command(cmd)
+                    response.append(process_completedprocess(completedprocess))
+                    if(completedprocess.returncode != 0):
+                        continue_next = False
+                response.append("Environment configured")
+                nextcommand = "prepareworkingdir"
+            if(command == "prepareworkingdir"):
+                # At this point, we should have the standard model we need
+                if(check_pocketsphinx_model(self.standard_dir)):
+                    # FIXME It might be safest to remove the working dir at this
+                    # point if it already exists
+                    if not os.path.isdir(self.model_dir):
+                        # Copy the sphinx model into model_dir
+                        shutil.copytree(self.standard_dir, self.model_dir)
+                    if(check_pocketsphinx_model(self.model_dir)):
+                        query = " ".join([
+                            "select",
+                            " rowid,",
+                            " case",
+                            "  when length(trim(verified_transcription))>0",
+                            "   then (length(trim(verified_transcription))-length(replace(trim(verified_transcription),' ','')))+1",
+                            "  else 0",
+                            " end as WordCount,",
+                            " filename,",
+                            " upper(trim(replace(replace(verified_transcription,'?',''),',',''))) as transcription",
+                            "from audiolog",
+                            "where type in('active','passive') and reviewed!=''"
+                        ])
+                        df = pd.read_sql_query(query, conn)
+                        # Take the above and create naomi.fileids and naomi.transcription
+                        # fileids:
+                        description.append("on {} wav files".format(str(df.shape[0])))
+                        response.append("Adapting on {} wav files".format(df.shape[0]))
+                        with open(os.path.join(self.working_dir, "naomi.fileids"), "w+") as f:
+                            for filename in df['filename']:
+                                # No need to copy file, just leave it in audiolog
+                                f.write("{}\n".format(filename.rsplit(".", 1)[0]))
+                        with open(os.path.join(self.working_dir, "naomi.transcription"), "w+") as f:
+                            for t in df['transcription']:
+                                f.write("<s> {} </s>\n".format(t.lower()))
+                        nextcommand = "featureextraction"
+                    else:
+                        response.append("Error: failed to populate working model")
+            if(command == "featureextraction"):
+                cmd = [
+                    'sphinx_fe',
+                    '-argfile', os.path.join(self.model_dir, 'feat.params'),
+                    '-samprate', '16000',
+                    '-c', os.path.join(self.working_dir, 'naomi.fileids'),
+                    '-di', self.audiolog_dir,
+                    '-do', self.working_dir,
+                    '-ei', 'wav',
+                    '-eo', 'mfc',
+                    '-mswav', 'yes'
+                ]
+                completedprocess = run_command(cmd)
+                response.append(process_completedprocess(completedprocess))
+                if(completedprocess.returncode != 0):
+                    continue_next = False
+                nextcommand = "buildweights"
+            if(command == "buildweights"):
+                cmd = [
+                    os.path.join('/usr', 'local', 'libexec', 'sphinxtrain', 'bw'),
+                    '-hmmdir', self.model_dir,
+                    '-moddeffn', os.path.join(self.model_dir, 'mdef.txt'),
+                    '-ts2cbfn', '.ptm.',
+                    '-feat', '1s_c_d_dd',
+                    '-svspec', '0-12/13-25/26-38',
+                    '-cmn', 'current',
+                    '-agc', 'none',
+                    '-dictfn', os.path.join(self.model_dir, 'cmudict.dict'),
+                    '-ctlfn', os.path.join(self.working_dir, 'naomi.fileids'),
+                    '-lsnfn', os.path.join(self.working_dir, 'naomi.transcription'),
+                    '-cepdir', self.working_dir,
+                    '-accumdir', self.working_dir
+                ]
+                completedprocess = run_command(cmd)
+                response.append(process_completedprocess(completedprocess))
+                if(completedprocess.returncode != 0):
+                    continue_next = False
+                nextcommand = "mllr"
+            if(command == "mllr"):
+                # MLLR is a cheap adaptation method that is suitable when the amount of data is limited. It's good for online adaptation.
+                # MLLR works best for a continuous model. It's effect for semi-continuous models is limited.
+                cmd = [
+                    os.path.join("/usr", "local", "libexec", "sphinxtrain", "mllr_solve"),
+                    '-meanfn', os.path.join(self.model_dir, 'means'),
+                    '-varfn', os.path.join(self.model_dir, 'variances'),
+                    '-outmllrfn', os.path.join(self.model_dir, 'mllr_matrix'),
+                    '-accumdir', self.working_dir
+                ]
+                completedprocess = run_command(cmd)
+                response.append(process_completedprocess(completedprocess))
+                if(completedprocess.returncode != 0):
+                    continue_next = False
+                nextcommand = "map"
+            if(command == "map"):
+                # Update the acoustic model files with MAP
+                # In this case, unlike MLLR, we don't create a generic transform, but update each parameter in the model
+                # We copy the acoustic model directory and overwrite the new directory with the adapted model files
+                if(os.path.isdir(self.adapt_dir)):
+                    # Remove the adapt dir
+                    shutil.rmtree(self.adapt_dir)
+                    response.append("Cleared adapt directory {}".format(self.adapt_dir))
+                shutil.copytree(self.model_dir, self.adapt_dir)
+                cmd = [
+                    os.path.join('/usr', 'local', 'libexec', 'sphinxtrain', 'map_adapt'),
+                    '-moddeffn', os.path.join(self.model_dir, 'mdef.txt'),
+                    '-ts2cbfn', '.ptm.',
+                    '-meanfn', os.path.join(self.model_dir, 'means'),
+                    '-varfn', os.path.join(self.model_dir, 'variances'),
+                    '-mixwfn', os.path.join(self.model_dir, 'mixture_weights'),
+                    '-tmatfn', os.path.join(self.model_dir, 'transition_matrices'),
+                    '-accumdir', self.working_dir,
+                    '-mapmeanfn', os.path.join(self.adapt_dir, 'means'),
+                    '-mapvarfn', os.path.join(self.adapt_dir, 'variances'),
+                    '-mapmixwfn', os.path.join(self.adapt_dir, 'mixture_weights'),
+                    '-maptmatfn', os.path.join(self.adapt_dir, 'transition_matrices')
+                ]
+                completedprocess = run_command(cmd)
+                response.append(process_completedprocess(completedprocess))
+                if(completedprocess.returncode != 0):
+                    continue_next = False
+                nextcommand = "sendump"
+            if(command == "sendump"):
+                # Recreating the adapted sendump file
+                # a sendump file saves space and is supported by pocketsphinx
+                cmd = [
+                    os.path.join('/usr', 'local', 'libexec', 'sphinxtrain', 'mk_s2sendump'),
+                    '-pocketsphinx', 'yes',
+                    '-moddeffn', os.path.join(self.adapt_dir, 'mdef.txt'),
+                    '-mixwfn', os.path.join(self.adapt_dir, 'mixture_weights'),
+                    '-sendumpfn', os.path.join(self.adapt_dir, 'sendump')
+                ]
+                completedprocess = run_command(cmd)
+                response.append(process_completedprocess(completedprocess))
+                if(completedprocess.returncode != 0):
+                    continue_next = False
+                nextcommand = "updateprofile"
+            if(command == "updateprofile"):
+                # Format the dictionary
+                # Remove whitespace at the beginning of each line
+                # Remove (#) after first word
+                # collapse multiple whitespaces into a single space
+                # Remove any whitespaces from the end
+                with open(os.path.join(self.adapt_dir, "cmudict.dict"), "r") as in_file:
+                    with open(self.formatteddict_path, "w+") as out_file:
+                        for line in in_file:
+                            # Remove whitespace at beginning and end
+                            line = line.strip()
+                            # remove the number in parentheses (if there is one)
+                            line = re.sub('([^\\(]+)\\(\\d+\\)', '\\1', line)
+                            # compress all multiple whitespaces into a single whitespace
+                            line = re.sub('\s+', ' ', line)
+                            # replace the first whitespace with a tab
+                            line = line.replace(' ', '\t', 1)
+                            print(line, file=out_file)
+                # Use phonetisaurus to prepare an fst model
+                cmd = [
+                    "phonetisaurus-train",
+                    "--lexicon", self.formatteddict_path,
+                    "--seq2_del",
+                    "--dir_prefix", os.path.join(self.adapt_dir, "train")
+                ]
+                completedprocess = run_command(cmd)
+                response.append(process_completedprocess(completedprocess))
+                if(completedprocess.returncode == 0):
+                    # Now set the values in profile
+                    profile.set_profile_var(
+                        ['pocketsphinx', 'fst_model'],
+                        os.path.join(self.adapt_dir, "train", "model.fst")
+                    )
+                    profile.set_profile_var(
+                        ['pocketsphinx', 'hmm_dir'],
+                        self.adapt_dir
+                    )
+                    profile.save_profile()
+                    # Also run through the list of words that have been used
+                    # that are not the wake word or a command word and make
+                    # sure they are all identified so pocketsphinx can match
+                    # them and not get confused on word boundaries.
+                    # Pull a list of all words spoken from
+                    # verified translations
+                    query = " ".join([
+                        "with recursive split(",
+                        " word,",
+                        " rest",
+                        ") as (",
+                        " select",
+                        "  '',"
+                        "  upper(replace(replace(verified_transcription,'?',''),',','')) || ' '",
+                        " from audiolog",
+                        " where type in ('active','passive') and reviewed!=''",
+                        " union all select",
+                        "  substr(rest, 0, instr(rest,' ')),",
+                        "  substr(rest,instr(rest,' ')+1)",
+                        " from split where rest <> ''"
+                        ")",
+                        "select word from split where word!='' group by word"
+                    ])
+                    c.execute(query)
+                    words_used = [x[0].upper() for x in c.fetchall()]
+                    # Pull the list of words from the local standard phrases
+                    phrases = [profile.get_profile_var(['keyword']).upper()]
+                    custom_standard_phrases_dir = paths.sub(os.path.join(
+                        "data",
+                        "standard_phrases"
+                    ))
+                    custom_standard_phrases_file = os.path.join(
+                        custom_standard_phrases_dir,
+                        "{}.txt".format(self.language)
+                    )
+                    if(os.path.isfile(custom_standard_phrases_file)):
+                        with open(
+                            custom_standard_phrases_file,
+                            mode="r"
+                        ) as f:
+                            for line in f:
+                                phrase = line.strip().upper()
+                                if phrase:
+                                    phrases.append(phrase)
+                    # Get all the phrases that the plugins are looking for
+                    # There are two locations where plugins can be stored,
+                    # either in the plugins directory, or in the
+                    # ~/.naomi/plugins/ directory.
+                    # Right now, we always put plugins directly into the
+                    # plugins directory, but when we get to the point where
+                    # Naomi can be installed as a package, we will want to
+                    # put user plugins into the user config directory when
+                    # using the plugin manager
+                    ps = pluginstore.PluginStore([
+                        paths.config("plugins"),
+                        "plugins"
+                    ])
+                    ps.detect_plugins()
+                    for info in ps.get_plugins_by_category("speechhandler"):
+                        try:
+                            plugin = info.plugin_class(
+                                info,
+                                profile.get_profile()
+                            )
+                            if(hasattr(plugin, "get_phrases")):
+                                for phrase in plugin.get_phrases():
+                                    phrases.extend([
+                                        word.upper() for word in phrase.split()
+                                    ])
+                        except Exception as e:
+                            message = "Unknown"
+                            if hasattr(e, "message"):
+                                message = e.message
+                            response.append(
+                                "Plugin {} skipped! (Reason: {})".format(
+                                    info.name, message
+                                )
+                            )
+                    # Get the set of all words in words_used that do not appear
+                    # in phrases
+                    print("Phrases:")
+                    print(phrases)
+                    new_phrases = [
+                        word for word in words_used if word not in phrases
+                    ]
+                    response.append(
+                        "{} new phrases detected".format(len(new_phrases))
+                    )
+                    description.append(
+                        "adding {} new phrases".format(len(new_phrases))
+                    )
+                    if(len(new_phrases) > 0):
+                        table = "<table><tr><th>new phrase</th></tr>"
+                        # Append the new phrases to the custom
+                        # standard_phrases\{language}.txt file
+                        if(not os.path.isdir(custom_standard_phrases_dir)):
+                            os.makedirs(custom_standard_phrases_dir)
+                        with open(custom_standard_phrases_file, mode="a+") as f:
+                            for word in new_phrases:
+                                table += "<tr><td>{}</td></tr>".format(word)
+                                print(word, file=f)
+                        table += "</table>"
+                        response.append(table)
+                    '''
+                    table="<table><tr><th>old phrase</th></tr>"
+                    for word in phrases:
+                        table+="<tr><td>{}</td></tr>".format(word)
+                    table += "</table>"
+                    response.append(table)
+                    '''
+                    # Finally, force naomi to regenerate all of the
+                    # pocketsphinx vocabularies by deleting all the
+                    # vocabularies/{language}/sphinx/{}/revision
+                    # files:
+                    for revision_file in glob.glob(paths.sub(
+                        'vocabularies',
+                        self.language,
+                        'sphinx',
+                        "*",
+                        "revision"
+                    )):
+                        os.remove(revision_file)
+                    # Add the description
+                    c.execute(
+                        '''insert into trainings values(?,?,?)''',
+                        (
+                            datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                            'Adapt Pocketsphinx',
+                            " ".join(description)
+                        )
+                    )
+                    conn.commit()
+                else:
+                    continue_next = False
+        except Exception as e:
+            continue_next = False
+            message = "Unknown"
+            if hasattr(e, "message"):
+                message = e.message
+            self._logger.error(
+                "Error: {}".format(
+                    message
+                ),
+                exc_info=True
+            )
+            response.append('<span class="failure">{}</span>'.format(
+                message
+            ))
+        if not continue_next:
+            nextcommand = ""
+        return response, nextcommand, description


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit adds the NaomiSTTTrainer.py program. This runs as a
webserver under WSGI. You don't need a webserver to run it, just
run ./NaomiSTTTrainer.py and it should create a webserver
listening on port 8080 on your local machine. This is not intended
to run while you are running Naomi, it is only used for managing
your local database of audio clips and training different
speech to text engines. You should stop the webserver when you
are finished by pressing CTRL-C in the terminal window where it
is running.

If you start it up from within a GUI, it will also attempt to
launch your default browser. This is the first step towards
securing the browser by passing an access token, based on
my understanding of how jupyter notebook handles this.

This only works for users who have added the following line to
the Naomi profile:
```
audiolog:
  save_audio: true
```
Users will also have to install SphinxTrain:
  `git clone https://github.com/cmusphinx/sphinxtrain.git`

The interface consists of a page with two tabs
  * Verify transcriptions - this is the page that currently comes
  up by default. Towards the top of this window is an HTML5
  audio control. Play it to hear the audio clip Naomi recorded.
  Below that is a line that reads:
    Computer heard "{what the computer heard}"
  and below that is a series of radio buttons:

    The transcript is correct. I heard the same thing
    The transcript is not correct. This is what I heard:
    This was just noise with no voices
    This was too unclear to understand

  After listening to the clip, choose the appropriate radio
  button. If you heard something different from what Naomi
  heard, then type in your transcription. Naomi should
  automatically remove any punctuation and convert everything
  to upper case when training, so you don't have to follow
  the same convention of writing every word in upper case and
  writing everything in upper case that Naomi does.

  Audio that is just noise but no voices is important to
  capture for training the noise dictionary. Right now
  anything that is too unclear for a human to understand
  will not be used for training.

  * Train STT Engines - This tab has only one button on it
  currently, "Adapt Pocketsphinx". I have designed this
  program to work with Naomi's plugin system, so it should
  be easy to add additional STT trainers, to finally allow
  users to build and train their own models for Julius,
  Kaldi and DeepSpeech after running Naomi for a while using
  either standard PocketSphinx models or a cloud STT system
  like Google Cloud STT.

  If anything goes wrong while adapting your model, error
  messages should appear in the terminal window.

To accomplish this, I have changed the following files:

naomi/application.py - moved the check for populate.py back
into naomi/application.py because I was sometimes getting infinite
loops with it in naomi/commandline.py. To move the call to populate
back into application when the profile.yml file does not exist,
I am having profile.py create a flag that lets us know that the
profile was missing when we bubble back up to application.py.

naomi/brain.py - Made use of a new standard phrases file created
by Pocketsphinx_adapt. As the user trains the speech recognition,
the actual words used but not part of the "get_phrases" system
are put into this file to improve word recognition rates.

naomi/commandline.py - converted the commandline program into an
object. This was due to having trouble with it not initializing
correctly. This all has to do with the language setting. You want
the language to be set correctly before you can parse the i18n
translations, so you need to make sure the language is set up. At
the same time, if the language is currently set, you want to respect
the current settings when asking which language to use. The main
difference in converting this library into an object is just the
way it is called. Instead of doing:
```
  from naomi import commandline as interface
  interface.do_something()
```
You now use:
```
  from naomi import commandline
  interface = commandline.commandline()
  interface.do_something()
```
naomi/i18n.py - added the profile library and removed the requirement
to pass in a copy of the configuration when initializing the GettextMixin
object. It can now read the configuration directly. I had to add in
*args as a placeholder, though, since every plugin calls this library and
I didn't want to update all of them. Again, not exactly related to the
problem at hand, more of an issue I ran into while testing.

naomi/mic.py - added some code to create a new table in audiolog which
keeps track of your training history.

naomi/plugin.py - added the STTTrainerPlugin class. Right now it is not
really populated as I'm not sure how much, if any, duplicate code can be
moved into the base definition and out of the specific objects.

naomi/pluginstore.py - added the STTTrainerPlugin as stt_trainer type, also
modified the license check to accept the "License" line in the plugin.info
file or an actual LICENSE, LICENSE.md, or LICENSE.txt as created by
GitHub.

naomi/populate.py - just a couple of lines to deal with the changes to
commandline.

naomi/profile.py - sometimes it gets confusing when passing lists or tuples
to the profile functions when the path is only one level deep. With the
settings, you have to use tuples to hold path information since only tuples
can be used as indexes for dictionaries. Unfortunately, a tuple containing
only a single value seems to be interpreted as that value. I added a check
to the start of every function taking a path as argument to check if that
path is a string, and wrap it in a list if so.

plugins/speechhandler/check_email/check_email.py - I am currently working on
adding some additional functionality to the email system. This works toward
that goal by changing the "email: imap: setting" to "email: imap: server:" and
the "email: imap_port" to "email: imap: port:"

NaomiSTTTrainer.py - implemented a plugin system to make it easier to build
plugins for training different speech to text systems based on information
in audiolog.

plugins/stt_trainer/pocketsphinx_adapt - This folder contains the
pocketsphinx_adapt stt training program.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[One level deep settings interpreted as strings #195](https://github.com/NaomiProject/Naomi/issues/195)
[Automate STT training #103](https://github.com/NaomiProject/Naomi/issues/103)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Naomi should be a showcase for experimenting with offline/local Speech to Text solutions. To this end, I am working towards getting Naomi working better with different offline/local speech to text engines. One big advantage that Naomi has is that it only has to learn a limited number of voices, and it should be able to do that fairly well. It should even be able to adapt to speech impediments and strong accents.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this on Raspbian Stretch x86 running in a virtual machine.
I ran the unittest routines and don't appear to have made anything worse
I need to install this on a new Raspbian installation on a Raspberry Pi. I hope to do that sometime this week.
If you are interested in testing and can provide any feedback, please do so.
It should work in English, German and French. If you try it in German or French please let me know the result.

## Screenshots (if appropriate):
![Screenshot at 2019-06-23 22-13-13](https://user-images.githubusercontent.com/7544675/59986321-5e70d800-9604-11e9-9d61-40f40ed22d6f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
