### PR TITLE
Force profile load before use

### DIFF
--- a/naomi/profile.py
+++ b/naomi/profile.py
@@ -177,6 +177,8 @@ def get_profile(command=""):
 
 def save_profile():
     global _profile, _profile_read, _test_profile
+    if not _profile_read:
+        get_profile()
     # I want to make sure the user's profile is never accidentally overwritten
     # with a test profile.
     if not _test_profile:
@@ -193,6 +195,8 @@ def get_profile_var(path, default=None):
     If the value does not exist in the profile, returns
     either the default value (if there is one) or None.
     """
+    if not _profile_read:
+        get_profile()
     response = _walk_profile(path, True)
     if response is None:
         response = default
@@ -205,6 +209,8 @@ def get_profile_password(path, default=None):
     If the value does not exist in the profile, returns
     either the default value (if there is one) or None.
     """
+    if not _profile_read:
+        get_profile()
     key = get_profile_key()
     cipher_suite = Fernet(key)
     response = _walk_profile(path, True)
@@ -226,6 +232,8 @@ def get_profile_flag(path, default=None):
     None
     """
     # Get the variable value
+    if not _profile_read:
+        get_profile()
     temp = str(_walk_profile(path, True))
     if(temp is None):
         # the variable is not defined
@@ -242,6 +250,8 @@ def check_profile_var_exists(path):
     Option is passed in as a list so that if we need to check
     if a suboption exists, we can pass the full path to it.
     """
+    if not _profile_read:
+        get_profile()
     return _walk_profile(path, False)
 
 
@@ -267,6 +277,8 @@ def _walk_profile(path, returnValue):
 
 def set_profile_var(path, value):
     global _profile
+    if not _profile_read:
+        get_profile()
     temp = _profile
     if len(path) > 0:
         last = path[0]
@@ -285,6 +297,8 @@ def set_profile_var(path, value):
 
 
 def get_profile_key():
+    if not _profile_read:
+        get_profile()
     if not check_profile_var_exists(["key"]):
         set_profile_var(["key"], Fernet.generate_key().decode("utf-8"))
     return get_profile_var(["key"]).encode("utf-8")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds the following lines to the beginnings of any function
that either reads from or writes to the profile so that the
profile is always read first, otherwise, the profile might not
be read, in which case any new values will be overwritten when
the profile is read:
```
   if not _profile_read:
       get_profile()
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is something @TuxSeb discovered while building the UI interface

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is not obvious that you need to run profile.get_profile() before setting or getting values from it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running on Raspbian Stretch x86 on VirtualBox

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
