### PR TITLE
Naomi Plugin Repository

### DIFF
--- a/naomi/__main__.py
+++ b/naomi/__main__.py
@@ -51,17 +51,62 @@ def main(args=None):
             'and transcripts for training'
         ])
     )
+    # Plugin Repository Management
+    pr_man = parser.add_mutually_exclusive_group(required=False)
+    pr_man.add_argument(
+        '--list-available-plugins',
+        nargs='*',
+        dest='list_available',
+        action='append',
+        help='List available plugins (by category) and exit'
+    )
+    pr_man.add_argument(
+        '--install',
+        nargs="+",
+        dest='plugins_to_install',
+        action='append',
+        help='Install plugin and exit'
+    )
+    pr_man.add_argument(
+        '--update',
+        nargs="*",
+        dest='plugins_to_update',
+        action='append',
+        help='Update specific plugin(s) or all plugins and exit'
+    )
+    pr_man.add_argument(
+        '--remove',
+        nargs='+',
+        dest='plugins_to_remove',
+        action='append',
+        help='Remove (uninstall) plugins and exit'
+    )
+    pr_man.add_argument(
+        '--disable',
+        nargs='+',
+        dest='plugins_to_disable',
+        action='append',
+        help='Disable plugins and exit'
+    )
+    pr_man.add_argument(
+        '--enable',
+        nargs='+',
+        dest='plugins_to_enable',
+        action='append',
+        help='Enable plugins and exit'
+    )
     list_info = parser.add_mutually_exclusive_group(required=False)
     list_info.add_argument(
-        '--list-plugins',
+        '--list-active-plugins',
         action='store_true',
-        help='List plugins and exit'
+        help='List active plugins and exit'
     )
     list_info.add_argument(
         '--list-audio-devices',
         action='store_true',
         help='List audio devices and exit'
     )
+    # input options
     mic_mode = parser.add_mutually_exclusive_group(required=False)
     mic_mode.add_argument(
         '--local',
@@ -113,7 +158,7 @@ def main(args=None):
     # re-run populate.py when we examine the settings
     # variable while instantiating plugin objects
     # in plugin.GenericPlugin.__init__()
-    profile.set_arg("repopulate",p_args.repopulate)
+    profile.set_arg("repopulate", p_args.repopulate)
 
     # Run Naomi
     app = application.Naomi(
@@ -127,11 +172,29 @@ def main(args=None):
         save_active_audio=p_args.save_active_audio,
         save_noise=p_args.save_noise
     )
-    if p_args.list_plugins:
-        app.list_plugins()
-        sys.exit(1)
+    if p_args.list_active_plugins:
+        app.list_active_plugins()
+        sys.exit(0)
     elif p_args.list_audio_devices:
         app.list_audio_devices()
+        sys.exit(0)
+    if p_args.list_available:
+        app.list_available_plugins(p_args.list_available)
+        sys.exit(0)
+    if p_args.plugins_to_install:
+        app.install_plugins(p_args.plugins_to_install)
+        sys.exit(0)
+    if p_args.plugins_to_update:
+        app.update_plugins(p_args.plugins_to_update)
+        sys.exit(0)
+    if p_args.plugins_to_remove:
+        app.remove_plugins(p_args.plugins_to_remove)
+        sys.exit(0)
+    if p_args.plugins_to_enable:
+        app.enable_plugins(p_args.plugins_to_enable)
+        sys.exit(0)
+    if p_args.plugins_to_disable:
+        app.disable_plugins(p_args.plugins_to_disable)
         sys.exit(0)
     app.run()
 

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -481,7 +481,10 @@ class Naomi(object):
         # It would be good if we could actually read the csv file line by line
         # rather than reading it all into memory, but that might require some
         # custom code. For right now, we'll use the python tools.
-        with urllib.request.urlopen(url) as f:
+        # I should set up a context manager for this anyway, since I want to
+        # turn this into a routine that processes multiple urls from a
+        # text file, instead of repeating the same code three times
+        with urllib.request.urlopen(urllib.request.Request(url)) as f:  #nosec
             file_contents = f.read().decode('utf-8')
         csvfile = csv.DictReader(
             io.StringIO(file_contents),

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -511,7 +511,9 @@ class Naomi(object):
         # It would be good if we could actually read the csv file line by line
         # rather than reading it all into memory, but that might require some
         # custom code. For right now, we'll use the python tools.
-        with urllib.request.urlopen(urllib.request.Request(url)) as f:
+        # Codacy, I understand that the user can put something dumb into
+        # url. Chill.
+        with urllib.request.urlopen(urllib.request.Request(url)) as f:  #nosec
             file_contents = f.read().decode('utf-8')
         csvfile = csv.DictReader(io.StringIO(file_contents))
         for row in csvfile:
@@ -678,7 +680,15 @@ class Naomi(object):
             # Get a list of all the currently installed plugins
             for info in self.plugins._plugins.values():
                 flat_plugins.append(info.name)
-        with urllib.request.urlopen(urllib.request.Request(url)) as f:
+        # For Codacy:
+        # I understand that the following line can be an issue, and as the
+        # moment I might be able to appease you by copying the url into the
+        # line below, but eventually I want to read the location of the
+        # repository from a text file so the user can control what store
+        # they are using, so eventually the URL will not be hard coded.
+        # Yes, a user could put something dumb in there. That is up to the
+        # user.
+        with urllib.request.urlopen(urllib.request.Request(url)) as f:  #nosec
             file_contents = f.read().decode('utf-8')
         csvfile = csv.DictReader(io.StringIO(file_contents))
         for row in csvfile:

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -508,10 +508,11 @@ class Naomi(object):
     def install_plugins(self, plugins):
         flat_plugins = [y for x in plugins for y in x]
         url = "https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv"
+        urlreq = urllib.request.Request(url)
         # It would be good if we could actually read the csv file line by line
         # rather than reading it all into memory, but that might require some
         # custom code. For right now, we'll use the python tools.
-        with urllib.request.urlopen(url) as f:
+        with urllib.request.urlopen(urlreq) as f:
             file_contents = f.read().decode('utf-8')
         csvfile = csv.DictReader(io.StringIO(file_contents))
         for row in csvfile:
@@ -604,7 +605,7 @@ class Naomi(object):
                             break
                     else:
                         rev += 1
-                        install_to = "_".join(install_to_base, str(rev))
+                        install_to = "_".join([install_to_base, str(rev)])
                 if(fail):
                     continue
                 if(not os.path.isdir(install_to)):
@@ -674,11 +675,12 @@ class Naomi(object):
     def update_plugins(self, plugins):
         flat_plugins = [y for x in plugins for y in x]
         url = "https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv"
+        urlreq = urllib.request.Request(url)
         if len(flat_plugins) == 0:
             # Get a list of all the currently installed plugins
             for info in self.plugins._plugins.values():
                 flat_plugins.append(info.name)
-        with urllib.request.urlopen(url) as f:
+        with urllib.request.urlopen(urlreq) as f:
             file_contents = f.read().decode('utf-8')
         csvfile = csv.DictReader(io.StringIO(file_contents))
         for row in csvfile:
@@ -796,7 +798,8 @@ class Naomi(object):
                     "has it been disabled?"
                 ))
 
-    def enable_plugins(self, plugins):
+    @staticmethod
+    def enable_plugins(plugins):
         flat_plugins = [y for x in plugins for y in x]
         plugins_enabled = 0
         for plugin in flat_plugins:

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -1,16 +1,25 @@
 # -*- coding: utf-8 -*-
+import csv
+import io
 import logging
+import os
 import pkg_resources
+import re
+import shutil
+import urllib
 from . import audioengine
 from . import brain
+from . import commandline
 from . import paths
 from . import pluginstore
 from . import populate
 from . import conversation
 from . import mic
 from . import profile
+from .run_command import run_command
 from . import local_mic
 from . import batch_mic
+from .strcmpci import strcmpci
 
 USE_STANDARD_MIC = 0
 USE_TEXT_MIC = 1
@@ -31,6 +40,7 @@ class Naomi(object):
         save_noise=False
     ):
         self._logger = logging.getLogger(__name__)
+        self._interface = commandline.commandline()
         if repopulate:
             populate.run()
         if(profile.get_arg("Profile_missing", False)):
@@ -167,7 +177,7 @@ class Naomi(object):
                 )
         # Load plugins
         plugin_directories = [
-            paths.config('plugins'),
+            paths.sub('plugins'),
             pkg_resources.resource_filename(__name__, '../plugins')
         ]
         self.plugins = pluginstore.PluginStore(plugin_directories)
@@ -388,7 +398,7 @@ class Naomi(object):
         active_stt_response = profile.get_profile_var(
             ['active_stt', 'response']
         )
-
+        # pdb.set_trace()
         tts_plugin_info = self.plugins.get_plugin(tts_slug, category='tts')
         tts_plugin = tts_plugin_info.plugin_class(tts_plugin_info, self.config)
 
@@ -431,19 +441,442 @@ class Naomi(object):
         self.conversation = conversation.Conversation(
             self.mic, self.brain, self.config)
 
-    def list_plugins(self):
+    def list_active_plugins(self):
         plugins = self.plugins.get_plugins()
         len_name = max(len(info.name) for info in plugins)
         len_version = max(len(info.version) for info in plugins)
+        # Sort these alphabetically by name
+        plugins_sorted = {}
         for info in plugins:
-            print("%s %s - %s" % (info.name.ljust(len_name),
-                                  ("(v%s)" % info.version).ljust(len_version),
-                                  info.description))
+            plugins_sorted[info.name.lower()] = info
+        for name in sorted(plugins_sorted):
+            info = plugins_sorted[name]
+            print("{} {} - {}".format(
+                info.name.ljust(len_name),
+                ("(v%s)" % info.version).ljust(len_version),
+                info.description
+            ))
 
     def list_audio_devices(self):
         for device in self.audio.get_devices():
             device.print_device_info(
                 verbose=(self._logger.getEffectiveLevel() == logging.DEBUG))
+
+    # Functions for plugin management
+    def list_available_plugins(self, categories):
+        installed_plugins = {}
+        for category in self.plugins._categories_map:
+            # Get a list of installed plugins in each category
+            superclass = self.plugins._categories_map[category]
+            for info in self.plugins._plugins.values():
+                if issubclass(info.plugin_class, superclass):
+                    if(category not in installed_plugins):
+                        installed_plugins[category] = {}
+                    installed_plugins[category][info.name] = info.version
+        print("Available Plugins:")
+        # Get the list of available plugins:
+        # NaomiProject: https://raw.githubusercontent.com/NaomiProject/naomi-plugins/master/plugins.csv
+        # aaronchantrill: https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv
+        url = "https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv"
+        # It would be good if we could actually read the csv file line by line
+        # rather than reading it all into memory, but that might require some
+        # custom code. For right now, we'll use the python tools.
+        with urllib.request.urlopen(url) as f:
+            file_contents = f.read().decode('utf-8')
+        csvfile = csv.DictReader(
+            io.StringIO(file_contents),
+            delimiter=',',
+            quotechar='"'
+        )
+        print_plugins = {}
+        flat_cat = [y for x in categories for y in x]
+        for row in csvfile:
+            if len(flat_cat):
+                if(row["Category"] in [y for x in categories for y in x]):
+                    print_plugins[row["Name"].lower()] = row
+            else:
+                print_plugins[row["Name"].lower()] = row
+        if(len(print_plugins) == 0):
+            print("Sorry, no plugins matched")
+        else:
+            for name in sorted(print_plugins):
+                pluginstore.printplugin(print_plugins[name], installed_plugins)
+
+    # Right now what install_plugins does is git clone the plugin into the
+    # user's plugin dir (~/.naomi/plugins) and then run install.py if there
+    # is one, or python_requirements.txt if there is one.
+    def install_plugins(self, plugins):
+        flat_plugins = [y for x in plugins for y in x]
+        url = "https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv"
+        # It would be good if we could actually read the csv file line by line
+        # rather than reading it all into memory, but that might require some
+        # custom code. For right now, we'll use the python tools.
+        with urllib.request.urlopen(url) as f:
+            file_contents = f.read().decode('utf-8')
+        csvfile = csv.DictReader(io.StringIO(file_contents))
+        for row in csvfile:
+            # Keeps track of any failure inside the naming while loop
+            fail = False
+            if(row['Name'] in flat_plugins):
+                print('Installing {}...'.format(row['Name']))
+                # install it to the user's plugin directory
+                install_dir = paths.sub(
+                    os.path.join(
+                        'plugins',
+                        row['Category']
+                    )
+                )
+                # Make sure the install dir exists
+                if not os.path.isdir(install_dir):
+                    os.makedirs(install_dir)
+                # We aren't capturing the actual name of the directory.
+                # The name of the directory does not matter, so we should just
+                # create one. Replace any spaces in the plugin name with
+                # underscores.
+                install_name = re.sub('\W', '', re.sub('\s', '_', row['Name']))
+                install_to_base = os.path.join(install_dir, install_name)
+                install_to = install_to_base
+                rev = 0
+                installed_url = ""
+                while(os.path.isdir(install_to)):
+                    # Check if the git fetch url is the same. If so, then
+                    # this is the same plugin and just needs to be updated.
+                    # If not, then this is a different plugin, so rename the
+                    # install_to directory.
+                    installed_url = ""
+                    cmd = [
+                        "git",
+                        '-C', install_to,
+                        "remote", "-v"
+                    ]
+                    completed_process = run_command(cmd, 1)
+                    # # This is how you can get the URL from the info file
+                    # # instead of git:
+                    # installed_url = self.plugins.parse_plugin(install_to)
+
+                    # This could easily fail, if this directory is not
+                    # actually a git directory
+                    if(completed_process.returncode == 0):
+                        installed_url = completed_process.stdout.decode(
+                            "UTF-8"
+                        ).split("\n")[0].split("\t")[1].split()[0]
+                    if(strcmpci(
+                        installed_url,
+                        row['Repository']
+                    )):
+                        # It's the same plugin
+                        # Just go ahead and reset the head and do
+                        # a git pull origin.
+                        # The following assumes there is a master branch:
+                        cmd = [
+                            'git',
+                            '-C', install_to,
+                            'checkout',
+                            'master'
+                        ]
+                        completed_process = run_command(cmd, 2)
+                        if(completed_process.returncode == 0):
+                            # break out of the loop
+                            break
+                        else:
+                            print('Unable to reset plugin "{}": {}'.format(
+                                row['Name'],
+                                completed_process.stderr.decode("UTF-8")
+                            ))
+                            fail = True  # next line from csv
+                            break
+                        cmd = [
+                            'git',
+                            '-C', install_to,
+                            'pull',
+                            'origin'
+                        ]
+                        completed_process = run_command(cmd, 2)
+                        if(completed_process.returncode == 0):
+                            # break out of the while loop
+                            break
+                        else:
+                            print('Unable to update plugin "{}": {}'.format(
+                                row['Name'],
+                                completed_process.stderr.decode("UTF-8")
+                            ))
+                            fail = True  # next line from csv
+                            break
+                    else:
+                        rev += 1
+                        install_to = "_".join(install_to_base, str(rev))
+                if(fail):
+                    continue
+                if(not os.path.isdir(install_to)):
+                    cmd = [
+                        'git',
+                        'clone',
+                        row['Repository'],
+                        install_to
+                    ]
+                    completed_process = run_command(cmd, 2)
+                    if(completed_process.returncode != 0):
+                        print(completed_process.stderr.decode("UTF-8"))
+                if(os.path.isdir(install_to)):
+                    # checkout the specific commit
+                    cmd = [
+                        'git',
+                        '--git-dir={}/.git'.format(install_to),
+                        '--work-tree={}'.format(install_to),
+                        'checkout',
+                        row['Commit']
+                    ]
+                    completed_process = run_command(cmd, 2)
+                    if(completed_process.returncode != 0):
+                        print(completed_process.stderr.decode("UTF-8"))
+                        # At this point, we have a potentially rogue
+                        # copy of the plugin, with code that has not
+                        # been vetted.
+                        # A developer could easily force this condition
+                        # by simply deleting the vetted commit from their
+                        # repository. At that point, anyone who installed
+                        # the plugin would get whatever the current state
+                        # is.
+                        print("Failed to set head to the vetted commit")
+                        print("Deleting {}".format(install_to))
+                        shutil.rmtree(install_to)
+                    else:
+                        # check and see if there is an install.py file
+                        install_file = os.path.join(install_to, "install.py")
+                        if os.path.isfile(install_file):
+                            # run that
+                            run_command(install_file)
+                        else:
+                            required_file = os.path.join(
+                                install_dir,
+                                "python_required.txt"
+                            )
+                            if os.path.isfile(required_file):
+                                # Install any python packages required
+                                cmd = [
+                                    'pip3',
+                                    'install',
+                                    '--user',
+                                    '--requirement',
+                                    required_file
+                                ]
+                                run_command(cmd)
+                        # Since the plugin will request its own settings each
+                        # time it is run with settings missing, no need to set
+                        # that up now.
+                        self.plugins.detect_plugins()
+                        self.enable_plugins([[row['Name']]])
+                        print('Plugin "{}" installed to {}'.format(
+                            row['Name'],
+                            install_to
+                        ))
+
+    def update_plugins(self, plugins):
+        flat_plugins = [y for x in plugins for y in x]
+        url = "https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv"
+        if len(flat_plugins) == 0:
+            # Get a list of all the currently installed plugins
+            for info in self.plugins._plugins.values():
+                flat_plugins.append(info.name)
+        with urllib.request.urlopen(url) as f:
+            file_contents = f.read().decode('utf-8')
+        csvfile = csv.DictReader(io.StringIO(file_contents))
+        for row in csvfile:
+            if(row['Name'] in flat_plugins):
+                print("Updating {}".format(row["Name"]))
+                # Find the plugin
+                for info in self.plugins._plugins.values():
+                    if(info.name == row["Name"]):
+                        if(info.version == row['Version']):
+                            print(
+                                "{} versions identical, updating anyway".format(
+                                    row['Name']
+                                )
+                            )
+                        else:
+                            print("Updating {} from {} to {}".format(
+                                row["Name"],
+                                info.version,
+                                row["Version"]
+                            ))
+                        # There is some duplication of effort here.
+                        # Basically everything below this point
+                        # is identical to parts of the install
+                        # script. This could be solved by generating
+                        # an error if attempting to install a plugin
+                        # that is already installed rather than updating
+                        # it.
+                        plugin_dir = info._path
+                        # checkout the specific commit
+                        cmd = [
+                            'git',
+                            '--git-dir={}/.git'.format(plugin_dir),
+                            '--work-tree={}'.format(plugin_dir),
+                            'checkout',
+                            row['Commit']
+                        ]
+                        completed_process = run_command(cmd, 2)
+                        if(completed_process.returncode != 0):
+                            print(completed_process.stderr.decode("UTF-8"))
+                            # At this point, we have a potentially rogue
+                            # copy of the plugin, with code that has not
+                            # been vetted.
+                            # A developer could easily force this condition
+                            # by simply deleting the vetted commit from their
+                            # repository. At that point, anyone who installed
+                            # the plugin would get whatever the current state
+                            # is.
+                            print("Failed to set head to the vetted commit")
+                            print("Deleting {}".format(plugin_dir))
+                            shutil.rmtree(plugin_dir)
+                        else:
+                            # check and see if there is an install.py file
+                            install_file = os.path.join(
+                                plugin_dir,
+                                "install.py"
+                            )
+                            if os.path.isfile(install_file):
+                                # run that
+                                run_command(install_file)
+                            else:
+                                required_file = os.path.join(
+                                    plugin_dir,
+                                    "python_required.txt"
+                                )
+                                if os.path.isfile(required_file):
+                                    # Install any python packages required
+                                    cmd = [
+                                        'pip3',
+                                        'install',
+                                        '--user',
+                                        '--requirement',
+                                        required_file
+                                    ]
+                                    run_command(cmd)
+                            # Since the plugin will request its own settings
+                            # each time it is run with settings missing, no
+                            # need to set that up now.
+                            self.plugins.detect_plugins()
+                            self.enable_plugins([[row['Name']]])
+                            print('Plugin "{}" Updated'.format(row['Name']))
+
+    # I don't know what we want this to do. If this is a plugin in the user's
+    # directory, then delete it. If it is a directory in the main naomi dir,
+    # then disable it.
+    def remove_plugins(self, plugins):
+        flat_plugins = [y for x in plugins for y in x]
+        for plugin in flat_plugins:
+            plugin_found = False
+            for info in self.plugins._plugins.values():
+                if(info.name == plugin):
+                    plugin_found = True
+                    if(paths.sub() == info._path[:len(paths.sub())]):
+                        print('Removing plugin "{}"'.format(info.name))
+                        if(self._interface.simple_yes_no("Are you sure?")):
+                            # FIXME Remove the plugin line from profile.yml
+                            # This would require using del or pop to remove
+                            # the key, but would have to traverse the tree
+                            # until we reach the key first.
+                            print("Removing directory: {}".format(info._path))
+                            shutil.rmtree(info._path)
+                            plugin_category = info._path.split(os.path.sep)[
+                                len(info._path.split(os.path.sep)) - 2
+                            ]
+                            profile.remove_profile_var([
+                                'plugins',
+                                plugin_category,
+                                info.name
+                            ])
+                            profile.save_profile()
+                    else:
+                        self.disable_plugins([[info.name]])
+            if(not plugin_found):
+                print('Could not locate plugin "{}" ({})'.format(
+                    plugin,
+                    "has it been disabled?"
+                ))
+
+    def enable_plugins(self, plugins):
+        flat_plugins = [y for x in plugins for y in x]
+        plugins_enabled = 0
+        for plugin in flat_plugins:
+            plugin_enabled = False
+            # Being disabled, the plugin won't be in self.plugins
+            # We need to search every plugin category in profile.plugins
+            for category in profile.get_profile_var(['plugins']):
+                if(plugin in profile.get_profile_var(['plugins', category])):
+                    if(profile.get_profile_var([
+                        'plugins',
+                        category,
+                        plugin
+                    ]) == 'Enabled'):
+                        print('Plugin "{}" is enabled'.format(plugin))
+                        plugin_enabled = True
+                    else:
+                        profile.set_profile_var(
+                            [
+                                'plugins',
+                                category,
+                                plugin
+                            ],
+                            'Enabled'
+                        )
+                        print('Enabled plugin "{}"'.format(plugin))
+                        plugin_enabled = True
+                        plugins_enabled += 1
+            if(not plugin_enabled):
+                print('Unable to enable plugin "{}"'.format(plugin))
+        if(plugins_enabled > 0):
+            profile.save_profile()
+
+    def disable_plugins(self, plugins):
+        flat_plugins = [y for x in plugins for y in x]
+        plugins_disabled = 0
+        # We don't know what category the plugin is in from just the name
+        # so the first thing we have to do is figure out the category
+        plugin_category = None
+        # Being enabled, the plugin should appear in self.plugins
+        for plugin in flat_plugins:
+            plugin_disabled = False
+            for info in self.plugins._plugins.values():
+                if(info.name == plugin):
+                    plugin_category = info._path.split(os.path.sep)[
+                        len(info._path.split(os.path.sep)) - 2
+                    ]
+            if(not plugin_category):
+                # If we were not able to find the plugin in self.plugins
+                # check the profile directly. The plugin may have been skipped
+                # due to a syntax error or missing depenency.
+                for category in profile.get_profile_var(['plugins']):
+                    if(plugin in profile.get_profile_var([
+                        'plugins',
+                        category
+                    ])):
+                        plugin_category = category
+            if(plugin_category):
+                if(profile.get_profile_var([
+                    'plugins',
+                    plugin_category,
+                    plugin
+                ]) == 'Disabled'):
+                    print('Plugin "{}" is disabled'.format(plugin))
+                    plugin_disabled = True
+                else:
+                    profile.set_profile_var(
+                        [
+                            'plugins',
+                            plugin_category,
+                            plugin
+                        ],
+                        'Disabled'
+                    )
+                    print('Disabled plugin "{}"'.format(plugin))
+                    plugin_disabled = True
+                    plugins_disabled += 1
+            if(not plugin_disabled):
+                print('Unable to disable plugin "{}"'.format(plugin))
+        if(plugins_disabled > 0):
+            profile.save_profile()
 
     def run(self):
         self.conversation.askName()

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -508,11 +508,10 @@ class Naomi(object):
     def install_plugins(self, plugins):
         flat_plugins = [y for x in plugins for y in x]
         url = "https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv"
-        urlreq = urllib.request.Request(url)
         # It would be good if we could actually read the csv file line by line
         # rather than reading it all into memory, but that might require some
         # custom code. For right now, we'll use the python tools.
-        with urllib.request.urlopen(urlreq) as f:
+        with urllib.request.urlopen(urllib.request.Request(url)) as f:
             file_contents = f.read().decode('utf-8')
         csvfile = csv.DictReader(io.StringIO(file_contents))
         for row in csvfile:
@@ -675,12 +674,11 @@ class Naomi(object):
     def update_plugins(self, plugins):
         flat_plugins = [y for x in plugins for y in x]
         url = "https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv"
-        urlreq = urllib.request.Request(url)
         if len(flat_plugins) == 0:
             # Get a list of all the currently installed plugins
             for info in self.plugins._plugins.values():
                 flat_plugins.append(info.name)
-        with urllib.request.urlopen(urlreq) as f:
+        with urllib.request.urlopen(urllib.request.Request(url)) as f:
             file_contents = f.read().decode('utf-8')
         csvfile = csv.DictReader(io.StringIO(file_contents))
         for row in csvfile:

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -99,6 +99,10 @@ class Mic(object):
             # Get the slug from the engine
             if(sample_type.lower() == "active"):
                 engine = type(self.active_stt_engine).__name__
+                if(self.active_stt_engine._vocabulary_name != "default"):
+                    # we are in a special mode. We don't want to put words
+                    # from this sample into the default standard_phrases
+                    sample_type = self.active_stt_engine._vocabulary_name
             else:
                 # noise (empty transcript) response is only from passive engine
                 engine = type(self.passive_stt_engine).__name__

--- a/naomi/strcmpci.py
+++ b/naomi/strcmpci.py
@@ -1,0 +1,11 @@
+import unicodedata
+
+
+def strcmpci(str1, str2):
+    return unicodedata.normalize(
+        "NFKD",
+        str1.casefold()
+    ) == unicodedata.normalize(
+        "NFKD",
+        str2.casefold()
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In this pull request, I am attempting to add the ability to install plugins from the Naomi plugin store. Right now the store's URL is https://raw.githubusercontent.com/aaronchantrill/naomi-plugins/master/plugins.csv. I have a pull request in at the official NaomiProject/naomi_plugins project to update the CSV to the format that worked for me here.

The repository should probably be turned into a line in a configuration file somewhere so that people can easily change or add locations to get updates from. This is all pretty rudimentary right now. The error handling is pretty lacking, and a lot of the time it won't tell you that it was unable to find a plugin that you asked to install or upgrade, which should probably be addressed.

Added the following command-line arguments to Naomi.py:
--list-available-plugins [category] - pull a list of available plugins from the Naomi store csv. The user can opt to supply a category such as "tts" or "speechhandler" as a filter.
--install {plugin} - installs the requested plugin(s) using the Naomi store csv. It searches the repository for a plugin with the requested name, "git clone"s it into the user's ~/.naomi/plugins folder, then checks out the specific commit listed in the repository. Finally, enables the plugin if it has been disabled in the profile, and searches for an install.py file to run in the plugin's main folder, or a python-required.txt file to pip install.
--update {plugin} - updates a plugin to the newest version as listed in plugins.csv.
--remove {plugin} - deletes the directory the plugin was installed to. You definitely don't want to accidentally do this to a plugin you are developing. Should probably list the directory it is about to delete before it asks if you want to continue. Also should have a parameter indicating to skip the interaction so it can be used from the web GUI.
--enable - If the plugin is listed in the profile as "Disabled" change it to "Enabled". Otherwise, add the plugin to the profile and enable it.
--disable - If the plugin is listed in the profile as "Enabled" change it to "Disabled".
I also changed the --list-plugins argument to --list-active-plugins since it only lists plugins that are installed and loaded. Should probably take into account plugins that have been manually disabled.
I need to add test routines for all these options. That is what I plan to work on next, along with fixing any unittests that fail just because they are missing dependencies.

Here are the changes to specific files:
naomi/\_\_main\_\_.py -- Added arguments for plugin management
  Renamed --list-plugins to --list-active-plugins
  Redirected all the new arguments to routines in naomi/application.py

naomi/application.py -- added routines for handling plugin management.
  Some of this might be better handled in \_\_main\_\_.py. For instance,
  if you have your tts engine set to a plugin that you have disabled,
  the program will crash with a message about the plugin not being
  found before it processes the enable command. So if you have a disabled
  engine selected somewhere, you have to manually fixed that in profile.yml

naomi/mic.py -- when saving audio for training, if you are not using the
  default vocabulary, then capture the name of the special vocabulary you
  are using. This will allow adding appropriate words to the vocabulary list.

naomi/pluginstore.py -- added a routine for printing plugins for the plugin
  store. Added a routine to automatically add plugins to the profile.yml the
  first time they are loaded.

naomi/profile.py -- added a routine for removing a profile variable.
  Prevent the profile from being saved if it has not been loaded yet.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue #141 - Plugin discovery, install through Naomi](https://github.com/NaomiProject/Naomi/issues/141)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I would like to be able to publish my own plugins for Naomi without having to add them to the main Naomi project. I want to be able to discover other people's Naomi compatible plugins without having to search Github. I want to be able to install and uninstall these plugins quickly and easily. I wanted to start the process of figuring out what tools would be necessary to accomplish more complex installations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested on Raspbian Stretch x86 running on VirtualBox.

## Screenshots (if appropriate):
```
$ ./Naomi.py --local
************************************************************
*                    Naomi Assistant                       *
* Made by the Naomi Community, based on the Jasper Project *
* Source code available from                               *
*    https://github.com/NaomiProject/Naomi                 *
************************************************************
NAOMI: My name is NAOMI.
NAOMI: How can I be of service?
YOU: Thank you
NAOMI: My apologies, could you try saying that again?
YOU: shutdown
NAOMI: Shutting down.
Terminated

$ ./Naomi.py --list-available-plugins
************************************************************
*                    Naomi Assistant                       *
* Made by the Naomi Community, based on the Jasper Project *
* Source code available from                               *
*    https://github.com/NaomiProject/Naomi                 *
************************************************************
Available Plugins:
Control LED (speechhandler [1.0.0]) - A simple module that combines Naomi and the Arduino platform to show possibilities in IOT and new interactions.
googlecalendar (speechhandler [1.0.0]) - Set and retrieve events from your Google calendar
You're Welcome (speechhandler [0.0.1]) - Answers "Thank you" with "You're welcome"

$ ./Naomi.py --install "You're Welcome"
************************************************************
*                    Naomi Assistant                       *
* Made by the Naomi Community, based on the Jasper Project *
* Source code available from                               *
*    https://github.com/NaomiProject/Naomi                 *
************************************************************
Installing You're Welcome...
Plugin "You're Welcome" is enabled
Plugin "You're Welcome" installed to /home/pi/.naomi/plugins/speechhandler/Youre_Welcome

$ ./Naomi.py --local
************************************************************
*                    Naomi Assistant                       *
* Made by the Naomi Community, based on the Jasper Project *
* Source code available from                               *
*    https://github.com/NaomiProject/Naomi                 *
************************************************************
NAOMI: My name is NAOMI.
NAOMI: How can I be of service?
YOU: Thank you
NAOMI: You are welcome
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
