### PR TITLE
Naomi WebRTC Chunk Length

### DIFF
--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -403,15 +403,7 @@ def get_notification_info():
         text_choice = _("text").lower()[:1]
         print(
             "    " + interface.instruction_text(
-                _("Would you prefer to have notifications sent by")
-            )
-        )
-        print(
-            "    " + interface.instruction_text(
-                _("email ({e}) or text message ({t})?").format(
-                    e=email_choice.upper(),
-                    t=text_choice.upper()
-                )
+                _("How would you prefer to have notifications sent?")
             )
         )
         print("")
@@ -1011,18 +1003,8 @@ def get_tts_engine():
     }
     # Prepare the tts_plugins object so we can
     # instantiate and test the chosen plugin.
-    tts_plugins = pluginstore.PluginStore(
-        [os.path.join(
-            os.path.dirname(
-                os.path.dirname(
-                    os.path.abspath(__file__)
-                )
-            ),
-            "plugins",
-            "tts"
-        )]
-    )
-    tts_plugins.detect_plugins()
+    tts_plugins = pluginstore.PluginStore()
+    tts_plugins.detect_plugins("tts")
     voice_chosen = False
     while not voice_chosen:
         try:
@@ -1398,18 +1380,8 @@ def get_beep_or_voice():
 # Return a list of currently installed audio engines.
 def get_audio_engines():
     global audioengine_plugins
-    audioengine_plugins = pluginstore.PluginStore(
-        [os.path.join(
-            os.path.dirname(
-                os.path.dirname(
-                    os.path.abspath(__file__)
-                )
-            ),
-            "plugins",
-            "audioengine"
-        )]
-    )
-    audioengine_plugins.detect_plugins()
+    audioengine_plugins = pluginstore.PluginStore()
+    audioengine_plugins.detect_plugins("audioengine")
     audioengines = [
         ae_info.name
         for ae_info

--- a/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
@@ -347,19 +347,8 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                                 if phrase:
                                     phrases.append(phrase)
                     # Get all the phrases that the plugins are looking for
-                    # There are two locations where plugins can be stored,
-                    # either in the plugins directory, or in the
-                    # ~/.naomi/plugins/ directory.
-                    # Right now, we always put plugins directly into the
-                    # plugins directory, but when we get to the point where
-                    # Naomi can be installed as a package, we will want to
-                    # put user plugins into the user config directory when
-                    # using the plugin manager
-                    ps = pluginstore.PluginStore([
-                        paths.config("plugins"),
-                        "plugins"
-                    ])
-                    ps.detect_plugins()
+                    ps = pluginstore.PluginStore()
+                    ps.detect_plugins("speechhandler")
                     for info in ps.get_plugins_by_category("speechhandler"):
                         try:
                             plugin = info.plugin_class(

--- a/plugins/vad/snr_vad/snr_vad.py
+++ b/plugins/vad/snr_vad/snr_vad.py
@@ -56,7 +56,12 @@ class SNRPlugin(plugin.VADPlugin):
                 [key * value for key, value in self.distribution.items()]
             ) / items
             stddev = math.sqrt((sum1 - (items * (mean ** 2))) / (items - 1))
-            self._threshold = mean + (stddev * 1.5)
+            self._threshold = mean + (
+                stddev * profile.get(
+                    ['snr_vad', 'tolerance'],
+                    1
+                )
+            )
             if(self._logger.getEffectiveLevel() < logging.WARN):
                 print(
                     "\t".join([


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request implements a fix for sound cards that do not honor the
chunk size when set through the alsaaudio.PCM().setperiodsize(chunk_size)
function.

This specifically affects the Intel 82801AA-ICH card that VirtualBox
creates as a passthrough device from the virtual machine to the hardware,
but I have heard of others having the same trouble with certain hardware
sound cards.

In addition to providing guidance to set your input_chunksize to something
that will result in a 10, 20, or 30 ms chunk length, now the webrtcvad
plugin will attempt to "fix" a chunk which is not the correct length to
work with webrtcvad by cutting it down to the next smaller valid sample
length. So if your sound card insists on only returning chunks of length
682 (which is what VirtualBox was doing), it sees that a 20ms chunk at
16000Hz is 640bytes (16000 samples per second *.02 seconds * 2 bytes per
sample) and cuts the chunk down to the first 640 bytes before running
webrtcvad.is_speech() on it. Hopefully this will be helpful to someone.

I also fixed a small problem where populate.py was searching for
audioengine and stt plugins separate from the main plugin search, which
was causing the plugins: section of profile.py to create a small section
with an empty label that only contained them, because the way we were
searching for category specific plugins we were losing the category name.
This fixes it so you can pass a separate, optional "category" parameter
to pluginstore.detect_plugins(). This also makes the plugin_dirs
parameter optional since we generally always search the same two
locations for plugins.

Here are the files affected:

naomi/pluginstore.py - made plugin_dirs optional when instantiating a
PluginStore object. If nothing is passed in, then it defaults to
~/Naomi/plugins and ~/.naomi/plugins (or whatever the equivalents
are under the specific setup). Added an optional "category" parameter
to detect_plugins() so you can detect only a specific category of
plugins by just passing the name in without setting the specific
folder to search.

naomi/populate.py - changed the prompt for email or text message so
it didn't appear to be asking the question twice. Fixed the tts
and audioengine plugin searches so they didn't create ghost
entries in profile.yml.

plugins/stt_trainer/pocketsphinx_adapt/packetsphinx_adapt.py -
Changed to use the new PluginStore method for searching for
speechhandler plugins.

plugins/vad/snr_vad/snr_vad.py - changed the tolerance multiplier
to default to 1, but can now be set by the user through the
```
snr_vad: 
    tolerance: 
```
setting in profile.yml

plugins/vad/webrtc_vad/webrtc_vad.py - made it so that webrtc_vad
can truncate the chunk size to the next smaller allowed chunk size
if alsa is overriding the requested chunk size. Still demands that
the user sets the chunk size in profile.yml as that is still
optimal.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Documentation for "DeepSpeech setup" needs to be updated](https://github.com/NaomiProject/naomi-docs/issues/20)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It made it so I could use the webrtc_vad plugin with a problem sound card, also fixed a small problem when repopulating the profile where certain plugins were added to the profile twice.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on VirtualBox using Raspbian Stretch x86.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
