### PR TITLE
Language Variable Bugfix

### DIFF
--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -20,7 +20,7 @@ class GenericPlugin(object):
         if(not hasattr(self, '_logger')):
             self._logger = logging.getLogger(__name__)
         interface = commandline.commandline()
-        self.language = interface.get_language(once=True)
+        _ = interface.get_language(once=True)
         translations = i18n.parse_translations(paths.data('locale'))
         translator = i18n.GettextMixin(translations)
         _ = translator.gettext

--- a/plugins/tts/espeak-tts/espeak.py
+++ b/plugins/tts/espeak-tts/espeak.py
@@ -2,20 +2,21 @@ import collections
 import logging
 import pipes
 import re
-import subprocess
-import tempfile
 from naomi import diagnose
 from naomi import plugin
+from naomi.run_command import run_command
 
 if not diagnose.check_executable('espeak'):
     raise ImportError("espeak executable not found!")
 
 
-RE_PATTERN = re.compile(r'(?P<pty>\d+)\s+' +
-                        r'(?P<lang>[a-z-]+)\s+' +
-                        r'(?P<gender>[MF-])\s+' +
-                        r'(?P<name>[\w-]+)\s+\S+\s+' +
-                        r'(?P<other>(?:\([a-z-]+\s+\d+\))*)')
+RE_PATTERN = re.compile(''.join([
+    r'(?P<pty>\d+)\s+',
+    r'(?P<lang>[a-z-]+)\s+',
+    r'(?P<gender>[MF-])\s+',
+    r'(?P<name>[\w-]+)\s+\S+\s+',
+    r'(?P<other>(?:\([a-z-]+\s+\d+\))*)'
+]))
 RE_OTHER = re.compile(r'\((?P<lang>[a-z-]+)\s+(?P<pty>\d+)\)')
 
 Voice = collections.namedtuple(
@@ -79,8 +80,11 @@ class EspeakTTSPlugin(plugin.TTSPlugin):
         self.words_per_minute = words_per_minute
 
     def get_voices(self):
-        output = subprocess.check_output(['espeak', '--voices'])
-        output += subprocess.check_output(['espeak', '--voices=mbrola'])
+        output = run_command(['espeak', '--voices'], 1).stdout.decode("UTF-8")
+        output += run_command(
+            ['espeak', '--voices=mbrola'],
+            1
+        ).stdout.decode("UTF-8")
         voices = []
         for pty, lang, gender, name, other in RE_PATTERN.findall(output):
             voices.append(Voice(name=name, gender=gender,
@@ -92,16 +96,19 @@ class EspeakTTSPlugin(plugin.TTSPlugin):
         return sorted(voices, key=lambda voice: voice.priority)
 
     def say(self, phrase):
-        with tempfile.SpooledTemporaryFile() as out_f:
-            cmd = ['espeak', '-v', self.voice,
-                             '-p', self.pitch_adjustment,
-                             '-s', self.words_per_minute,
-                             '--stdout',
-                             phrase]
-            cmd = [str(x) for x in cmd]
-            self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
-                                                         for arg in cmd]))
-            subprocess.call(cmd, stdout=out_f)
-            out_f.seek(0)
-            data = out_f.read()
-            return data
+        cmd = [
+            'espeak',
+            '-v', self.voice,
+            '-p', self.pitch_adjustment,
+            '-s', self.words_per_minute,
+            '--stdout',
+            phrase
+        ]
+        cmd = [str(x) for x in cmd]
+        self._logger.debug(
+            'Executing %s', ' '.join(
+                [pipes.quote(arg) for arg in cmd]
+            )
+        )
+        data = run_command(cmd, 1).stdout
+        return data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pull Request #196 NaomiSTTTrainer added some gettext functions to
naomi/plugin.py. To make sure that language was configured, I
added the line self.language=interface.get_language().

Unfortunately, that was incompatible with witai-stt. That plugin
defined it's own language property using @property but did not
set a setter, so it was impossible to set that property. The
solution was to either give that property a setter, delete the
getter, or just change the line in plugin.py to
language=interface.get_language()
since I'm not really using the language variable outsite of
the init anyway. WitAI also does not appear to be using its
"language" variable.

Also included in this bugfix is a fix for espeak. If you had
not set a voice for that TTS plugin, the get_voices() method
was trying to figure out the best voice for you based on your
language, but was trying to use regex on a binary object
returned by the subprocess method, which was blowing up. This
seems to be an aftereffect of the conversion to Python3.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Bugfix

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since one of the plugins used a language property without a setter, my language property was causing a conflict with it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Raspbian Stretch x86

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
