### PR TITLE
VAD Visualization

### DIFF
--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -20,7 +20,7 @@ t = None
 def println(string):
     # check and see if string ends with a line feed
     addCR = False
-    matchgroups = re.match('^(.*)\n$',string,re.MULTILINE)
+    matchgroups = re.match('^(.*)\n$', string, re.MULTILINE)
     if(matchgroups):
         string = matchgroups.groups(0)[0]
         addCR = True
@@ -30,7 +30,7 @@ def println(string):
     except TypeError:
         columns = 79
     sys.stdout.write("{}{}\r".format(
-        string," "*(columns-len(string)))
+        string, " " * (columns - len(string)))
     )
     if(addCR):
         sys.stdout.write("\n")

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -1,15 +1,40 @@
+from blessings import Terminal
+from getpass import getpass
 from naomi import i18n
 from naomi import paths
 from naomi import profile
-from getpass import getpass
 import re
-from blessings import Terminal
+import sys
+
 
 _ = None
 affirmative = ""
 negative = ""
 audioengine_plugins = None
 t = None
+
+
+# This method gives me a way to print to the terminal while
+# the SNRVAD is providing a visualization of how Naomi is
+# listening
+def println(string):
+    # check and see if string ends with a line feed
+    addCR = False
+    matchgroups = re.match('^(.*)\n$',string,re.MULTILINE)
+    if(matchgroups):
+        string = matchgroups.groups(0)[0]
+        addCR = True
+    # clear the current line
+    try:
+        columns = t.width - 1
+    except TypeError:
+        columns = 79
+    sys.stdout.write("{}{}\r".format(
+        string," "*(columns-len(string)))
+    )
+    if(addCR):
+        sys.stdout.write("\n")
+    sys.stdout.flush()
 
 
 class commandline(object):

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from . import alteration
-from . import paths
-from . import profile
 from datetime import datetime
+from naomi.commandline import println
+from naomi import alteration
+from naomi import paths
+from naomi import profile
 import audioop
 import contextlib
 import logging
@@ -16,7 +17,6 @@ class Mic(object):
     """
     The Mic class handles all interactions with the microphone and speaker.
     """
-
     def __init__(
         self,
         input_device,
@@ -258,7 +258,7 @@ class Mic(object):
                 else:
                     if(len(transcribed)):
                         if(self._print_transcript):
-                            print("<  {}".format(transcribed))
+                            println("<  {}\n".format(transcribed))
                             self._log_audio(f, transcribed, "passive")
                         if any([
                             keyword.lower() in t.lower()
@@ -275,7 +275,7 @@ class Mic(object):
                                     self._logger.error("Active transcription failed!", exc_info=dbg)
                                 else:
                                     if(self._print_transcript):
-                                        print("<< {}".format(transcribed))
+                                        println("<< {}\n".format(transcribed))
                                     if(self._save_active_audio):
                                         self._log_audio(f, transcribed, "active")
                                 return transcribed
@@ -283,7 +283,7 @@ class Mic(object):
                                 return False
                     else:
                         if(self._print_transcript):
-                            print("<  <noise>")
+                            println("<  <noise>\n")
                             self._log_audio(f, "", "noise")
 
     def active_listen(self, timeout=3):
@@ -311,7 +311,7 @@ class Mic(object):
                 self._logger.error("Active transcription failed!", exc_info=dbg)
             else:
                 if(self._print_transcript):
-                    print("<< {}".format(transcribed))
+                    println("<< {}\n".format(transcribed))
                     self._log_audio(f, transcribed, "active")
         return transcribed
 
@@ -333,7 +333,7 @@ class Mic(object):
 
     def say(self, phrase):
         if(self._print_transcript):
-            print(">> {}".format(phrase))
+            println(">> {}\n".format(phrase))
         altered_phrase = alteration.clean(phrase)
         with tempfile.SpooledTemporaryFile() as f:
             f.write(self.tts_engine.say(altered_phrase))

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -167,18 +167,21 @@ class TTSPlugin(GenericPlugin):
 
 
 class VADPlugin(GenericPlugin):
+    # timeout is seconds of audio to capture before first
+    # and after last voice detected
+    # minimum capture is minimum audio to capture, minus the padding
+    # at the front and end
     def __init__(self, input_device, timeout=1, minimum_capture=0.5):
         self._logger = logging.getLogger(__name__)
         # input device
         self._input_device = input_device
         # Here is the number of frames that have to pass without
         # detecing a voice before we respond
-        chunklength = input_device._input_rate / input_device._input_chunksize
-        self._timeout = round(chunklength * timeout)
+        chunklength = input_device._input_chunksize / input_device._input_rate
+        self._timeout = round(timeout / chunklength)
         # Mimimum capture frames is the smallest number of frames that will
-        # be recognized as audio. I'm setting this to 1/2 second longer than
-        # the timeout value.
-        self._minimum_capture = round(chunklength * (timeout + minimum_capture))
+        # be recognized as audio.
+        self._minimum_capture = round((timeout + minimum_capture) / chunklength)
         ct = input_device._input_chunksize / input_device._input_rate
         self._chunktime = ct
 
@@ -190,6 +193,7 @@ class VADPlugin(GenericPlugin):
 
     def get_audio(self):
         frames = collections.deque([], 30)
+        last_voice_frame = 0
         recording = False
         recording_frames = []
         self._logger.info("Waiting for voice data")
@@ -200,7 +204,7 @@ class VADPlugin(GenericPlugin):
             self._input_device._input_rate
         ):
             frames.append(frame)
-            voice_detected = self._voice_detected(frame, recording)
+            voice_detected = self._voice_detected(frame, recording=recording)
             if not recording:
                 if(voice_detected):
                     # Voice activity detected, start recording and use
@@ -212,7 +216,7 @@ class VADPlugin(GenericPlugin):
                     )
                     recording = True
                     # Include the previous 10 frames in the recording.
-                    recording_frames = list(frames)[-10:]
+                    recording_frames = list(frames)[-self._timeout:]
                     last_voice_frame = len(recording_frames)
             else:
                 # We're recording

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -185,7 +185,7 @@ class VADPlugin(GenericPlugin):
     # Override the _voice_detected method with your own method for
     # detecting whether a voice is detected or not. Return True if
     # you detect a voice, otherwise False.
-    def _voice_detected(self, frame):
+    def _voice_detected(self, *args, **kwargs):
         pass
 
     def get_audio(self):
@@ -200,7 +200,7 @@ class VADPlugin(GenericPlugin):
             self._input_device._input_rate
         ):
             frames.append(frame)
-            voice_detected = self._voice_detected(frame)
+            voice_detected = self._voice_detected(frame, recording)
             if not recording:
                 if(voice_detected):
                     # Voice activity detected, start recording and use

--- a/plugins/vad/snr_vad/snr_vad.py
+++ b/plugins/vad/snr_vad/snr_vad.py
@@ -12,6 +12,8 @@
 # recording stops. If the total length of the recording is
 # over twice the length of timeout, then the recorded audio
 # is returned for processing.
+from blessings import Terminal
+from naomi.commandline import println
 from naomi import plugin
 from naomi import profile
 import audioop
@@ -22,7 +24,7 @@ import math
 class SNRPlugin(plugin.VADPlugin):
     def __init__(self, *args, **kwargs):
         input_device = args[0]
-        timeout = profile.get_profile_var(["snr_vad", "timeout"], 1)
+        timeout = profile.get_profile_var(["snr_vad", "timeout"], 10)
         minimum_capture = profile.get_profile_var(
             ["snr_vad", "minimum_capture"],
             0.5
@@ -35,7 +37,11 @@ class SNRPlugin(plugin.VADPlugin):
         # Keep track of the number of audio levels
         self.distribution = {}
 
-    def _voice_detected(self, frame):
+    def _voice_detected(self, *args, **kwargs):
+        frame = args[0]
+        recording = False
+        if "recording" in kwargs:
+            recording = kwargs["recording"]
         rms = audioop.rms(frame, int(self._input_device._input_bits / 8))
         if rms > 0 and self._threshold > 0:
             snr = round(20.0 * math.log(rms / self._threshold, 10))
@@ -62,20 +68,21 @@ class SNRPlugin(plugin.VADPlugin):
                     1
                 )
             )
-            if(self._logger.getEffectiveLevel() < logging.WARN):
-                print(
-                    "\t".join([
-                        "snr: {}",
-                        "threshold: {}",
-                        "mean: {}",
-                        "deviation: {}"
-                    ]).format(
-                        snr,
-                        round(self._threshold),
-                        round(mean),
-                        round(stddev)
-                    )
-                )
+            # We'll say that the max possible value for SNR is mean+3*stddev
+            #displaywidth = shutil.get_terminal_size((80, 20)).columns - 6
+            displaywidth = Terminal().width - 7
+            # print("displaywidth: {}".format(displaywidth))
+            maxsnr=mean+3*stddev
+            if snr>maxsnr:
+                maxsnr=snr
+            feedback = ["+"] if recording else ["-"]
+            feedback.extend(list("||" + ("="*int(displaywidth*(snr/maxsnr)))+("-"*int(displaywidth*((maxsnr-snr)/maxsnr)))+"|| "))
+            # insert markers for mean and threshold
+            if(mean<maxsnr):
+                feedback[int(displaywidth*(mean/maxsnr))]='m'
+            if(self._threshold<maxsnr):
+                feedback[int(displaywidth*(self._threshold/maxsnr))]='t'
+            println("".join(feedback))
         if(items > 100):
             # Every 100 samples, rescale, allowing changes in
             # the environment to be recognized more quickly.

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -61,7 +61,6 @@ class WebRTCPlugin(plugin.VADPlugin):
 
     def _voice_detected(self, *args, **kwargs):
         frame = args[0]
-        recording = False
         self._logger.info("Frame length: {} bytes".format(len(frame)))
         # The frame length must be either .01, .02 or .02 ms.
         # Sometimes the audio card will refuse to obey the chunksize

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -13,7 +13,7 @@ class WebRTCPlugin(plugin.VADPlugin):
     def __init__(self, *args):
         self._logger = logging.getLogger(__name__)
         input_device = args[0]
-        timeout = profile.get_profile_var(["webrtc_vad", "timeout"], 1)
+        timeout = profile.get_profile_var(["webrtc_vad", "timeout"], 10)
         minimum_capture = profile.get_profile_var(
             ["webrtc_vad", "minimum_capture"],
             0.25
@@ -59,7 +59,11 @@ class WebRTCPlugin(plugin.VADPlugin):
                 )
             )
 
-    def _voice_detected(self, frame):
+    def _voice_detected(self, *args, **kwargs):
+        frame = args[0]
+        recording = False
+        if "recording" in kwargs:
+            recording = kwargs["recording"]
         self._logger.info("Frame length: {} bytes".format(len(frame)))
         # The frame length must be either .01, .02 or .02 ms.
         # Sometimes the audio card will refuse to obey the chunksize

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -13,7 +13,7 @@ class WebRTCPlugin(plugin.VADPlugin):
     def __init__(self, *args):
         self._logger = logging.getLogger(__name__)
         input_device = args[0]
-        timeout = profile.get_profile_var(["webrtc_vad", "timeout"], 10)
+        timeout = profile.get_profile_var(["webrtc_vad", "timeout"], 1)
         minimum_capture = profile.get_profile_var(
             ["webrtc_vad", "minimum_capture"],
             0.25
@@ -62,8 +62,6 @@ class WebRTCPlugin(plugin.VADPlugin):
     def _voice_detected(self, *args, **kwargs):
         frame = args[0]
         recording = False
-        if "recording" in kwargs:
-            recording = kwargs["recording"]
         self._logger.info("Frame length: {} bytes".format(len(frame)))
         # The frame length must be either .01, .02 or .02 ms.
         # Sometimes the audio card will refuse to obey the chunksize


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request is to add a display to the snr_vad voice
activity detection engine, which is the default for Naomi.

Sometimes it is difficult to tell what Naomi is doing as far
as listening. Sometimes when it does not respond right away it
is because it didn't realize you were speaking. Sometimes it is
because it has not realized that you have stopped speaking yet.
And sometimes it just didn't recognize any words in what it
heard. This provides some visual feedback. I suggest using it
together with the print_transcript and passive_listen options
for the best overall experience.

The goal is not to rely on this to provide visual feedback, but
to provide feedback so that we can improve Naomi's responsiveness
to the point where the feedback is no longer necessary.

naomi/commandline.py - Added a new "println" function that is used by the
snr_vad and naomi_transcript when printing to the display. Rather than
constantly adding new lines and scrolling up, this tries to print the full
display width, adding spaces after whatever is being printed to cover the
current line.

If you want to print to the screen and there might be something on that
line already, then you should use the commandline.println() function.
Because this is used to print to the line and then go back to print on
the same line again, you should put a "\n" line feed at the end of any
string you want to stay up on the screen.

naomi/mic.py - switched to using the new println function when printing
the transcript of your conversation with naomi to the screen.

naomi/plugin.py - added "recording" as a boolean parameter to the call
to voice_detected, so that I could display a character to show whether
Naomi is recording or not. Also made some tweaks for the calculations
of timeouts, which appear to have provided a performance boost.

plugins/vad/snr_vad/snr_vad.py - changed the _voice_detected method
to use *args and **kwargs so I could receive the "recording" parameter
if passed in. Finally, this is where the actual display is built and shown.

plugins/vad/webrtc_vad/webrtc_vad.py - changed the _voice_detected
method to use *args and **kwargs to bring it in line with snr_vad.py, 
even though I'm not adding a display here. I should be able to at some
point. In this case I don't have so much information available about what
the vad engine is doing, but I could at least create a display of showing
when recording begins and how long it goes before ending.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#206 Better visualization for VAD](https://github.com/NaomiProject/Naomi/issues/206)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I have had trouble understanding when Naomi is listening. Sometimes when I say something and Naomi does not react right away, I don't know if Naomi didn't hear me, or is still recording, or didn't recognize any words in what I said. This can be especially frustrating when not using "passive_listening" and the audio is being clipped in such a way that Naomi is unable to understand its own name. In that case, it will simply refuse to respond no matter what you do.

The "print_transcript" setting helps, so I can see when Naomi has rejected a recording as noise, or exactly what it understood what I said as ("I'm sorry, could you repeat that?" does not tell me much about what Naomi heard) but this change will allow me to see more clearly when Naomi is or is not recording.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Debian Buster x86_64

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
