### PR TITLE
Fixed vad visualization when snr goes negative

### DIFF
--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -2,6 +2,7 @@
 import random
 from naomi import plugin, profile
 import subprocess
+import time
 
 
 class ShutdownPlugin(plugin.SpeechHandlerPlugin):
@@ -32,6 +33,11 @@ class ShutdownPlugin(plugin.SpeechHandlerPlugin):
         message = random.choice(messages)
 
         mic.say(message)
+        # specifically wait for Naomi to finish talking
+        # here, otherwise it will exit before getting to
+        # speak.
+        while( mic.current_thread.is_alive() ):
+            time.sleep(1)
 
         proc = subprocess.Popen(["pkill", "-f", "Naomi.py"],
                                 stdout=subprocess.PIPE)

--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -36,7 +36,7 @@ class ShutdownPlugin(plugin.SpeechHandlerPlugin):
         # specifically wait for Naomi to finish talking
         # here, otherwise it will exit before getting to
         # speak.
-        while( mic.current_thread.is_alive() ):
+        while(mic.current_thread.is_alive()):
             time.sleep(1)
 
         proc = subprocess.Popen(["pkill", "-f", "Naomi.py"],

--- a/plugins/vad/snr_vad/snr_vad.py
+++ b/plugins/vad/snr_vad/snr_vad.py
@@ -23,7 +23,7 @@ import math
 class SNRPlugin(plugin.VADPlugin):
     _maxsnr = None
     _minsnr = None
-    
+
     def __init__(self, *args, **kwargs):
         input_device = args[0]
         timeout = profile.get_profile_var(["snr_vad", "timeout"], 1)
@@ -88,7 +88,7 @@ class SNRPlugin(plugin.VADPlugin):
                 self._minsnr = minsnr
             snrrange = self._maxsnr - self._minsnr
             if snrrange == 0:
-                snrrange = 1 # to avoid divide by zero below
+                snrrange = 1  # to avoid divide by zero below
             feedback = ["+"] if recording else ["-"]
             feedback.extend(
                 list("".join([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I didn't realize that the Signal to Noise Ratio can go
negative on some sound cards. This was causing the display
to grow to more than the size of the terminal window,
resulting in the line wrapping and scrolling. This would
also cause the median and threshold markers to appear in
the wrong place. Also changed the print(phrase) to
the SNR visualization friendly println(phrase) in mic.say().

Fixed the mic.play_file() method to work with the
asnychronous say_thread method, otherwise if Naomi tried
to play a beep or boop to indicate listening but was
already speaking, an error would occur (at least when using
the alsa audio engine). Added visual beep and boop markers
to active_listen when "--print-transcript" option is enabled
to indicate "beep_hi.wav" and "beep_lo.wav".

Added a wait loop to shutdown.py so Naomi can finish
talking before actually shutting down. I feel like I've
done this before, but somehow it doesn't seem to be in
the latest git source.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#209 SNR_VAD Visualizer does not work with negative SNR's](https://github.com/NaomiProject/Naomi/issues/209)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is meant to display a volume indicator as a line across the bottom of the terminal window, using carriage returns instead of line feeds to constantly overwrite itself.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a raspberry pi 3B+ using a [usb conference phone](https://smile.amazon.com/gp/product/B078RJK4FW)
Used the standard unittest with discover:
```terminal
$ python3 -m unittest discover
ss....ssssssssssss...........sss..This STT plugin doesn't have multilanguage support!
This STT plugin doesn't have multilanguage support!
.This STT plugin doesn't have multilanguage support!
This STT plugin doesn't have multilanguage support!
..s
----------------------------------------------------------------------
Ran 38 tests in 4.950s

OK (skipped=18)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
