### PR TITLE
Visualizations

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -3,7 +3,6 @@ import csv
 import io
 import logging
 import os
-import pkg_resources
 import re
 import shutil
 import urllib
@@ -20,6 +19,7 @@ from . import profile
 from .run_command import run_command
 from . import local_mic
 from . import batch_mic
+from . import visualizations
 from .strcmpci import strcmpci
 
 USE_STANDARD_MIC = 0
@@ -190,12 +190,11 @@ class Naomi(object):
                     ['audiolog', 'save_noise']
                 )
         # Load plugins
-        plugin_directories = [
-            paths.sub('plugins'),
-            pkg_resources.resource_filename(__name__, '../plugins')
-        ]
-        self.plugins = pluginstore.PluginStore(plugin_directories)
+        self.plugins = pluginstore.PluginStore()
         self.plugins.detect_plugins()
+
+        # load visualizations
+        visualizations.load_visualizations(self)
 
         # Initialize AudioEngine
         ae_info = self.plugins.get_plugin(
@@ -462,8 +461,7 @@ class Naomi(object):
 
     # This is a standardized function for getting all the plugins available
     # from all the repositories the user has enabled in their profile
-    @staticmethod
-    def get_remote_plugin_repositories(plugins=None):
+    def get_remote_plugin_repositories(self, plugins=None):
         csvfile = []
         repositories = profile.get(
             ['plugin_repositories'],
@@ -471,6 +469,7 @@ class Naomi(object):
         )
         for url in repositories:
             if repositories[url] == 'Enabled':
+                self._logger.info("Reading {}".format(url))
                 # It would be good if we could actually read the csv file line
                 # by line rather than reading it all into memory, but that
                 # might require some custom code. For right now, we'll use the

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -278,20 +278,30 @@ class commandline(object):
 
     # AaronC Sept 18 2018 This uses affirmative/negative to ask
     # a yes/no question. Returns True for yes and False for no.
-    def simple_yes_no(self, prompt):
+    def simple_yes_no(self, prompt, default=None):
         response = ""
-        while(response not in (affirmative.lower()[:1], negative.lower()[:1])):
+        # Make it so the default value is upper case and the non-default value
+        # is lower case
+        choice_affirmative = affirmative[:1].lower()
+        choice_negative = negative[:1].lower()
+        if default:
+            if default[:1].lower() == affirmative[:1].lower():
+                choice_affirmative = affirmative[:1].upper()
+            if default[:1].lower() == negative[:1].lower():
+                choice_negative = negative[:1].upper()
+        while(response[:1] not in (affirmative.lower()[:1], negative.lower()[:1])):
             response = self.simple_input(
                 self.format_prompt(
                     "?",
                     prompt + self.instruction_text(" (") + self.choices_text(
-                        affirmative.upper()[:1]
+                        choice_affirmative
                     ) + self.instruction_text("/") + self.choices_text(
-                        negative.upper()[:1]
+                        choice_negative
                     ) + self.instruction_text(")")
-                )
-            ).strip().lower()[:1]
-            if response not in (affirmative.lower()[:1], negative.lower()[:1]):
+                ),
+                default
+            ).strip().lower()
+            if response[:1] not in (affirmative.lower()[:1], negative.lower()[:1]):
                 print(self.alert_text("Please select '{}' or '{}'.").format(
                     affirmative.upper()[:1],
                     negative.upper()[:1]
@@ -394,6 +404,13 @@ class commandline(object):
                         setting,
                         response
                     )
+            elif(controltype == "boolean"):
+                value = profile.get_profile_flag(setting, default)
+                response = value
+                once = False
+                while not (once):
+                    once = True
+                    tmp_response = self.simple_yes_no(definition['title'], response)
             else:
                 # this is the default (textbox)
                 print("")

--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -1,37 +1,35 @@
 # -*- coding: utf-8 -*-
 import logging
-from . import paths
 from . import i18n
+from . import paths
+from . import profile
 #  from notifier import Notifier
 
 
 class Conversation(i18n.GettextMixin):
-    def __init__(self, mic, brain, profile):
+    def __init__(self, mic, brain, *args, **kwargs):
         translations = i18n.parse_translations(paths.data('locale'))
         i18n.GettextMixin.__init__(self, translations, profile)
         self._logger = logging.getLogger(__name__)
         self.mic = mic
-        self.profile = profile
         self.brain = brain
-        self.translations = {
-
-        }
         #  self.notifier = Notifier(profile)
+        self.translations = {}
 
     # Add way for the system to ask for name if is not found in the config
     def askName(self):
-        if 'keyword' in self.profile:
+        if profile.get(['keyword']):
             salutation = self.gettext("My name is {}.").format(
-                self.profile['keyword']
+                profile.get(['keyword'])
             )
         else:
             salutation = self.gettext("My name is Naomi")
         self.mic.say(salutation)
 
     def greet(self):
-        if 'first_name' in self.profile:
+        if profile.get(['first_name']):
             salutation = self.gettext("How can I be of service, {}?").format(
-                self.profile["first_name"]
+                profile.get(["first_name"])
             )
         else:
             salutation = self.gettext("How can I be of service?")

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -249,3 +249,11 @@ class VADPlugin(GenericPlugin):
 
 class STTTrainerPlugin(GenericPlugin):
     pass
+
+
+class TTIPlugin(GenericPlugin):
+    pass
+
+
+class VisualizationsPlugin(GenericPlugin):
+    pass

--- a/naomi/pluginstore.py
+++ b/naomi/pluginstore.py
@@ -205,10 +205,12 @@ class PluginStore(object):
         self._categories_map = {
             'audioengine': plugin.AudioEnginePlugin,
             'speechhandler': plugin.SpeechHandlerPlugin,
+            'tti': plugin.TTIPlugin,
             'tts': plugin.TTSPlugin,
             'stt': plugin.STTPlugin,
             'stt_trainer': plugin.STTTrainerPlugin,
-            'vad': plugin.VADPlugin
+            'vad': plugin.VADPlugin,
+            'visualizations': plugin.VisualizationsPlugin
         }
 
     def detect_plugins(self, category=None):

--- a/naomi/visualizations.py
+++ b/naomi/visualizations.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+_visualizations = []
+
+
+def load_visualizations(self):
+    # Inititalize Visualizations
+    global _visualizations
+    for info in self.plugins.get_plugins_by_category('visualizations'):
+        try:
+            _visualizations.append(info.plugin_class(info, self.config))
+        except Exception as e:
+            self._logger.warning(
+                "Plugin '%s' skipped! (Reason: %s)", info.name,
+                e.message if hasattr(e, 'message') else 'Unknown',
+                exc_info=(
+                    self._logger.getEffectiveLevel() == logging.DEBUG
+                )
+            )
+
+
+def run_visualization(visualization_name, *args, **kwargs):
+    # the name of the visualization being run will be the first parameter,
+    # followed by any parameters for the visualization
+    for plugin in _visualizations:
+        if visualization_name in dir(plugin):
+            visualization = getattr(plugin, visualization_name)
+            visualization(*args, **kwargs)

--- a/plugins/audioengine/pyaudio-ae/pyaudioengine.py
+++ b/plugins/audioengine/pyaudio-ae/pyaudioengine.py
@@ -140,7 +140,8 @@ class PyAudioDevice(plugin.audioengine.AudioDevice):
         except ValueError as e:
             if e.args in (('Sample format not supported', -9994),
                           ('Invalid sample rate', -9997),
-                          ('Invalid number of channels', -9998)):
+                          ('Invalid number of channels', -9998),
+                          ('Device unavailable', -9985)):
                 return False
             else:
                 raise

--- a/plugins/speechhandler/clock/clock.py
+++ b/plugins/speechhandler/clock/clock.py
@@ -20,10 +20,10 @@ class ClockPlugin(plugin.SpeechHandlerPlugin):
         tz = app_utils.get_timezone(self.profile)
         now = datetime.datetime.now(tz=tz)
         if now.minute == 0:
-            fmt = "It is {t:%l} {t:%p} right now."
+            fmt = self.gettext("It is {t:%l} {t:%p} right now.")
         else:
-            fmt = "It is {t:%l}:{t:%M} {t:%p} right now."
-        mic.say(self.gettext(fmt).format(t=now))
+            fmt = self.gettext("It is {t:%l}:{t:%M} {t:%p} right now.")
+        mic.say(fmt.format(t=now))
 
     def is_valid(self, text):
         """

--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import random
-from naomi import plugin, profile
-import subprocess
 import time
+from naomi import plugin
+from naomi import profile
 
 
 class ShutdownPlugin(plugin.SpeechHandlerPlugin):
@@ -39,9 +39,7 @@ class ShutdownPlugin(plugin.SpeechHandlerPlugin):
         while(mic.current_thread.is_alive()):
             time.sleep(1)
 
-        proc = subprocess.Popen(["pkill", "-f", "Naomi.py"],
-                                stdout=subprocess.PIPE)
-        proc.wait()
+        quit()
 
     def is_valid(self, text):
         """

--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -2,6 +2,7 @@
 import random
 from naomi import plugin, profile
 import subprocess
+import time
 
 
 class ShutdownPlugin(plugin.SpeechHandlerPlugin):
@@ -32,6 +33,11 @@ class ShutdownPlugin(plugin.SpeechHandlerPlugin):
         message = random.choice(messages)
 
         mic.say(message)
+        # specifically wait for Naomi to finish talking
+        # here, otherwise it will exit before getting to
+        # speak.
+        while( mic.current_thread.is_alive() ):
+            time.sleep(1)
 
         proc = subprocess.Popen(["pkill", "-f", "Naomi.py"],
                                 stdout=subprocess.PIPE)

--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -36,7 +36,7 @@ class ShutdownPlugin(plugin.SpeechHandlerPlugin):
         # specifically wait for Naomi to finish talking
         # here, otherwise it will exit before getting to
         # speak.
-        while( mic.current_thread.is_alive() ):
+        while(mic.current_thread.is_alive()):
             time.sleep(1)
 
         proc = subprocess.Popen(["pkill", "-f", "Naomi.py"],

--- a/plugins/speechhandler/wwis_weather/wwis_weather.py
+++ b/plugins/speechhandler/wwis_weather/wwis_weather.py
@@ -74,7 +74,7 @@ class WWISWeatherPlugin(plugin.SpeechHandlerPlugin):
         # Set the language used for the location data
         language = profile.get_profile_var(["language"], "en")[:2]
         url = "https://worldweather.wmo.int/en/json/Country_{}.xml".format(language)
-        response = requests.get(url)
+        response = requests.get(url, timeout=2)
         jsondoc = str(response.content, 'utf-8')
         self.locationdata = json.loads(jsondoc)
         # Make a list of locations

--- a/plugins/vad/snr_vad/snr_vad.py
+++ b/plugins/vad/snr_vad/snr_vad.py
@@ -23,7 +23,7 @@ import math
 class SNRPlugin(plugin.VADPlugin):
     _maxsnr = None
     _minsnr = None
-    
+
     def __init__(self, *args, **kwargs):
         input_device = args[0]
         timeout = profile.get_profile_var(["snr_vad", "timeout"], 1)
@@ -88,7 +88,7 @@ class SNRPlugin(plugin.VADPlugin):
                 self._minsnr = minsnr
             snrrange = self._maxsnr - self._minsnr
             if snrrange == 0:
-                snrrange = 1 # to avoid divide by zero below
+                snrrange = 1  # to avoid divide by zero below
             feedback = ["+"] if recording else ["-"]
             feedback.extend(
                 list("".join([

--- a/plugins/visualizations/terminal/__init__.py
+++ b/plugins/visualizations/terminal/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .terminal import TerminalVisualizationsPlugin

--- a/plugins/visualizations/terminal/plugin.info
+++ b/plugins/visualizations/terminal/plugin.info
@@ -1,0 +1,10 @@
+[Plugin]
+Name = Terminal Visualizations
+Version = 1.0.0
+License = MIT
+URL = http://naomiproject.github.io/
+Description = Visualizations of Naomi's internal state for the terminal
+
+[Author]
+Name = Naomi Project
+URL = http://naomiproject.github.io/

--- a/plugins/visualizations/terminal/terminal.py
+++ b/plugins/visualizations/terminal/terminal.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from blessings import Terminal
+from naomi.commandline import println
+from naomi import plugin
+import pdb
+
+
+class TerminalVisualizationsPlugin(plugin.VisualizationsPlugin):
+    def mic_volume(self, *args, **kwargs):
+        try:
+            recording = kwargs['recording']
+            snr = kwargs['snr']
+            minsnr = kwargs['minsnr']
+            maxsnr = kwargs['maxsnr']
+            mean = kwargs['mean']
+            threshold = kwargs['threshold']
+        except KeyError:
+            return
+        try:
+            displaywidth = Terminal().width - 6
+        except TypeError:
+            displaywidth = 20
+        snrrange = maxsnr - minsnr
+        if snrrange == 0:
+            snrrange = 1  # to avoid divide by zero below
+
+        feedback = ["+"] if recording else ["-"]
+        feedback.extend(
+            list("".join([
+                "||",
+                ("=" * int(displaywidth * ((snr - minsnr) / snrrange))),
+                ("-" * int(displaywidth * ((maxsnr - snr) / snrrange))),
+                "||"
+            ]))
+        )
+        # insert markers for mean and threshold
+        if(minsnr < mean < maxsnr):
+            feedback[int(displaywidth * ((mean - minsnr) / snrrange))] = 'm'
+        if(minsnr < threshold < maxsnr):
+            feedback[int(displaywidth * ((threshold - minsnr) / snrrange))] = 't'
+        println("".join(feedback))
+

--- a/plugins/visualizations/terminal/terminal.py
+++ b/plugins/visualizations/terminal/terminal.py
@@ -2,10 +2,10 @@
 from blessings import Terminal
 from naomi.commandline import println
 from naomi import plugin
-import pdb
 
 
 class TerminalVisualizationsPlugin(plugin.VisualizationsPlugin):
+    @classmethod
     def mic_volume(self, *args, **kwargs):
         try:
             recording = kwargs['recording']

--- a/plugins/visualizations/terminal/test_terminal.py
+++ b/plugins/visualizations/terminal/test_terminal.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import unittest
+from naomi import testutils
+from .terminal import TerminalVisualizationsPlugin
+
+
+class TestTerminalVisualizationsPlugin(unittest.TestCase):
+    def setUp(self):
+        self.plugin = testutils.get_plugin_instance(TerminalVisualizationsPlugin)
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a grab-bag of different small fixes, but the main fix
is to add support for a Visualizations type plugin.

I have included a "Terminal" type visualizations plugin, which
runs the visualization I introduced for volume level that runs
at the bottom of the screen and indicates the volume level,
threshold and recording status so as to better understand what
Naomi can and can't hear.

Now you can disable that status by setting

plugins:
  visualizations:
    Terminal Visualizations: Disabled

in profile.yml

You can also download the Respeaker 4mic Volume visualizations
plugin through the store to demonstrate how a different
visualizations plugin works.

Specific changes:

naomi/application.py - remove vestigial pkg_resources import. Use defaults
  for plugin directories. Load visualizations.

naomi/commandline.py - Added support for boolean setting type

naomi/conversation.py - No longer relies on having the profile passed in.

naomi/plugin.py - added the TTI and Visualizations plugin types

naomi/pluginstore.py - added the TTI and Visualizations plugin types

naomi/visualizations.py - Loads the visualizations plugins and
  provides the run_visualizations() method that other plugins
  can use to run the loaded visualizations.

plugins/audioengines/pyaudio-ae/pyaudioengine.py - catching error
  'Device unavailable'

plugins/speechhandler/clock/clock.py - moved gettext to outside the
  string literals where gettext can extract the string when building
  the .po files.

plugins/speechhandler/shutdownplugin/shutdown.py - replaced a subprocess
  call for pkill to shut down all copies of Naomi to a simple quit().
  Hopefully this won't cause any problems down the line. It appears
  to be an attempt to clean up any sub daemon processes that Naomi has
  started, but that seems unnecessary, and the SIGTERM signal was failing
  to run the cleanup code for the respeaker plugin, so the lights were
  getting left on if you asked Naomi to shut down nicely, but turning off
  if you used CTRL-C to kill the program, which seemed backwards.

plugins/speechhandler/wwiw_weather/wwis_weather.py - set a 2 second
  timeout on the request for getting the location data so Naomi
  wouldn't hang forever while first starting up. If the location
  data is not received in 2 seconds, then the wwis_weather plugin
  raises an exception and gets skipped.

plugins/vad/snr_vad/snr_vad.py - moved the mic volume visualization
  into a visualizations plugin.

plugins/visualizations/terminal - added a visualizations plugin for
  the terminal. Right now only contains the mic-volume visualization.
  Eventually, I would like to add emotional visualizations (happy,
  sad faces) weather visualizations (clouds, sun, etc) and would
  love to get suggestions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#211 speechhandler shutdown plugin does not clean up](https://github.com/NaomiProject/Naomi/issues/211)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted to be able to create visual cues for Naomi, which display on a range of hardware, allowing developers to easily create and distribute their own versions of visualizations, or suggest types of visualizations that could be developed for their plugins.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been developed and tested on a Raspberry Pi with a SeeedStudio 4Mic Raspberry Pi hat. That plugin is available through the store.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
