### PR TITLE
Finished adding core variables as settings

### DIFF
--- a/Populate.py
+++ b/Populate.py
@@ -1,18 +1,9 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import logging
 import naomi
-import os
-import yaml
+import sys
 
-logging.basicConfig(level=logging.CRITICAL)
+if(sys.version_info.major < 3):
+    raise SystemError("This version of Naomi requires Python 3.5 or greater")
 
-configfile = naomi.paths.config('profile.yml')
-
-if os.path.exists(configfile):
-    with open(configfile, "r") as f:
-        config = yaml.safe_load(f)
-else:
-    config = {}
-
-naomi.populate.run(config)
+naomi.main(args=["--repopulate"])

--- a/naomi/app_utils.py
+++ b/naomi/app_utils.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+import email
+import imaplib
 import smtplib
+from dateutil import parser
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from urllib import request as urllib_request
@@ -9,32 +12,43 @@ import logging
 from naomi import profile
 
 
+# AaronC - This is currently used to clean phone numbers
+def clean_number(s):
+    return re.sub(r'[^0-9]', '', s)
+
+
+def get_date(email):
+    return parser.parse(email.get('date'))
+
+
 def send_email(
     SUBJECT,
     BODY,
     TO,
-    FROM,
-    SENDER,
-    PASSWORD,
-    SMTP_SERVER,
-    SMTP_PORT
+    SENDER=profile.get(['keyword'], ['Naomi'])[0]
 ):
     """Sends an HTML email."""
 
+    USERNAME = profile.get_profile_password(['email', 'username'])
+    FROM = profile.get_profile_password(['email', 'address'])
+    PASSWORD = profile.get_profile_password(['email', 'password'])
+    SERVER = profile.get(['email', 'smtp', 'server'])
+    PORT = profile.get(['email', 'smtp', 'port'], 587)
+
     msg = MIMEMultipart()
-    msg['From'] = SENDER
+    msg['From'] = "{} <{}>".format(SENDER, FROM)
     msg['To'] = TO
     msg['Subject'] = SUBJECT
-
     msg.attach(MIMEText(BODY.encode('UTF-8'), 'html', 'UTF-8'))
 
-    logging.info('using %s, and %s as port', SMTP_SERVER, SMTP_PORT)
+    FROM = profile.get_profile_password(['email', 'address'])
+    logging.info('using %s, and %s as port', SERVER, PORT)
 
-    session = smtplib.SMTP(SMTP_SERVER, SMTP_PORT)
+    session = smtplib.SMTP(SERVER, PORT)
 
     session.starttls()
 
-    session.login(FROM, PASSWORD)
+    session.login(USERNAME, PASSWORD)
     session.sendmail(SENDER, TO, msg.as_string())
     session.quit()
     logging.info('Successful.')
@@ -42,23 +56,24 @@ def send_email(
 
 def email_user(SUBJECT="", BODY=""):
     """
-    sends an email.
+    sends an email to the user.
 
     Arguments:
         SUBJECT -- subject line of the email
         BODY -- body text of the email
     """
+    SENDER = profile.get(['keyword'], ['Naomi'])[0]
     if not BODY:
         return False
 
     body = 'Hello {},'.format(profile.get(['first_name']))
     body += '\n\n' + BODY.strip() + '\n\n'
-    body += 'Best Regards,\nNaomi\n'
+    body += 'Best Regards,\n{}\n'.format(SENDER)
 
     recipient = None
 
     if profile.get(['email', 'address']):
-        recipient = profile.get(['email', 'address'])
+        recipient = profile.get_profile_password(['email', 'address'])
         first_name = profile.get(['first_name'])
         last_name = profile.get(['last_name'])
         if first_name and last_name:
@@ -68,7 +83,7 @@ def email_user(SUBJECT="", BODY=""):
                 recipient=recipient
             )
     else:
-        phone_number = profile.get(['phone_number'])
+        phone_number = clean_number(profile.get_profile_password(['phone_number']))
         carrier = profile.get(['carrier'])
         if phone_number and carrier:
             recipient = "{}@{}".format(
@@ -80,26 +95,63 @@ def email_user(SUBJECT="", BODY=""):
         return False
 
     try:
-        user = profile.get(['email', 'username'])
-        password = profile.get_profile_password(['email', 'password'])
-        server = profile.get(['email', 'smtp'])
-        port = profile.get(['email', 'smtp_port'], 587)
-
         send_email(
             SUBJECT,
             body,
-            recipient,
-            user,
-            "Naomi <naomi>",
-            password,
-            server,
-            port
+            recipient
         )
 
-    except Exception:
+    except Exception as e:
+        print(e)
         return False
     else:
         return True
+
+
+def fetch_emails(since=None, filter="", markRead=False, limit=None):
+    """
+        Fetches a list of unread email objects from a user's Email inbox.
+
+        Arguments:
+        since -- if provided, no emails before this date will be returned
+        markRead -- if True, marks all returned emails as read in target
+                    inbox
+
+        Returns:
+        A list of unread email objects.
+    """
+    host = profile.get_profile_var(['email', 'imap', 'server'])
+    port = int(profile.get_profile_var(['email', 'imap', 'port'], "993"))
+    conn = imaplib.IMAP4_SSL(host, port)
+    conn.debug = 0
+
+    conn.login(
+        profile.get_profile_password(['email', 'username']),
+        profile.get_profile_password(['email', 'password'])
+    )
+    conn.select(readonly=(not markRead))
+
+    msgs = []
+    (retcode, messages) = conn.search(None, filter)
+
+    if retcode == 'OK' and messages != ['']:
+        numUnread = len(messages[0].split(b' '))
+        if limit and numUnread > limit:
+            return numUnread
+
+        for num in messages[0].split(b' '):
+            # parse email RFC822 format
+            ret, data = conn.fetch(num, '(RFC822)')
+            raw_email = data[0][1]
+            raw_email_str = raw_email.decode("utf-8")
+            msg = email.message_from_string(raw_email_str)
+
+            if not since or get_date(msg) > since:
+                msgs.append(msg)
+    conn.close()
+    conn.logout()
+
+    return msgs
 
 
 def get_timezone():
@@ -130,7 +182,7 @@ def is_negative(phrase):
     Arguments:
         phrase -- the input phrase to-be evaluated
     """
-    return bool(re.search(r'\b(no(t)?|don\'t|stop|end|n)\b', phrase,
+    return bool(re.search(r'\b(no(t)?|don\'t|stop|end|n|false)\b', phrase,
                           re.IGNORECASE))
 
 
@@ -141,6 +193,6 @@ def is_positive(phrase):
         Arguments:
         phrase -- the input phrase to-be evaluated
     """
-    return bool(re.search(r'\b(sure|yes|yeah|go|yup|y)\b',
+    return bool(re.search(r'\b(sure|yes|yeah|go|yup|y|true)\b',
                           phrase,
                           re.IGNORECASE))

--- a/naomi/app_utils.py
+++ b/naomi/app_utils.py
@@ -108,7 +108,7 @@ def email_user(SUBJECT="", BODY=""):
         return True
 
 
-def fetch_emails(since=None, filter="", markRead=False, limit=None):
+def fetch_emails(since=None, email_filter="", markRead=False, limit=None):
     """
         Fetches a list of unread email objects from a user's Email inbox.
 
@@ -132,7 +132,7 @@ def fetch_emails(since=None, filter="", markRead=False, limit=None):
     conn.select(readonly=(not markRead))
 
     msgs = []
-    (retcode, messages) = conn.search(None, filter)
+    (retcode, messages) = conn.search(None, email_filter)
 
     if retcode == 'OK' and messages != ['']:
         numUnread = len(messages[0].split(b' '))
@@ -141,7 +141,7 @@ def fetch_emails(since=None, filter="", markRead=False, limit=None):
 
         for num in messages[0].split(b' '):
             # parse email RFC822 format
-            ret, data = conn.fetch(num, '(RFC822)')
+            (retcode, data) = conn.fetch(num, '(RFC822)')
             raw_email = data[0][1]
             raw_email_str = raw_email.decode("utf-8")
             msg = email.message_from_string(raw_email_str)

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -1,18 +1,24 @@
 # -*- coding: utf-8 -*-
+import audioop
+import collections
 import csv
 import io
 import logging
+import math
 import os
+import platform
 import re
 import shutil
+import tempfile
 import urllib
+import wave
 from . import audioengine
 from . import brain
 from . import commandline as interface
 from . import i18n
 from . import paths
 from . import pluginstore
-from . import populate
+# from . import populate
 from . import conversation
 from . import mic
 from . import profile
@@ -33,6 +39,16 @@ DEFAULT_PLUGIN_URL = "/".join([
     "plugins.csv"
 ])
 _ = None
+audioengine_plugins = None
+
+
+# AaronC = for detecting audio. Switch to using VAD engine.
+def _snr(input_bits, threshold, frames):
+    rms = audioop.rms(b''.join(frames), int(input_bits / 8))
+    if ((threshold > 0) and (rms > threshold)):
+        return 20.0 * math.log(rms / threshold, 10)
+    else:
+        return 0
 
 
 class Naomi(object):
@@ -51,27 +67,67 @@ class Naomi(object):
         global _
         self._logger = logging.getLogger(__name__)
         self._interface = interface.commandline()
-        if repopulate:
-            populate.run()
-        if(profile.get_arg("Profile_missing", False)):
-            print("Your config file does not exist.")
-            text_input = input(
-                " ".join([
-                    "Would you like to answer a few ",
-                    "questions to create a new one? (y/N): "
+        # check that the values we need in order to run Naomi
+        # exist
+        language = profile.get_profile_var(['language'])
+        if(not language):
+            language = 'en-US'
+            self._logger.warn(
+                ' '.join([
+                    'language not specified in profile,',
+                    'using default ({})'.format(language)
                 ])
             )
-            if(text_input.strip()[:1].upper() == "Y"):
-                populate.run()
-            else:
-                print("Cannot continue. Exiting.")
-                quit()
-        # FIXME We still need this next line because a lot of
-        # plugins still use self.config
-        self.config = profile.get_profile()
         translations = i18n.parse_translations(paths.data('locale'))
         translator = i18n.GettextMixin(translations)
+        self.gettext = translator.gettext
         _ = translator.gettext
+        # Load plugins
+        self.plugins = pluginstore.PluginStore()
+        self.plugins.detect_plugins()
+        self._logger.info("Using Language '{}'".format(language))
+        if hasattr(self, "settings"):
+            # set a variable here to tell us if all settings are
+            # completed or not
+            # If all settings do not currently exist, go ahead and
+            # re-query all settings for this plugin
+            settings_complete = True
+            # Step through the settings and check for
+            # any missing settings
+            for setting in self.settings():
+                if not profile.check_profile_var_exists(setting):
+                    self._logger.info(
+                        "{} setting does not exist".format(setting)
+                    )
+                    # Go ahead and pull the setting
+                    settings_complete = False
+        # Disabling populate until I figure out what can't be
+        # handled through settings.
+        # if(profile.get_arg("Profile_missing", False)):
+        #     print("Your config file does not exist.")
+        #     text_input = input(
+        #         " ".join([
+        #             "Would you like to answer a few ",
+        #             "questions to create a new one? (y/N): "
+        #         ])
+        #     )
+        #     if(text_input.strip()[:1].upper() == "Y"):
+        #         populate.run()
+        #     else:
+        #         print("Cannot continue. Exiting.")
+        #         quit()
+        if(profile.get_arg("repopulate") or profile.get_arg("profile_missing") or not settings_complete):
+            print(self._interface.status_text(_(
+                "Configuring {}"
+            ).format(
+                profile.get_profile_var(['keyword'], ['Naomi'])[0]
+            )))
+            for setting in self.settings():
+                self._interface.get_setting(
+                    setting, self.settings()[setting]
+                )
+            # Save the profile with the new settings
+            profile.save_profile()
 
         language = profile.get_profile_var(['language'])
         if(not language):
@@ -193,9 +249,6 @@ class Naomi(object):
                 save_noise = profile.get_profile_flag(
                     ['audiolog', 'save_noise']
                 )
-        # Load plugins
-        self.plugins = pluginstore.PluginStore()
-        self.plugins.detect_plugins()
 
         # load visualizations
         visualizations.load_visualizations(self)
@@ -205,7 +258,7 @@ class Naomi(object):
             audio_engine_slug,
             category='audioengine'
         )
-        self.audio = ae_info.plugin_class(ae_info, self.config)
+        self.audio = ae_info.plugin_class(ae_info)
         # self.check_settings(self.audio, repopulate)
 
         # Initialize audio input device
@@ -275,9 +328,8 @@ class Naomi(object):
         # Initialize audio output device
         devices = [device.slug for device in self.audio.get_devices(
             device_type=audioengine.DEVICE_TYPE_OUTPUT)]
-        try:
-            device_slug = self.config['audio']['output_device']
-        except KeyError:
+        device_slug = profile.get(['audio', 'output_device'])
+        if not device_slug:
             device_slug = self.audio.get_default_device(output=True).slug
             self._logger.warning(
                 " ".join([
@@ -285,8 +337,8 @@ class Naomi(object):
                     "defaulting to '{0:s}' (Possible values: {1:s})"
                 ]).format(device_slug, ', '.join(devices))
             )
+        output_device = self.audio.get_device_by_slug(device_slug)
         try:
-            output_device = self.audio.get_device_by_slug(device_slug)
             if audioengine.DEVICE_TYPE_OUTPUT not in output_device.types:
                 raise audioengine.UnsupportedFormat(
                     " ".join([
@@ -338,7 +390,8 @@ class Naomi(object):
         self.brain = brain.Brain(intent_parser)
         for info in self.plugins.get_plugins_by_category('speechhandler'):
             try:
-                plugin = info.plugin_class(info, self.config)
+                plugin = info.plugin_class(info)
+                self.brain.add_plugin(plugin)
             except Exception as e:
                 self._logger.warning(
                     "Plugin '%s' skipped! (Reason: %s)", info.name,
@@ -347,8 +400,7 @@ class Naomi(object):
                         self._logger.getEffectiveLevel() == logging.DEBUG
                     )
                 )
-            else:
-                self.brain.add_plugin(plugin)
+
         # print(self.brain._intentparser.intent_map)
         self.brain.train()
 
@@ -369,8 +421,7 @@ class Naomi(object):
         active_stt_plugin = active_stt_plugin_info.plugin_class(
             'default',
             active_phrases,
-            active_stt_plugin_info,
-            self.config
+            active_stt_plugin_info
         )
         if(profile.check_profile_var_exists(['active_stt', 'samplerate'])):
             active_stt_plugin._samplerate = int(
@@ -382,6 +433,10 @@ class Naomi(object):
             active_stt_plugin._volume_normalization = float(
                 profile.get_profile_var(['active_stt', 'volume_normalization'])
             )
+        active_stt_reply = profile.get_profile_var(['active_stt', 'reply'])
+        active_stt_response = profile.get_profile_var(
+            ['active_stt', 'response']
+        )
 
         # passive speech to text engine
         # Here we are checking to see if passive and
@@ -404,9 +459,8 @@ class Naomi(object):
 
         passive_stt_plugin = passive_stt_plugin_info.plugin_class(
             'keyword',
-            self.brain.get_standard_phrases() + keyword,
-            passive_stt_plugin_info,
-            self.config
+            self.brain.get_standard_phrases(),
+            passive_stt_plugin_info
         )
 
         if(profile.check_profile_var_exists(['passive_stt', 'samplerate'])):
@@ -420,13 +474,39 @@ class Naomi(object):
                 profile.get_profile_var(['passive_stt', 'volume_normalization'])
             )
 
-        active_stt_reply = profile.get_profile_var(['active_stt', 'reply'])
-        active_stt_response = profile.get_profile_var(
-            ['active_stt', 'response']
+        # We need to engage the special stt engine here, otherwise if we are
+        # in "populate" mode, it will ask for information the first time it
+        # is initialized. Luckily, we need a YES/NO special mode anyway.
+        if special_stt_slug != active_stt_slug:
+            special_stt_plugin_info = self.plugins.get_plugin(
+                special_stt_slug, category='stt'
+            )
+        else:
+            special_stt_plugin_info = active_stt_plugin_info
+
+        yesno_stt_plugin = special_stt_plugin_info.plugin_class(
+            'yes/no',
+            [
+                _("YES"),
+                _("NO")
+            ],
+            special_stt_plugin_info
         )
-        # pdb.set_trace()
+
+        if(profile.check_profile_var_exists(['special_stt', 'samplerate'])):
+            yesno_stt_plugin._samplerate = int(
+                profile.get_profile_var(['special_stt', 'samplerate'])
+            )
+        if(profile.check_profile_var_exists(
+            ['special_stt', 'volume_normalization']
+        )):
+            yesno_stt_plugin._volume_normalization = float(
+                profile.get_profile_var(['special_stt', 'volume_normalization'])
+            )
+
+        # Initialize Text to speech engine
         tts_plugin_info = self.plugins.get_plugin(tts_slug, category='tts')
-        tts_plugin = tts_plugin_info.plugin_class(tts_plugin_info, self.config)
+        tts_plugin = tts_plugin_info.plugin_class(tts_plugin_info)
 
         # Initialize Mic
         if use_mic == USE_TEXT_MIC:
@@ -454,7 +534,6 @@ class Naomi(object):
                 self.plugins,
                 tts_plugin,
                 vad_plugin,
-                self.config,
                 keyword=keyword,
                 print_transcript=print_transcript,
                 passive_listen=passive_listen,
@@ -465,7 +544,491 @@ class Naomi(object):
             )
 
         self.conversation = conversation.Conversation(
-            self.mic, self.brain, self.config)
+            self.mic, self.brain
+        )
+
+    def settings(self):
+        _ = self.gettext
+        return collections.OrderedDict(
+            [
+                (
+                    ("keyword",), {
+                        "title": _("By what name would you like to call me?"),
+                        "description": _("A good choice for a name would have multiple syllables and not sound like any common words."),
+                        "default": "Naomi"
+                    }
+                ),
+                (
+                    ("audio_engine",), {
+                        "type": "listbox",
+                        "title": _("Please select an audio engine"),
+                        "options": self.get_audio_engines,
+                        "default": "alsa" if re.match(r'linux', platform.system().lower()) else "pyaudio"
+                    }
+                ),
+                (
+                    ("audio", "output_device"), {
+                        "type": "listbox",
+                        "title": _("please select an output device"),
+                        "options": self.get_output_devices,
+                        "validation": self.validate_output_device,
+                        "default": "default"
+                    }
+                ),
+                (
+                    ("audio", "input_device"), {
+                        "type": "listbox",
+                        "title": _("Please select an input device"),
+                        "options": self.get_input_devices,
+                        "validation": self.validate_input_device,
+                        "default": "default"
+                    }
+                ),
+                (
+                    ("passive_stt", "engine"), {
+                        "type": "listbox",
+                        "title": _("Please select a passive speech to text engine"),
+                        "description": _("The passive STT engine processes everything you say near me. It is highly recommended to use an offline engine like sphinx."),
+                        "options": [info.name for info in self.plugins.get_plugins_by_category("stt")],
+                        "default": "sphinx"
+                    }
+                ),
+                (
+                    ("active_stt", "engine"), {
+                        "type": "listbox",
+                        "title": _("Please select an active speech to text engine"),
+                        "description": _("After I hear my wake word, this engine processes everything you say. I recommend an offline option, but you could also use an online option like Google Voice."),
+                        "options": [info.name for info in self.plugins.get_plugins_by_category("stt")],
+                        "default": "sphinx"
+                    }
+                ),
+                (
+                    ("special_stt", "engine"), {
+                        "type": "listbox",
+                        "title": _("Please select a special speech to text engine"),
+                        "description": _("Special mode is used when I am listening for a specific set of requests while in a specific plugin. An offline option should work fine here, but an online option should also work."),
+                        "options": [info.name for info in self.plugins.get_plugins_by_category("stt")],
+                        "default": "sphinx"
+                    }
+                ),
+                (
+                    ("tts_engine"), {
+                        "type": "listbox",
+                        "title": _("Please select a text to speech engine"),
+                        "description": _("This provides my voice."),
+                        "options": [info.name for info in self.plugins.get_plugins_by_category("tts")],
+                        "default": "flite-tts"
+                    }
+                ),
+                (
+                    ("passive_listen"), {
+                        "type": "boolean",
+                        "title": _("Would you like to turn on passive listening?"),
+                        "description": _("In normal mode, when I hear my wake word I will beep and wait for a command. In passive listening mode, I will process whatever you say with the wake word. So in normal mode, you would say 'Naomi' and I would beep and you would say 'what time is it' and I would tell you, but in passive mode you could just say 'Naomi what time is it' and I would tell you."),
+                        "default": True
+                    }
+                ),
+                (
+                    ("print_transcript"), {
+                        "type": "boolean",
+                        "title": _("Would you like to turn on print transcript?"),
+                        "description": _("In 'print transcript' mode, I will print everything I say and everything I think I hear you say to the command line. This is mostly useful for debugging."),
+                        "default": True
+                    }
+                ),
+                (
+                    ("email", "address"), {
+                        "type": "encrypted",
+                        "title": _("Please enter your email address"),
+                        "description": _("I can use your email address to check your mail and send you notifications"),
+                        "validation": "email"
+                    }
+                ),
+                (
+                    ("email", "imap", "server"), {
+                        "title": _("Please enter your IMAP email server url"),
+                        "description": _(
+                            "I need to know the url of your email server if you want me to check your emails for you"),
+                        "active": lambda: True if len(
+                            profile.get_profile_var(["email", "address"]).strip()) > 0 else False
+                    }
+                ),
+                (
+                    ("email", "imap", "port"), {
+                        "title": _("Please enter your IMAP email server port"),
+                        "description": _("I need to know I have the correct port to access your email"),
+                        "default": "993",
+                        "validation": "int",
+                        "active": lambda: True if (
+                            len(profile.get_profile_var(["email", "address"]).strip()) > 0
+                        ) and (
+                            len(profile.get_profile_var(["email", "imap"])) > 0
+                        ) else False
+                    }
+                ),
+                (
+                    ("email", "smtp", "server"), {
+                        "title": _("Please enter an SMTP email server url I can use"),
+                        "description": _(
+                            "I need to know the url for an SMTP email server to send emails to or for you."),
+                        "active": lambda: True if len(
+                            profile.get_profile_var(["email", "address"]).strip()) > 0 else False
+                    }
+                ),
+                (
+                    ("email", "smtp", "port"), {
+                        "title": _("Please enter an SMTP email server port I can use"),
+                        "description": _("I need to know I have the correct port to send email"),
+                        "default": "587",
+                        "validation": "int",
+                        "active": lambda: True if (
+                            len(profile.get_profile_var(["email", "address"]).strip()) > 0
+                        ) and (
+                            len(profile.get_profile_var(["email", "imap"])) > 0
+                        ) else False
+                    }
+                ),
+                (
+                    ("email", "username"), {
+                        "type": "encrypted",
+                        "title": _("Please enter your email username"),
+                        "description": _(
+                            "Your username is normally either your full email address or just the part before the '@' symbol."),
+                        "active": lambda: True if len(
+                            profile.get_profile_var(["email", "address"]).strip()) > 0 else False
+                    }
+                ),
+                (
+                    ("email", "password"), {
+                        "type": "password",
+                        "title": _("Please enter your email password"),
+                        "description": _("I need your email address in order to check your emails."),
+                        "active": lambda: True if(
+                            len(profile.get_profile_password(["email", "address"]).strip()) > 0
+                        ) and (
+                            len(profile.get_profile_var(["email", "imap"])) > 0
+                        ) else False
+                    }
+                ),
+                (
+                    ("phone_number",), {
+                        "type": "encrypted",
+                        "title": _("Please enter your phone number"),
+                        "description": _("I can use your phone number to send text messages to you")
+                    }
+                ),
+                (
+                    ("carrier",), {
+                        "title": _("Please enter your carrier"),
+                        "description": _("I need to know your phone carrier in order to send text messages to you from the SMTP account I'm using. If you don't know it, try sending a text message to your email account. When it arrives, it will be in the form <phone number>@<carrier> i.e. 2125551212@vtext.com"),
+                        "active": lambda: True if (len(profile.get_profile_password(["phone_number"]).strip()) > 0) else False
+                    }
+                ),
+                (
+                    ("allows_email",), {
+                        "type": "boolean",
+                        "title": _("Would you like to let me send you emails?"),
+                        "description": _("If you select 'Yes' I will send emails to you at your request, or to let you know when important things are happening."),
+                        "active": lambda: True if(
+                            len(profile.get_profile_password(["email", "address"]).strip())
+                        ) else False,
+                        "default": True
+                    }
+                )
+            ]
+        )
+
+    # Return a list of currently installed audio engines.
+    @staticmethod
+    def get_audio_engines():
+        global audioengine_plugins
+        audioengine_plugins = pluginstore.PluginStore()
+        audioengine_plugins.detect_plugins("audioengine")
+        audioengines = [
+            ae_info.name
+            for ae_info
+            in audioengine_plugins.get_plugins_by_category(
+                category='audioengine'
+            )
+        ]
+        return audioengines
+
+    def get_output_devices(self):
+        return self.get_audio_devices(audioengine.DEVICE_TYPE_OUTPUT)
+
+    def get_input_devices(self):
+        return self.get_audio_devices(audioengine.DEVICE_TYPE_INPUT)
+
+    def validate_output_device(self, output_device_slug):
+        response = True
+        print(self._interface.instruction_text(
+            _("Testing device by playing a sound")
+        ))
+        ae_info = audioengine_plugins.get_plugin(
+            profile.get_profile_var(['audio_engine']),
+            category='audioengine'
+        )
+        # AaronC 2018-09-14 Get a list of available output devices
+        audio_engine = ae_info.plugin_class(ae_info, profile.get_profile())
+        output_device = audio_engine.get_device_by_slug(output_device_slug)
+        output_chunksize = profile.get(
+            ['audio', 'output_chunksize'],
+            1024
+        )
+        output_add_padding = profile.get(
+            ['audio', 'output_padding'],
+            False
+        )
+        filename = os.path.join(
+            os.path.dirname(
+                os.path.abspath(__file__)
+            ),
+            "data",
+            "audio",
+            "beep_lo.wav"
+        )
+        try:
+            output_device.play_file(
+                filename,
+                chunksize=output_chunksize,
+                add_padding=output_add_padding
+            )
+        except Exception as e:
+            print(e)
+        heard = self._interface.simple_yes_no(
+            _("Were you able to hear the beep?")
+        )
+        try:
+            if not (heard):
+                print(
+                    self._interface.instruction_text(" ".join([
+                        _("The volume on your device may be too low."),
+                        _("You should be able to use 'alsamixer'"),
+                        _("to set the volume level.")
+                    ]))
+                )
+                heard = self._interface.simple_yes_no(
+                    self._interface.instruction_text(
+                        " ".join([
+                            _("Do you want to continue now"),
+                            _("and fix the volume later?")
+                        ])
+                    )
+                )
+                if not (heard):
+                    response = False
+        except audioengine.UnsupportedFormat as e:
+            print(self._interface.alert_text(str(e)))
+            print(
+                self._interface.instruction_text(
+                    _("Output format not supported on this device.")
+                )
+            )
+            print(
+                self._interface.instruction_text(
+                    _("Please choose a different device.")
+                )
+            )
+            print("")
+            response = False
+        return response
+
+    def validate_input_device(self, input_device_slug):
+        # AaronC 2018-09-14 Initialize AudioEngine
+        ae_info = audioengine_plugins.get_plugin(
+            profile.get_profile_var(['audio_engine']),
+            category='audioengine'
+        )
+        # AaronC 2018-09-14 Get a list of available output devices
+        audio_engine = ae_info.plugin_class(ae_info, profile.get_profile())
+        # AaronC 2018-09-14 Get the input device
+        input_device_slug = profile.get_profile_var(["audio", "input_device"])
+        if not input_device_slug:
+            input_device_slug = audio_engine.get_default_device(output=False).slug
+        response = True
+        # try recording a sample
+        test = self._interface.simple_yes_no(" ".join([
+            _("Would you like me to test your selection"),
+            _("by recording your voice and playing it back to you?")
+        ]))
+        while test:
+            test = False
+            # FIXME AaronC Sept 16 2018
+            # The following are defaults. They should be read
+            # from the proper locations in the profile file if
+            # they have been set.
+            threshold = 10  # 10 dB
+            input_chunks = profile.get_profile_var(
+                ['audio', 'input_chunksize'],
+                1024
+            )
+            input_bits = profile.get_profile_var(
+                ['audio', 'input_samplewidth'],
+                16
+            )
+            input_channels = profile.get_profile_var(
+                ['audio', 'input_channels'],
+                1
+            )
+            input_rate = profile.get_profile_var(
+                ['audio', 'input_samplerate'],
+                16000
+            )
+
+            output_chunksize = profile.get_profile_var(
+                ['audio', 'output_chunksize'],
+                1024
+            )
+            output_add_padding = profile.get_profile_var(
+                ['audio', 'output_padding'],
+                False
+            )
+            input_device = audio_engine.get_device_by_slug(
+                profile.get_profile_var(['audio', 'input_device'])
+            )
+            output_device = audio_engine.get_device_by_slug(
+                profile.get_profile_var(["audio", "output_device"])
+            )
+            frames = collections.deque([], 30)
+            recording = False
+            recording_frames = []
+            filename = os.path.join(
+                os.path.dirname(
+                    os.path.abspath(__file__)
+                ),
+                "data",
+                "audio",
+                "beep_hi.wav"
+            )
+            if(os.path.isfile(filename)):
+                output_device.play_file(
+                    filename,
+                    chunksize=output_chunksize,
+                    add_padding=output_add_padding
+                )
+            started = False
+            for frame in input_device.record(
+                input_chunks,
+                input_bits,
+                input_channels,
+                input_rate
+            ):
+                frames.append(frame)
+                # Moved this down here because sometimes it takes a second
+                # for the sound card to actually start recording
+                if not started:
+                    started = True
+                    print(
+                        self._interface.instruction_text(
+                            _("Please speak into the mic now")
+                        )
+                    )
+
+                if not recording:
+                    snr = _snr(input_bits, threshold, [frame])
+                    if snr >= threshold:
+                        print(
+                            self._interface.alert_text(
+                                _("Sound detected - recording")
+                            )
+                        )
+                        recording = True
+                        if len(frames) > 30:
+                            recording_frames = list(frames)[-30:]
+                        else:
+                            recording_frames = list(frames)
+                    elif len(frames) >= frames.maxlen:
+                        # Threshold not reached. Update.
+                        soundlevel = float(audioop.rms(b"".join(frames), 2))
+                        if (soundlevel < threshold):
+                            print(self._interface.alert_text(" ".join([
+                                _("No sound detected."),
+                                _("Setting threshold from {t} to {s}").format(
+                                    t=threshold,
+                                    s=soundlevel
+                                )
+                            ])))
+                            threshold = soundlevel
+                else:
+                    recording_frames.append(frame)
+                    if len(recording_frames) > 20:
+                        # Check if we are below threshold again
+                        last_snr = _snr(
+                            input_bits,
+                            threshold,
+                            recording_frames[-10:]
+                        )
+                        if((
+                            last_snr <= threshold
+                        )or(
+                            len(recording_frames) > 60
+                        )):
+                            # stop recording
+                            recording = False
+                            print(
+                                self._interface.success_text(
+                                    _("Recorded %d frames")
+                                    % len(recording_frames)
+                                )
+                            )
+                            break
+            if len(recording_frames) > 20:
+                response = False
+                replay = True
+                while (replay):
+                    response = True
+                    with tempfile.NamedTemporaryFile(mode='w+b') as f:
+                        wav_fp = wave.open(f, 'wb')
+                        wav_fp.setnchannels(input_channels)
+                        wav_fp.setsampwidth(int(input_bits / 8))
+                        wav_fp.setframerate(input_rate)
+                        fragment = b"".join(frames)
+                        wav_fp.writeframes(fragment)
+                        wav_fp.close()
+                        output_device.play_file(
+                            f.name,
+                            chunksize=output_chunksize,
+                            add_padding=output_add_padding
+                        )
+                    heard = self._interface.simple_yes_no(
+                        _("Did you hear yourself?")
+                    )
+                    if (heard):
+                        replay = False
+                        response = True
+                    else:
+                        replay = self._interface.simple_yes_no(
+                            _("Replay?")
+                        )
+                        if (not replay):
+                            skip = self._interface.simple_yes_no(
+                                _("Do you want to skip this test and continue?")
+                            )
+                            if (skip):
+                                replay = False
+                                heard = True
+                                response = True
+                                test = False
+                            else:
+                                replay = False
+                                heard = True
+                                response = False
+                                test = False
+        return response
+
+    @staticmethod
+    def get_audio_devices(device_type):
+        ae_info = audioengine_plugins.get_plugin(
+            profile.get_profile_var(['audio_engine']),
+            category='audioengine'
+        )
+        # AaronC 2018-09-14 Get a list of available output devices
+        audio_engine = ae_info.plugin_class(ae_info, profile.get_profile())
+        # AaronC 2018-09-14 Get a list of available input devices
+        input_devices = [device.slug for device in audio_engine.get_devices(
+            device_type=device_type
+        )]
+        return input_devices
 
     def list_audio_devices(self):
         for device in self.audio.get_devices():
@@ -519,10 +1082,10 @@ class Naomi(object):
             plugins_sorted[info.name.lower()] = info
         for name in sorted(plugins_sorted):
             info = plugins_sorted[name]
-            print("{} {} - {}".format(
-                info.name.ljust(len_name),
-                (
-                    "(v%s)" % info.version).ljust(len_version),
+            print(
+                "{} {} - {}".format(
+                    info.name.ljust(len_name),
+                    ("(v%s)" % info.version).ljust(len_version),
                     info.description
                 )
             )

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -37,7 +37,6 @@ class Mic(object):
         plugins,
         tts_engine,
         vad_plugin,
-        config,
         keyword=['NAOMI'],
         print_transcript=False,
         passive_listen=False,

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -1756,55 +1756,55 @@ def run():
     greet_user()
     interface.separator()
 
-    get_wakeword()
-    interface.separator()
+    # get_wakeword()
+    # interface.separator()
 
-    select_audio_engine()
-    interface.separator()
+    # select_audio_engine()
+    # interface.separator()
 
-    get_output_device()
-    interface.separator()
+    # get_output_device()
+    # interface.separator()
 
-    get_input_device()
-    interface.separator()
+    # get_input_device()
+    # interface.separator()
 
-    get_passive_stt_engine()
-    interface.separator()
+    # get_passive_stt_engine()
+    # interface.separator()
 
-    get_active_stt_engine()
-    interface.separator()
+    # get_active_stt_engine()
+    # interface.separator()
 
-    get_special_stt_engine()
-    interface.separator()
+    # get_special_stt_engine()
+    # interface.separator()
 
-    get_tts_engine()
-    interface.separator()
+    # get_tts_engine()
+    # interface.separator()
 
     get_beep_or_voice()
     interface.separator()
 
-    get_user_name()
-    interface.separator()
+    # get_user_name()
+    # interface.separator()
 
-    get_email_info()
-    interface.separator()
+    # get_email_info()
+    # interface.separator()
 
-    get_phone_info()
-    interface.separator()
+    # get_phone_info()
+    # interface.separator()
 
-    get_notification_info()
-    interface.separator()
+    # get_notification_info()
+    # interface.separator()
 
     # comment out the following two lines as the weather location service
     # at weather underground has now been shut down. AaronC 2019-03-25
     # get_weather_location()
     # interface.separator()
 
-    get_timezone()
-    interface.separator()
+    # get_timezone()
+    # interface.separator()
 
     # write to profile
-    profile.save_profile()
+    # profile.save_profile()
 
     interface.separator()
     print(

--- a/naomi/visualizations.py
+++ b/naomi/visualizations.py
@@ -8,7 +8,7 @@ def load_visualizations(self):
     global _visualizations
     for info in self.plugins.get_plugins_by_category('visualizations'):
         try:
-            _visualizations.append(info.plugin_class(info, self.config))
+            _visualizations.append(info.plugin_class(info))
         except Exception as e:
             self._logger.warning(
                 "Plugin '%s' skipped! (Reason: %s)", info.name,

--- a/plugins/speechhandler/hackernews/hackernews.py
+++ b/plugins/speechhandler/hackernews/hackernews.py
@@ -80,7 +80,7 @@ class HackerNewsPlugin(plugin.SpeechHandlerPlugin):
         )
         mic.say(text)
 
-        if profile.get_profile_flag(['prefers_email']):
+        if profile.get_profile_flag(['allows_email']):
             mic.say(_('Would you like me to send you these articles?'))
 
             answers = mic.active_listen()

--- a/plugins/speechhandler/news/news.py
+++ b/plugins/speechhandler/news/news.py
@@ -88,7 +88,7 @@ class NewsPlugin(plugin.SpeechHandlerPlugin):
         if not email:
             return
 
-        if profile.get_profile_flag(['prefers_email'], False):
+        if profile.get_profile_flag(['allows_email'], False):
 
             mic.say(_('Would you like me to send you these articles?'))
 

--- a/plugins/stt/pocketsphinx-stt/sphinxplugin.py
+++ b/plugins/stt/pocketsphinx-stt/sphinxplugin.py
@@ -1,6 +1,7 @@
 import os.path
 import tempfile
 from collections import OrderedDict
+from naomi import paths
 from naomi import plugin
 from naomi import profile
 from . import sphinxvocab
@@ -127,41 +128,27 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
         # Get the defaults for settings
         # hmm_dir
         hmm_dir = profile.get(
-            ['pocketsphinx', 'hmm_dir'],
-            "/usr/local/share/pocketsphinx/model/hmm/en_US/hub4wsj_sc_8k"
+            ['pocketsphinx', 'hmm_dir']
         )
         if(not hmm_dir):
-            if(os.path.isdir(os.path.join(
-                os.path.expanduser("~"),
-                "pocketsphinx-python",
-                "pocketsphinx",
-                "model",
-                "en-us",
-                "en-us"
-            ))):
-                hmm_dir = os.path.join(
+            # Make a list of possible paths to check
+            hmm_dir_paths = [
+                os.path.join(
                     os.path.expanduser("~"),
                     "pocketsphinx-python",
                     "pocketsphinx",
                     "model",
                     "en-us",
                     "en-us"
-                )
-            elif(os.path.isdir(os.path.join(
-                os.path.expanduser("~"),
-                "pocketsphinx",
-                "model",
-                "en-us",
-                "en-us"
-            ))):
-                hmm_dir = os.path.join(
+                ),
+                os.path.join(
                     os.path.expanduser("~"),
                     "pocketsphinx",
                     "model",
                     "en-us",
                     "en-us"
-                )
-            elif(os.path.isdir(os.path.join(
+                ),
+                os.path.join(
                     "/",
                     "usr",
                     "share",
@@ -169,18 +156,8 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
                     "model",
                     "en-us",
                     "en-us"
-            ))):
-                hmm_dir = os.path.join(
-                    "/",
-                    "usr",
-                    "share",
-                    "pocketsphinx",
-                    "model",
-                    "en-us",
-                    "en-us"
-                )
-            else:
-                hmm_dir = os.path.join(
+                ),
+                os.path.join(
                     "/usr",
                     "local",
                     "share",
@@ -190,19 +167,28 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
                     "en_US",
                     "hub4wsj_sc_8k"
                 )
+            ]
+            # see if any of these paths exist
+            for path in hmm_dir_paths:
+                if os.path.isdir(path):
+                    hmm_dir = path
         # fst_model
         fst_model = profile.get_profile_var(["pocketsphinx", "fst_model"])
         if not fst_model:
-            if(os.path.isfile(os.path.join(
-                os.path.expanduser("~"),
-                "pocketsphinx-python",
-                "pocketsphinx",
-                "model",
-                "en-us",
-                "train",
-                "model.fst"
-            ))):
-                fst_model = os.path.join(
+            # Make a list of possible paths to check
+            fst_model_paths = [
+                os.path.join(
+                    paths.sub(
+                        os.path.join(
+                            "pocketsphinx",
+                            "adapt",
+                            "en-US",
+                            "train",
+                            "model.fst"
+                        )
+                    )
+                ),
+                os.path.join(
                     os.path.expanduser("~"),
                     "pocketsphinx-python",
                     "pocketsphinx",
@@ -210,41 +196,28 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
                     "en-us",
                     "train",
                     "model.fst"
-                )
-            elif(os.path.isfile(os.path.join(
-                os.path.expanduser("~"),
-                "cmudict",
-                "train",
-                "model.fst"
-            ))):
-                fst_model = os.path.join(
+                ),
+                os.path.join(
                     os.path.expanduser("~"),
                     "cmudict",
                     "train",
                     "model.fst"
-                )
-            elif(os.path.isfile(os.path.join(
-                os.path.expanduser("~"),
-                "CMUDict",
-                "train",
-                "model.fst"
-            ))):
-                fst_model = os.path.join(
+                ),
+                os.path.join(
                     os.path.expanduser("~"),
                     "CMUDict",
                     "train",
                     "model.fst"
-                )
-            elif(os.path.isfile(os.path.join(
-                os.path.expanduser("~"),
-                "phonetisaurus",
-                "g014b2b.fst"
-            ))):
-                fst_model = os.path.join(
+                ),
+                os.path.join(
                     os.path.expanduser("~"),
                     "phonetisaurus",
                     "g014b2b.fst"
                 )
+            ]
+            for path in fst_model_paths:
+                if os.path.isfile(path):
+                    fst_model = path
         phonetisaurus_executable = profile.get_profile_var(
             ['pocketsphinx', 'phonetisaurus_executable']
         )
@@ -271,7 +244,7 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
                         'description': "".join([
                             _('PocketSphinx finite state transducer file')
                         ]),
-                        'default': hmm_dir
+                        'default': fst_model
                     }
                 ),
                 (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This depricates the populate.py file for right now. I'm leaving
it in place in case we need to bring it back. For the moment,
all of the settings required for core naomi are contained in
a structure in naomi/application.py. I haven't restored all
the functionality, in particular it would be nice to be
able to restore the ability to preview voices which we had,
at least for flite.

It would be nice to move the structure somewhere more accessible,
like the top of the file or, preferably, into its own file.

I also moved all the methods for sending and reading emails,
anything that requires access to the user's email address,
password, phone number, etc, to the app_utils folder. We may
have gone a bit overboard on the encryption, especially since
plugins still have full access to the user's email, but
it is a nice way of marking that these are variables that
should not be available to plugins. I would like to restrict
access to encrypted variables to only the app_utils.py module.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue 16 Email username and password in plain text](https://github.com/NaomiProject/Naomi/issues/16)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I want to limit the use of certain values in the profile to only core modules. I don't want my username and password exposed to every plugin I install.

This does not completely accomplish that goal. Plugins can still simply request the decrypted information. My plan is to limit access to encrypted values to the Naomi core using stack traces to verify which program requests are coming from.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested from no profile to full profile just verified.

I moved the email access routines out of check email and into naomi/app_utils.py. I also changed the "prefers_email" profile variable to "allows email" to indicate that I'm allowing naomi to send emails. Right now, the only use of that variable is to control whether or not news and hacker news ask if you would like the news stories sent to you.

I changed Populate.py into a synonym for Naomi.py --repopulate. It now goes straight into Naomi after populating. I am no longer using naomi/populate.py. I added some interface specific code into the settings. I'm not sure how to deal with that, but hope that either setting a variable to indicate which interface to use, or changing the actual interface as a plugin could be helpful. I really won't know how to address it until there is a second interface to worry about.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
