### PR TITLE
Fixing keyword handling for STT-Trainer | Mentioned in: #221

### DIFF
--- a/NaomiSTTTrainer.py
+++ b/NaomiSTTTrainer.py
@@ -315,7 +315,7 @@ def application(environ, start_response):
             )
             ret.append(
                 '<html><head><title>{} STT Training</title>'.format(
-                    keyword
+                    ', '.join(keyword)
                 ).encode("utf-8")
             )
             # Return the main page
@@ -719,7 +719,7 @@ def application(environ, start_response):
                         ret.append("""</ul>""".encode("utf-8"))
 
                     ret.append("""<h1>{} transcription {} ({})</h1>""".format(
-                        keyword,
+                        ', '.join(keyword),
                         rowID,
                         Current_record["Type"]).encode("utf-8")
                     )
@@ -742,7 +742,7 @@ def application(environ, start_response):
                             '{} heard',
                             '"<span style="font-weight:bold">{}</span>"<br />'
                         ]).format(
-                            keyword,
+                            ', '.join(keyword),
                             Current_record["Transcription"]
                         ).encode("utf-8"))
                     ret.append("What did you hear?<br />".encode("utf-8"))

--- a/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
@@ -328,7 +328,7 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                     c.execute(query)
                     words_used = [x[0].upper() for x in c.fetchall()]
                     # Pull the list of words from the local standard phrases
-                    phrases = [profile.get_profile_var(['keyword']).upper()]
+                    phrases = profile.get_profile_var(['keyword']).copy()
                     custom_standard_phrases_dir = paths.sub(os.path.join(
                         "data",
                         "standard_phrases"

--- a/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
@@ -328,7 +328,7 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                     c.execute(query)
                     words_used = [x[0].upper() for x in c.fetchall()]
                     # Pull the list of words from the local standard phrases
-                    phrases = profile.get_profile_var(['keyword']).copy()
+                    phrases = [word.upper() for word in profile.get(['keyword'], ['NAOMI'])]
                     custom_standard_phrases_dir = paths.sub(os.path.join(
                         "data",
                         "standard_phrases"


### PR DESCRIPTION
Hello,
I fixed the keyword handling for NaomiSTTTrainer and PocketSphinx_adapt by copying the list to phrases and changing all format(keyword) lines to format(', '.join(keyword)).

## Related Issue
#221 mentioned here

## Motivation and Context
Now STTTrainer should be working correctly again. Of course I wanted to fix the problem I caused with my recent PR which added the keyword lists.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
