### PR TITLE
Additional paths for pocketsphinx_adapt

### DIFF
--- a/NaomiSTTTrainer.py
+++ b/NaomiSTTTrainer.py
@@ -200,7 +200,9 @@ def clean_transcription(transcription):
 
 
 def application(environ, start_response):
-    keyword = profile.get_profile_var(["keyword"], "Naomi")
+    keyword = profile.get_profile_var(["keyword"], ["Naomi"])
+    if(isinstance(keyword, list)):
+        keyword = keyword[0]
     print("PATH_INFO=%s" % environ["PATH_INFO"])
     if(environ["PATH_INFO"] == "/favicon.ico"):
         start_response(
@@ -315,7 +317,7 @@ def application(environ, start_response):
             )
             ret.append(
                 '<html><head><title>{} STT Training</title>'.format(
-                    ', '.join(keyword)
+                    keyword
                 ).encode("utf-8")
             )
             # Return the main page
@@ -719,7 +721,7 @@ def application(environ, start_response):
                         ret.append("""</ul>""".encode("utf-8"))
 
                     ret.append("""<h1>{} transcription {} ({})</h1>""".format(
-                        ', '.join(keyword),
+                        keyword,
                         rowID,
                         Current_record["Type"]).encode("utf-8")
                     )
@@ -742,7 +744,7 @@ def application(environ, start_response):
                             '{} heard',
                             '"<span style="font-weight:bold">{}</span>"<br />'
                         ]).format(
-                            ', '.join(keyword),
+                            keyword,
                             Current_record["Transcription"]
                         ).encode("utf-8"))
                     ret.append("What did you hear?<br />".encode("utf-8"))

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -118,10 +118,13 @@ class Naomi(object):
         #         quit()
         if(profile.get_arg("repopulate") or profile.get_arg("profile_missing") or not settings_complete):
             populate.run()
+            keyword = profile.get_profile_var(['keyword'], ['Naomi'])
+            if(isinstance(keyword, list)):
+                keyword = keyword[0]
             print(self._interface.status_text(_(
                 "Configuring {}"
             ).format(
-                profile.get_profile_var(['keyword'], ['Naomi'])[0]
+                keyword
             )))
             for setting in self.settings():
                 self._interface.get_setting(
@@ -1056,7 +1059,7 @@ class Naomi(object):
                 # The nosec comment on the next line has to be there to say
                 # "Yes, I know I'm doing something unsecure" or codacy has a
                 # fit
-                with urllib.request.urlopen(urllib.request.Request(url)) as f:  #nosec
+                with urllib.request.urlopen(urllib.request.Request(url)) as f:  # nosec
                     file_contents = f.read().decode('utf-8')
                 for line in csv.DictReader(
                     io.StringIO(file_contents),

--- a/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
@@ -186,8 +186,11 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                     continue_next = False
                 nextcommand = "buildweights"
             if(command == "buildweights"):
+                bw = '/usr/lib/sphinxtrain/bw'
+                if os.path.isfile('/usr/local/libexec/sphinxtrain/bw'):
+                    bw = '/usr/local/libexec/sphinxtrain/bw'
                 cmd = [
-                    os.path.join('/usr', 'local', 'libexec', 'sphinxtrain', 'bw'),
+                    bw,
                     '-hmmdir', self.model_dir,
                     '-moddeffn', os.path.join(self.model_dir, 'mdef.txt'),
                     '-ts2cbfn', '.ptm.',
@@ -209,8 +212,11 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
             if(command == "mllr"):
                 # MLLR is a cheap adaptation method that is suitable when the amount of data is limited. It's good for online adaptation.
                 # MLLR works best for a continuous model. It's effect for semi-continuous models is limited.
+                mllr = '/usr/lib/sphinxtrain/mllr_solve'
+                if os.path.isfile('/usr/local/libexec/sphinxtrain/mllr_solve'):
+                    mllr = '/usr/local/libexec/sphinxtrain/mllr_solve'
                 cmd = [
-                    os.path.join("/usr", "local", "libexec", "sphinxtrain", "mllr_solve"),
+                    mllr,
                     '-meanfn', os.path.join(self.model_dir, 'means'),
                     '-varfn', os.path.join(self.model_dir, 'variances'),
                     '-outmllrfn', os.path.join(self.model_dir, 'mllr_matrix'),
@@ -230,8 +236,11 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                     shutil.rmtree(self.adapt_dir)
                     response.append("Cleared adapt directory {}".format(self.adapt_dir))
                 shutil.copytree(self.model_dir, self.adapt_dir)
+                map_adapt = '/usr/lib/sphinxtrain/map_adapt'
+                if os.path.isfile('/usr/local/libexec/sphinxtrain/map_adapt'):
+                    map_adapt = '/usr/local/libexec/sphinxtrain/map_adapt'
                 cmd = [
-                    os.path.join('/usr', 'local', 'libexec', 'sphinxtrain', 'map_adapt'),
+                    map_adapt,
                     '-moddeffn', os.path.join(self.model_dir, 'mdef.txt'),
                     '-ts2cbfn', '.ptm.',
                     '-meanfn', os.path.join(self.model_dir, 'means'),
@@ -252,8 +261,11 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
             if(command == "sendump"):
                 # Recreating the adapted sendump file
                 # a sendump file saves space and is supported by pocketsphinx
+                mk_s2sendump = '/usr/lib/sphinxtrain/mk_s2sendump'
+                if os.path.isfile('/usr/local/libexec/sphinxtrain/mk_s2sendump'):
+                    mk_s2sendump = '/usr/local/libexec/sphinxtrain/mk_s2sendump'
                 cmd = [
-                    os.path.join('/usr', 'local', 'libexec', 'sphinxtrain', 'mk_s2sendump'),
+                    mk_s2sendump,
                     '-pocketsphinx', 'yes',
                     '-moddeffn', os.path.join(self.adapt_dir, 'mdef.txt'),
                     '-mixwfn', os.path.join(self.adapt_dir, 'mixture_weights'),
@@ -328,7 +340,10 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                     c.execute(query)
                     words_used = [x[0].upper() for x in c.fetchall()]
                     # Pull the list of words from the local standard phrases
-                    phrases = [word.upper() for word in profile.get(['keyword'], ['NAOMI'])]
+                    keywords = profile.get_profile_var(['keyword'])
+                    if(isinstance(keywords, str)):
+                        keywords = [keywords]
+                    phrases = [keyword.upper() for keyword in keywords]
                     custom_standard_phrases_dir = paths.sub(os.path.join(
                         "data",
                         "standard_phrases"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added some additional path locations for the pocketsphinx_adapt
plugin, to cover cases where pocketsphinx_train was installed
using the apt package instead of from source.

Also fixed a couple of additional places where the keyword needs
to either be a string or a list. Either should work in profile.yml
now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#232 Paths are not right when pocketsphinx_train is installed from a package](https://github.com/NaomiProject/Naomi/issues/232)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the user installs sphinxtrain from an apt repository rather than building it from source, then the pocketsphinx_adapt STT Trainer plugin fails to find it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by building a new pocketsphinx model and then running Naomi.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
