### PR TITLE
Added process_completedprocess function

### DIFF
--- a/naomi/run_command.py
+++ b/naomi/run_command.py
@@ -50,3 +50,31 @@ def run_command(command, capture=0, stdin=None):
             command
         )
     return completedprocess
+
+
+def process_completedprocess(completedprocess, output='text'):
+    result = "failure"
+    command = " ".join(completedprocess.args)
+    response = ""
+    if(output == 'html'):
+        response = "<br />Check log for details<br />"
+    if(completedprocess.stdout):
+        response = " - {}".format(
+            completedprocess.stdout.decode("utf-8").strip()
+        )
+    if(completedprocess.returncode == 0):
+        result = "success"
+        response = ""
+    if(output == 'html'):
+        return '{}...<span class="{}">{}</span>{}'.format(
+            command,
+            result,
+            result.upper(),
+            response
+        )
+    else:
+        return '{}...{}{}'.format(
+            command,
+            result,
+            response
+        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added process_completedprocess(completedprocess, output) function
to naomi/run_command.py. This transforms a completedprocess object
into a success or error message. This will be used when setting up
a new pocketsphinx installation and for STT training.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is part of automatically downloading and installing a
default model for pocketsphinx based on the selected language. 

It is also used with the STT Training modules to provide feedback
via HTML.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running the Pocketsphinx_Adapt trainer and the unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
