### PR TITLE
Switch from pygettext to xgettext

### DIFF
--- a/NaomiSTTTrainer.py
+++ b/NaomiSTTTrainer.py
@@ -484,10 +484,12 @@ def application(environ, start_response):
                                     recording_type = "unclear"
                                     print("Setting recording_type to unclear")
                             # calculate the word error rate
-                            WER = wer(
-                                transcription,
-                                verified_transcription
-                            )
+                            WER = 0
+                            if(len(transcription) > 0):
+                                WER = wer(
+                                    transcription,
+                                    verified_transcription
+                                )
                             c.execute(
                                 " ".join([
                                     "update audiolog set ",

--- a/NaomiSTTTrainer.py
+++ b/NaomiSTTTrainer.py
@@ -949,6 +949,9 @@ def application(environ, start_response):
                         '<body>SQLite error: {}</body>',
                         '</html>'
                     ]).format(e))
+        # Save (commit) the changes
+        conn.commit()
+        conn.close()
         return [line.encode("UTF-8") for line in ret]
 
 

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -1281,7 +1281,7 @@ class Naomi(object):
                         else:
                             required_file = os.path.join(
                                 install_dir,
-                                "python_required.txt"
+                                "python_requirements.txt"
                             )
                             if os.path.isfile(required_file):
                                 # Install any python packages required

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from blessings import Terminal
 from getpass import getpass
 from naomi import app_utils

--- a/plugins/speechhandler/hackernews/hackernews.py
+++ b/plugins/speechhandler/hackernews/hackernews.py
@@ -36,7 +36,8 @@ class HackerNewsPlugin(plugin.SpeechHandlerPlugin):
                         'templates': [
                             "READ HACKER NEWS",
                             "WHAT IS IN HACKER NEWS",
-                            "WHAT ARE THE HACKER NEWS HEADLINES"
+                            "WHAT ARE THE HACKER NEWS HEADLINES",
+                            "WHAT IS HAPPENING IN HACKER NEWS"
                         ]
                     },
                     'fr-FR': {

--- a/plugins/speechhandler/news/news.py
+++ b/plugins/speechhandler/news/news.py
@@ -47,27 +47,45 @@ class NewsPlugin(plugin.SpeechHandlerPlugin):
             'NewsIntent': {
                 'locale': {
                     'en-US': {
+                        'keywords': {
+                            'NewsKeyword': [
+                                'NEWS',
+                                'HEADLINES'
+                            ]
+                        },
                         'templates': [
-                            "READ THE NEWS",
-                            "WHAT IS IN THE NEWS",
-                            "WHAT IS HAPPENING IN THE NEWS",
-                            "WHAT ARE TODAY'S HEADLINES"
+                            "READ THE {NewsKeyword}",
+                            "WHAT IS IN THE {NewsKeyword}",
+                            "WHAT IS HAPPENING IN THE {NewsKeyword}",
+                            "WHAT ARE TODAY'S {NewsKeyword}"
                         ]
                     },
                     'fr-FR': {
+                        'keywords': {
+                            'NewsKeyword': [
+                                "NOUVELLES",
+                                "TITRES D'AUJOURD'HUI"
+                            ]
+                        },
                         'templates': [
-                            "LIRE LES NOUVELLES",
-                            "CE QUI EST DANS LES NOUVELLES",
-                            "CE QUI SE PASSE DANS LES NOUVELLES",
-                            "QUELS SONT LES TITRES D'AUJOURD'HUI"
+                            "LIRE LES {NewsKeyword}",
+                            "CE QUI EST DANS LES {NewsKeyword}",
+                            "CE QUI SE PASSE DANS LES {NewsKeyword}",
+                            "QUELS SONT LES {NewsKeyword}"
                         ]
                     },
                     'de-DE': {
+                        'keywords':{
+                            'NewsKeyword': [
+                                "NACHRICHTEN",
+                                "SCHLAGZEILEN"
+                            ]
+                        },
                         'templates': [
-                            "LIES DIE NACHRICHTEN",
-                            "WAS IST IN DEN NACHRICHTEN",
-                            "WAS PASSIERT IN DEN NACHRICHTEN",
-                            "WAS SIND HEUTE SCHLAGZEILEN"
+                            "LIES DIE {NewsKeyword}",
+                            "WAS IST IN DEN {NewsKeyword}",
+                            "WAS PASSIERT IN DEN {NewsKeyword}",
+                            "WAS SIND HEUTE {NewsKeyword}"
                         ]
                     }
                 },

--- a/plugins/speechhandler/wwis_weather/wwis_weather.py
+++ b/plugins/speechhandler/wwis_weather/wwis_weather.py
@@ -313,7 +313,7 @@ class WWISWeatherPlugin(plugin.SpeechHandlerPlugin):
                 tomorrow.month,
                 tomorrow.day
             )
-            if("today" in text.lower()):
+            if(_("today") in text.lower()):
                 if(todaydate in forecast.keys()):
                     mic.say(
                         _("The weather today in {} is {}").format(
@@ -321,7 +321,7 @@ class WWISWeatherPlugin(plugin.SpeechHandlerPlugin):
                         )
                     )
                     snark = False
-            elif("tomorrow" in text.lower()):
+            elif(_("tomorrow") in text.lower()):
                 if(tomorrowdate in forecast.keys()):
                     mic.say(
                         _("The weather tomorrow in {} will be {}").format(
@@ -334,9 +334,9 @@ class WWISWeatherPlugin(plugin.SpeechHandlerPlugin):
                 first = True
                 for day in sorted(forecast.keys()):
                     if(day == todaydate):
-                        DOW = "today"
+                        DOW = _("today")
                     elif(day == tomorrowdate):
-                        DOW = "tomorrow"
+                        DOW = _("tomorrow")
                     else:
                         DOW = WEEKDAY_NAMES[datetime.datetime.strptime(day, "%Y-%m-%d").weekday()]
                     if(first):

--- a/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
@@ -398,7 +398,7 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                             if(hasattr(plugin, "intents")):
                                 intents = plugin.intents()
                                 for intent in intents:
-                                    for template in intents[intent]['templates']:
+                                    for template in intents[intent]['locale'][self.language]['templates']:
                                         phrases.extend([
                                             word.upper() for word in template.split()
                                         ])
@@ -411,6 +411,13 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                                     info.name, message
                                 )
                             )
+                            self._logger.warning(
+                                "Plugin '{}' skipped! (Reason: {})".format(
+                                    info.name, message
+                                ),
+                                exc_info=True
+                            )
+
                     # Get the set of all words in words_used that do not appear
                     # in phrases
                     print("Phrases:")

--- a/update_translations.py
+++ b/update_translations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Update .po files to receive updated translation strings
 # Create one .po file for the files in the main naomi directory,
@@ -28,8 +28,9 @@ def update_translation_files(
         new_phrases_file = os.path.join(locale_temp_dir, "temp.pot")
         cmd = [
             pygettext_path,
-            "-k", "gettext",
-            "-d", "temp",
+            "-L", "Python",
+            "-kgettext",
+            "-o", "temp.pot",
             "-p", locale_temp_dir
         ]
         for dirName, subdirList, fileList in os.walk(base_dir):
@@ -67,7 +68,8 @@ def update_translation_files(
             print("Updated %s" % language_file)
             # clean up the copied .po file
             os.remove(language_temp_file)
-        os.remove(new_phrases_file)
+        if(os.path.isfile(new_phrases_file)):
+            os.remove(new_phrases_file)
     else:
         logger.warn(
             "Skipping %s, %s directory does not exist" % (
@@ -160,18 +162,8 @@ def main():
                     languages.append(language)
 
     if(len(languages) > 0):
-        pygettext_path = "/".join([
-            "",
-            "usr",
-            "share",
-            "doc",
-            "python2.7",
-            "examples",
-            "Tools",
-            "i18n",
-            "pygettext.py"
-        ])
-        if(check_executable(pygettext_path)):
+        pygettext_path = "xgettext"
+        if(check_executable("xgettext")):
             if(check_executable("msgcat")):
                 # Update the translations for the "naomi" folder and subfolders
                 update_translation_files(
@@ -252,9 +244,9 @@ def main():
             logger.error(
                 '\n'.join([
                     "File %s does not exist." % pygettext_path,
-                    "Please install the examples package for python 2.7:",
+                    "Please install the gettext package:",
                     "",
-                    "sudo apt install python2.7-examples"
+                    "sudo apt install gettext"
                 ])
             )
     else:

--- a/update_translations.py
+++ b/update_translations.py
@@ -11,6 +11,12 @@ import re
 import shutil
 import subprocess
 import tempfile
+from datetime import datetime
+
+import pdb
+PROGRAM = "Naomi"
+VERSION = "3.0"
+LICENSE = "MIT"
 
 
 def update_translation_files(
@@ -18,8 +24,21 @@ def update_translation_files(
     pygettext_path,
     base_dir,
     locale_dir,
-    languages
+    languages,
+    plugin,
+    name,
+    email
 ):
+    now = datetime.now()
+    tdiff=round(100 * (now - datetime.utcnow()).seconds / 3600)
+    zone = str(tdiff) if tdiff<0 else "+{}".format(tdiff)
+    year = str(now.year)
+    month = str(now.month).zfill(2)
+    day = str(now.day).zfill(2)
+    hour = str(now.hour).zfill(2)
+    minute = str(now.minute).zfill(2)
+    second = str(now.second).zfill(2)
+
     if(os.path.isdir(locale_dir)):
         # temp file working directory
         locale_temp_dir = tempfile.gettempdir()
@@ -40,6 +59,7 @@ def update_translation_files(
                 cmd.append(os.path.join(dirName, file))
 
         # create the new phrases file
+        print(" ".join(cmd))
         subprocess.check_call(cmd)
 
         for language in languages:
@@ -49,26 +69,87 @@ def update_translation_files(
             language_temp_file = os.path.join(
                 locale_temp_dir, "%s.po" % language
             )
+            plural_forms = '"Plural-Forms: nplurals=2; plural=(n != 1);\\n"'
+            if(language == "fr-FR"):
+                plural_forms = '"Plural-Forms: nplurals=2; plural=(n>1);\\n"'
             if(os.path.isfile(language_file)):
+                print("cp {} {}".format(language_file, language_temp_file))
                 shutil.copyfile(language_file, language_temp_file)
             else:
                 # create a language file
+                print("touch {}".format(language_temp_file))
                 open(language_temp_file, "w").close()
             # combine the generated pot file with the temporary po file
             # and write them back to the working po file location
             with open(language_file, "w") as fp:
                 try:
-                    for line in (subprocess.check_output(
+                    print("msgcat {} {}".format(language_temp_file, new_phrases_file))
+                    header = False
+                    prev_line = ""
+                    skip1 = False
+                    skip2 = False
+                    for line in subprocess.check_output(
                         ["msgcat", language_temp_file, new_phrases_file]
-                    )):
-                        fp.write(line)
+                    ).decode('utf-8').split("\n"):
+                        if(line == "# #-#-#-#-#  temp.pot (PACKAGE VERSION)  #-#-#-#-#"):
+                            skip1 = True
+                        if(skip1):
+                            if(line == "#, fuzzy"):
+                                skip1 = False
+                            else:
+                                continue
+                        if(line == '"#-#-#-#-#  temp.pot (PACKAGE VERSION)  #-#-#-#-#\\n"'):
+                            skip2 = True
+                        if(skip2):
+                            if(line == ""):
+                                skip2 = False
+                            else:
+                                continue
+                        # Eliminate duplicate lines
+                        if(line == prev_line):
+                            continue
+                        prev_line = line
+                        if(line == "# SOME DESCRIPTIVE TITLE."):
+                            line = "# {} {} {}".format(PROGRAM, VERSION, plugin)
+                        if(line == "# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER"):
+                            line = "# Copyright (C) {} {}".format(year, "Naomi Project")
+                        if(line == "# This file is distributed under the same license as the PACKAGE package."):
+                            line = "# This file is distributed under the same {} license as the {} package.".format(LICENSE, PROGRAM)
+                        if(line == "# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR."):
+                            line = "# {} <{}>, {}".format(name, email, year)
+                        if(line == '"Project-Id-Version: PACKAGE VERSION\\n"'):
+                            line = '"Project-Id-Version: {}\\n"'.format('Naomi 3.0')
+                        if(line == '"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"'):
+                            line = '"Last-Translator: {} <{}>\\n"'.format(name, email)
+                        if(line == '"Language: \\n"'):
+                            line = '"Language: {}\\n"'.format(language)
+                        if(line == '"Report-Msgid-Bugs-To: \\n"'):
+                            line = '"Report-Msgid-Bugs-To: {}\\n"'.format(email)
+                        if(line[:19] == '"PO-Revision-Date: '):
+                            line = '"PO-Revision-Date: {}-{}-{} {}:{}{}\\n"'.format(year, month, day, hour, minute, zone)
+                        if(line == '"Language-Team: LANGUAGE <LL@li.org>\\n"'):
+                            line = '"Language-Team: {} <{}@projectnaomi.com>\\n"'.format(language, language)
+                        if(line == '"Content-Type: text/plain; charset=CHARSET\\n"'):
+                            line = '"Content-Type: text/plain; charset=UTF-8\\n"'
+                        if(line == '"Content-Transfer-Encoding: 8bit\n"'):
+                            line = "\n".join([
+                                '"Content-Transfer-Encoding: 8bit\\n"',
+                                plural_forms
+                            ])
+                        if(line[:15] == '"Plural-Forms: '):
+                            continue
+                        if(line == '"# #-#-#-#-#  temp.pot (PACKAGE VERSION)  #-#-#-#-#\\n"'):
+                            skip2 = True
+                        fp.write("{}\n".format(line))
                 except subprocess.CalledProcessError as e:
                     logger.error(e.output)
                 fp.close()
             print("Updated %s" % language_file)
             # clean up the copied .po file
+            print("rm {}".format(language_temp_file))
             os.remove(language_temp_file)
         if(os.path.isfile(new_phrases_file)):
+            print("rm {}".format(new_phrases_file))
             os.remove(new_phrases_file)
     else:
         logger.warn(
@@ -127,6 +208,18 @@ def main():
         action="store_true",
         help="Show debugging info"
     )
+    parser.add_argument(
+        "-a", "--author",
+        action="store",
+        help="Author's name (defaults to 'Naomi Project')",
+        default="Naomi Project"
+    )
+    parser.add_argument(
+        "-e", "--email",
+        action="store",
+        help="Author's email (defaults to 'naomi@projectnaomi.com'",
+        default="naomi@projectnaomi.com"
+    )
     args = parser.parse_args()
     logging.basicConfig(
         level=logging.DEBUG if args.debug else logging.ERROR
@@ -150,15 +243,18 @@ def main():
                         "%s." % existing_languages
                     ])
                 )
-                response = ""
+                response = "X"
                 while response not in ['Y', 'N']:
-                    response = raw_input(
+                    response = input(
                         " ".join([
                             "Are you sure you want to add it",
-                            "as a new language (Y/N)? "
+                            "as a new language (Y/n)? "
                         ])
                     ).strip().upper()
-                if(response=='Y'):
+                    if(len(response) == 0):
+                        response = 'Y'
+                print()
+                if(response != 'N'):
                     languages.append(language)
 
     if(len(languages) > 0):
@@ -171,7 +267,10 @@ def main():
                     pygettext_path,
                     os.path.join(base_dir, "naomi"),
                     locale_dir,
-                    languages
+                    languages,
+                    "Core",
+                    args.author,
+                    args.email
                 )
 
                 # now walk through all the directories in the plugins/*/
@@ -220,7 +319,10 @@ def main():
                                     plugin,
                                     "locale"
                                 ),
-                                languages
+                                languages,
+                                plugin,
+                                args.author,
+                                args.email
                             )
                 print("Finished.")
                 print(

--- a/update_translations.py
+++ b/update_translations.py
@@ -140,7 +140,7 @@ def update_translation_files(
                                 line = '"Language-Team: {} <{}@projectnaomi.com>\\n"'.format(language, language)
                             if(line == '"Content-Type: text/plain; charset=CHARSET\\n"'):
                                 line = '"Content-Type: text/plain; charset=UTF-8\\n"'
-                            if(line == '"Content-Transfer-Encoding: 8bit\n"'):
+                            if(line == '"Content-Transfer-Encoding: 8bit\\n"'):
                                 line = "\n".join([
                                     '"Content-Transfer-Encoding: 8bit\\n"',
                                     plural_forms

--- a/update_translations.py
+++ b/update_translations.py
@@ -97,7 +97,7 @@ def update_translation_files(
                                 new_phrases_file
                             )
                         )
-                        for line in subprocess.check_output(
+                        for line in subprocess.check_output(  # nosec
                             ["msgcat", language_temp_file, new_phrases_file]
                         ).decode('utf-8').split("\n"):
                             if(line == "# #-#-#-#-#  temp.pot (PACKAGE VERSION)  #-#-#-#-#"):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit switches the update_translations.py script to use
xgettext instead of pygettext, mostly because xgettext is installed
system wide, while pygettext moves around, especially when updating
python versions.

It also contains a few tweaks to the Naomi TTI system, which was
scoring Hacker News higher than News when responding to the word
"news" because every template in Hacker News contains the word
news while one of the templates in News does not. I have therefore
started penalizing the intent proportional to the weight of words
that do not appear in the incoming request, which seems to work
well so far, and penalizes "Hacker News" into a lower ranking if
the word "Hacker" is not detected in the incoming request.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue #224 Translation files need to be updated](https://github.com/NaomiProject/Naomi/issues/224)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Every time Raspbian updates to a new version of Python, the path to this utility changes. The official advice is to use xgettext anyway.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used this to generate brand new translation files a while back, and bundled this updated version with the pull request containing the translations. Unfortunately, this pull request sat around waiting to get merged to the point where eventually the translations became stale. This time I want to submit this update first, then submit the updated translation .po files so they can be worked on.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
