### PR TITLE
naomi-setup.sh

### DIFF
--- a/apt_requirements.txt
+++ b/apt_requirements.txt
@@ -20,10 +20,9 @@ pulsemixer
 
 ## STT
 ### pocketsphinx is default for wakeword spotting
-python3-pocketsphinx
-pocketsphinx
-sphinxbase-utils
-sphinxtrain
+swig
+bison
+
 #### Phonetisaurus is used to build dictionaries
 gcc
 g++

--- a/apt_requirements.txt
+++ b/apt_requirements.txt
@@ -16,7 +16,6 @@ portaudio19-dev
 libasound2-dev
 pulseaudio
 pulseaudio-utils
-pulsemixer
 
 ## STT
 ### pocketsphinx is default for wakeword spotting

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -155,6 +155,10 @@ if [ $APT -eq 1 ]; then
     SUDO_COMMAND "sudo apt upgrade $SUDO_APPROVE"
     # install dependencies
     SUDO_COMMAND "sudo ./naomi_apt_requirements.sh $SUDO_APPROVE"
+    if [ $? -ne 0 ]; then
+        echo "Error installing apt packages" >&2
+        exit 1
+    fi
 else
     ERROR=""
     if [[ $(CHECK_PROGRAM msgfmt) -ne "0" ]]; then
@@ -173,7 +177,7 @@ else
         ERROR="${ERROR} pip3 not found${NL}"
     fi
     if [ ! -z "$ERROR" ]; then
-        echo "Missing depenancies:${NL}${NL}$ERROR"
+        echo "Missing dependencies:${NL}${NL}$ERROR"
         CONTINUE
     fi
 fi

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -74,7 +74,7 @@ for var in "$@"; do
         SUDO_APPROVE="-y"
     fi
     if [ "$var" = "--help" ]; then
-        echo "USAGE: $0 [-y|--yes] [--virtualenv | --local | --primary | --help]"
+        echo "USAGE: $0 [-y|--yes] [--virtualenv | --local-compile | --system | --help]"
         echo
         echo "  --virtualenv    - install Naomi using a virtualenv environment for Naomi"
         echo "                    (this is the recommended choice. You will need to issue"

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -197,14 +197,21 @@ if [ $OPTION = "1" ]; then
         echo -e "\e[1;36m"
         echo "  Y)es, start virtualenvwrapper whenever I start a shell"
         echo "  N)o, don't start virtualenvwrapper for me"
-        echo -n -e "\e[1;36mChoice [\e[1;35mY\e[1;36m/\e[1;35mN\e[1;36m]: \e[0m"
+        echo -n -e "\e[1;36mChoice [\e[1;35mY\e[1;36m/\e[1;35mn\e[1;36m]: \e[0m"
         export AUTO_START=""
-        while [ "$AUTO_START" != "Y" ] && [ "$AUTO_START" != "y" ] && [ "$AUTO_START" != "N" ] && [ "$AUTO_START" != "n" ]; do
-            read -e -p 'Please select: ' AUTO_START
-            if [ "$AUTO_START" != "Y" ] && [ "$AUTO_START" != "y" ] && [ "$AUTO_START" != "N" ] && [ "$AUTO_START" != "n" ]; then
-                echo "Please choose 'Y' or 'N'"
-            fi
-        done
+        if [ "$SUDO_APPROVE" = "-y" ]; then
+            AUTO_START="Y"
+        else
+            while [ "$AUTO_START" != "Y" ] && [ "$AUTO_START" != "y" ] && [ "$AUTO_START" != "N" ] && [ "$AUTO_START" != "n" ]; do
+                read -e -p 'Please select: ' AUTO_START
+                if [ "$AUTO_START" = "" ]; then
+                    AUTO_START="Y"
+                fi
+                if [ "$AUTO_START" != "Y" ] && [ "$AUTO_START" != "y" ] && [ "$AUTO_START" != "N" ] && [ "$AUTO_START" != "n" ]; then
+                    echo "Please choose 'Y' or 'N'"
+                fi
+            done
+        fi
         if [ "$AUTO_START" = "Y" ] || [ "$AUTO_START" = "y" ]; then
             echo "export WORKON_HOME=$HOME/.virtualenvs" >> ~/.bashrc
             echo "export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3" >> ~/.bashrc

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -54,8 +54,9 @@ CHECK_PROGRAM() {
     echo $?
 }
 
-# Create our working directory (unfortunately this does not currently take into accunt the 
-# $
+# Create our working directory
+# FIXME unfortunately this does not currently take into account the 
+# $NAOMI_SUB environment variable)
 mkdir -p ~/.config/naomi/sources
 
 # Check command line options
@@ -107,19 +108,19 @@ fi
 
 # Main program logic
 if [ $OPTION = "0" ]; then
-    echo 'There are three methods to install Naomi:'
-    echo
-    echo '1) Use virtualenvwrapper to create a virtual Python 3 environment'
-    echo '   for Naomi (recommended)'
-    echo '2) Download, compile, and install a local copy of Python for Naomi'
-    echo '   (may not work for some users)'
-    echo '3) Use your primary Python 3 environment (this can be dangerous'
-    echo '   and can break other software on your system. It is only'
-    echo '   recommended for machines you intend to devote to running Naomi,'
-    echo '   like a virtual machine or Raspberry Pi)'
-    echo '4) Exit without installing'
-    echo
-    echo 'Note: This process can take quite a bit of time (up to three hours)'
+    printf "${LT_BLUE}There are three methods to install Naomi:${NL}"
+    printf "${NL}"
+    printf "1) Use virtualenvwrapper to create a virtual Python 3 environment${NL}"
+    printf "   for Naomi (${GREEN}recommended${LT_BLUE})${NL}"
+    printf "2) Download, compile, and install a local copy of Python for Naomi${NL}"
+    printf "   (may not work for some users)${NL}"
+    printf "3) Use your primary Python 3 environment (this can be dangerous${NL}"
+    printf "   and can break other software on your system. It is only${NL}"
+    printf "   recommended for machines you intend to devote to running Naomi,${NL}"
+    printf "   like a virtual machine or Raspberry Pi)${NL}"
+    printf "4) Exit without installing${NL}"
+    printf "${NL}"
+    printf "${RED}Note: This process can take quite a bit of time (up to three hours)${NC}${NL}"
     echo
     while [ $OPTION != "1" ] && [ $OPTION != "2" ] && [ $OPTION != "3" ] && [ $OPTION != "4" ]; do
         read -e -p 'Please select: ' OPTION
@@ -128,6 +129,23 @@ if [ $OPTION = "0" ]; then
         fi
     done
 fi
+
+case $OPTION in
+    "1")
+        printf "${GREEN}Installing using VirtualEnvWrapper${NC}${NL}"
+        ;;
+    "2")
+        printf "${GREEN}Installing using custom built python${NC}${NL}"
+        ;;
+    "3")
+        printf "${GREEN}Installing using default python3${NC}${NL}"
+        ;;
+    "4")
+        printf "${GREEN}Exiting${NC}${NL}"
+        exit 1
+        ;;
+esac
+
 # Assume this program is in the main Naomi directory
 # so we can save and return to it.
 NAOMI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -237,17 +255,20 @@ if [ $OPTION = "1" ]; then
     echo "python $NAOMI_DIR/Naomi.py \$@" >> Naomi
 fi
 if [ $OPTION = "2" ]; then
-    # installing python 3.5.3
-    echo 'Installing python 3.5.3 to ~/.config/naomi/local'
+    # installing python
+    echo 'Installing python 3.7.7 to ~/.config/naomi/local'
+    # libffi-dev required to build cython, required for setuptools, required for pip
+    # libsqlite3-dev required to build sqlite3 module
+    SUDO_COMMAND "sudo apt install libffi-dev libsqlite3-dev $SUDO_APPROVE"
     mkdir -p ~/.config/naomi/local
-    cd ~/.config/naomi/local
+    cd ~/.config/naomi/sources
     NAME=Python
-    VERSION=3.5.3
+    VERSION=3.7.7
     VERNAME=$NAME-$VERSION
-    CHKSUM=d8890b84d773cd7059e597dbefa510340de8336ec9b9e9032bf030f19291565a
+    CHKSUM=d348d978a5387512fbc7d7d52dd3a5ef
     TARFILE=$VERNAME.tgz
     URL=https://www.python.org/ftp/python/$VERSION/$TARFILE
-    KEYID=3A5CA953F73C700D # Larry Hastings <larry@hastings.org>
+    KEYID=2D347EA6AA65421D # Ned Deily (Python release signing key) <nad@python.org>
     if [ ! -f $TARFILE ]; then
         wget $URL
     fi
@@ -262,7 +283,8 @@ if [ $OPTION = "2" ]; then
         echo "Can't verify $TARFILE signature" >&2
         exit 1
     fi
-    echo "$CHKSUM $TARFILE" | sha256sum -c -
+    echo "$CHKSUM $TARFILE" | md5sum -c -
+
     if [ $? -eq 0 ]; then
         echo "Python checksum verified"
     else
@@ -271,62 +293,33 @@ if [ $OPTION = "2" ]; then
     fi
     tar xvzf $TARFILE
     cd $VERNAME
-    ./configure
+    export PYTHONHOME=$(cd ~/.config/naomi/local && pwd)
+    printf "[$(pwd)]\$ ${GREEN}./configure --prefix=${PYTHONHOME}${NC}${NL}"
+    ./configure --prefix=$PYTHONHOME
+    printf "[$(pwd)]\$ ${GREEN}make${NC}${NL}"
     make
-    make altinstall prefix=~/.config/naomi/local  # specify local installation directory
-    ln -s ~/.config/naomi/local/bin/python3.5 ~/.config/naomi/local/bin/python
+    printf "[$(pwd)]\$ ${GREEN}make altinstall prefix=${PYTHONHOME}${NC}${NL}"
+    make altinstall prefix=$PYTHONHOME  # specify local installation directory
+
+    echo "****************"
+    echo "Python Installed to ${PYTHONHOME}/bin/python"
+    echo "****************"
+    ln -s ~/.config/naomi/local/bin/python${VERSION:0:3} ~/.config/naomi/local/bin/python
+    ln -s ~/.config/naomi/local/bin/pip${VERSION:0:3} ~/.config/naomi/local/bin/pip
+    echo "Links created"
     cd ..  # ~/.config/naomi/local
-
-    # install setuptools and pip for package management
-    NAME=setuptools
-    VERSION=40.6.3
-    VERNAME=$NAME-$VERSION
-    CHKSUM=3b474dad69c49f0d2d86696b68105f3a6f195f7ab655af12ef9a9c326d2b08f8
-    ZIPFILE=$VERNAME.zip
-    URL=https://files.pythonhosted.org/packages/37/1b/b25507861991beeade31473868463dad0e58b1978c209de27384ae541b0b/$ZIPFILE
-    # URL=https://files.pythonhosted.org/packages/37/1b/b25507861991beeade31473868463dad0e58b1978c209de27384ae541b0b/setuptools-40.6.3.zip
-    echo 'Installing setuptools'
-    if [ ! -f $ZIPFILE ]; then
-        wget $URL
-    fi
-    echo "$CHKSUM $ZIPFILE" | sha256sum -c -
-    if [ $? -eq 0 ]; then
-        echo "SetupTools checksum verified"
-    else
-        echo "SetupTools checksum verification failed" >&2
-        exit 1
-    fi
-    unzip $ZIPFILE
-    cd $VERNAME
-    ~/.config/naomi/local/bin/python setup.py install  # specify the path to the python you installed above
-    cd .. # ~/.config/naomi/local
-
-    # The old version of pip expects to access pypi.org using http. PyPi now
-    # requires ssl for all connections.
-    NAME=pip
-    VERSION=18.1
-    VERNAME=$NAME-$VERSION
-    CHKSUM=c0a292bd977ef590379a3f05d7b7f65135487b67470f6281289a94e015650ea1
-    TARFILE=$VERNAME.tar.gz
-    URL=https://files.pythonhosted.org/packages/45/ae/8a0ad77defb7cc903f09e551d88b443304a9bd6e6f124e75c0fbbf6de8f7/$TARFILE
-    if [ ! -f $TARFILE ]; then
-        wget $URL
-    fi
-    echo "$CHKSUM $TARFILE" | sha256sum -c -
-    if [ $? -eq 0 ]; then
-        echo "$TARFILE checksum verified"
-    else
-        echo "$TARFILE checksum failed" >&2
-        exit 1
-    fi
-    tar xvzf $TARFILE
-    cd $VERNAME # ~/.config/naomi/local/pip-18.1
-    ~/.config/naomi/local/bin/python setup.py install  # specify the path to the python you installed above
 
     # install naomi & dependencies
     echo "Returning to $NAOMI_DIR"
     cd $NAOMI_DIR
-    ~/.config/naomi/local/bin/pip install -r python_requirements.txt
+    # Create a custom cache dir so we don't use cached files from our main python
+    export XDG_CACHE_HOME=~/.config/naomi/local/cache
+    mkdir -p "$XDG_CACHE_HOME"
+    ~/.config/naomi/local/bin/pip install --cache-dir=~/.config/naomi/local/cache -r python_requirements.txt
+    if [ $? -ne 0 ]; then
+        echo "Error installing python_requirements.txt"
+        exit 1
+    fi
 
     # start the naomi setup process
     echo "#!/bin/bash" > Naomi
@@ -406,7 +399,11 @@ cd Phonetisaurus
 make
 echo "Installing Phonetisaurus"
 SUDO_COMMAND "sudo make install"
+
+echo "cd python"
 cd python
+echo $(pwd)
+
 cp -iv ../.libs/Phonetisaurus.so ./
 if [ "$OPTION" = "1" ]; then
     SUDO_COMMAND "sudo python setup.py install"

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -238,7 +238,7 @@ if [ $OPTION = "1" ]; then
         fi
         pip install -r python_requirements.txt
         if [ $? -ne 0 ]; then
-            echo "Error installing python requirements: $!"
+            echo "Error installing python requirements: $!" >&2
             exit 1
         fi
     else
@@ -317,7 +317,7 @@ if [ $OPTION = "2" ]; then
     mkdir -p "$XDG_CACHE_HOME"
     ~/.config/naomi/local/bin/pip install --cache-dir=~/.config/naomi/local/cache -r python_requirements.txt
     if [ $? -ne 0 ]; then
-        echo "Error installing python_requirements.txt"
+        echo "Error installing python_requirements.txt" >&2
         exit 1
     fi
 
@@ -326,7 +326,11 @@ if [ $OPTION = "2" ]; then
     echo "~/.config/naomi/local/bin/python $NAOMI_DIR/Naomi.py \$@" >> Naomi
 fi
 if [ $OPTION = "3" ]; then
-    pip3 install -r python_requirements.txt
+    pip3 install --user -r python_requirements.txt
+    if [ $? -ne 0 ]; then
+        echo "Error installing python_requirements.txt" >&2
+        exit 1
+    fi
     # start the naomi setup process
     echo "#!/bin/bash" > Naomi
     echo "python3 $NAOMI_DIR/Naomi.py \$@" >> Naomi
@@ -351,12 +355,12 @@ autoreconf -i
 make
 SUDO_COMMAND "sudo make install"
 if [ $? -ne 0 ]; then
-    echo $!
+    echo $! >&2
     exit 1
 fi
 
 if [ -z "$(which fstinfo)" ]; then
-    echo "ERROR: openfst not installed"
+    echo "ERROR: openfst not installed" >&2
     exit 1
 fi
 
@@ -378,7 +382,7 @@ make
 echo "Installing mitlm"
 SUDO_COMMAND "sudo make install"
 if [ $? -ne 0 ]; then
-    echo $!
+    echo $! >&2
     exit 1
 fi
 
@@ -388,7 +392,7 @@ echo -e "\e[1;32mInstalling & Building cmuclmtk...\e[0m"
 cd ~/.config/naomi/sources
 svn co https://svn.code.sf.net/p/cmusphinx/code/trunk/cmuclmtk/
 if [ $? -ne 0 ]; then
-    printf "${ERROR}Error cloning cmuclmtk${NC}${NL}"
+    echo "Error cloning cmuclmtk" >&2
     exit 1
 fi
 
@@ -408,7 +412,7 @@ cd ~/.config/naomi/sources
 if [ ! -d "Phonetisaurus" ]; then
     git clone https://github.com/AdolfVonKleist/Phonetisaurus.git
     if [ $? -ne 0 ]; then
-        printf "${ERROR}Error cloning Phonetisaurus${NC}${NL}"
+        echo "Error cloning Phonetisaurus" >&2
         exit 1
     fi
 fi
@@ -434,7 +438,7 @@ if [ "$OPTION" = "3" ]; then
 fi
 
 if [ -z "$(which phonetisaurus-g2pfst)" ]; then
-    echo "ERROR: phonetisaurus-g2pfst does not exist"
+    echo "ERROR: phonetisaurus-g2pfst does not exist" >&2
     EXIT 1
 fi
 
@@ -445,7 +449,7 @@ cd ~/.config/naomi/sources
 if [ ! -d "pocketsphinx-python" ]; then
     git clone --recursive https://github.com/cmusphinx/pocketsphinx-python.git
     if [ $? -ne 0 ]; then
-        printf "${ERROR}Error cloning pocketsphinx${NC}${NL}"
+        echo "Error cloning pocketsphinx" >&2
         exit 1
     fi
 fi
@@ -479,15 +483,15 @@ fi
 
 cd $NAOMI_DIR
 if [ -z "$(which text2wfreq)" ]; then
-    echo "ERROR: text2wfreq does not exist"
+    echo "ERROR: text2wfreq does not exist" >&2
     EXIT 1
 fi
 if [ -z "$(which text2idngram)" ]; then
-    echo "ERROR: text2idngram does not exist"
+    echo "ERROR: text2idngram does not exist" >&2
     EXIT 1
 fi
 if [ -z "$(which idngram2lm)" ]; then
-    echo "ERROR: idngram2lm does not exist"
+    echo "ERROR: idngram2lm does not exist" >&2
     EXIT 1
 fi
 
@@ -520,4 +524,3 @@ fi
 echo "In the future, run $NAOMI_DIR/Naomi to start Naomi"
 echo
 ./Naomi --repopulate
-

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -425,6 +425,11 @@ echo
 echo -e "\e[1;32mBuilding and installing sphinxbase...\e[0m"
 cd ~/.config/naomi/sources
 git clone --recursive https://github.com/cmusphinx/pocketsphinx-python.git
+if [ $? -ne 0 ]; then
+    printf "${ERROR}Error cloning pocketsphinx${NC}${NL}"
+    exit 1
+fi
+
 cd pocketsphinx-python/sphinxbase
 ./autogen.sh
 make

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -365,6 +365,11 @@ echo
 echo -e "\e[1;32mInstalling & Building mitlm-0.4.2...\e[0m"
 cd ~/.config/naomi/sources
 git clone https://github.com/mitlm/mitlm.git
+if [ $? -ne 0 ]; then
+    printf "${ERROR}Error cloning mitlm${NC}${NL}"
+    exit 1
+fi
+
 cd mitlm
 ./autogen.sh
 make
@@ -380,6 +385,11 @@ echo
 echo -e "\e[1;32mInstalling & Building cmuclmtk...\e[0m"
 cd ~/.config/naomi/sources
 svn co https://svn.code.sf.net/p/cmusphinx/code/trunk/cmuclmtk/
+if [ $? -ne 0 ]; then
+    printf "${ERROR}Error cloning cmuclmtk${NC}${NL}"
+    exit 1
+fi
+
 cd cmuclmtk
 ./autogen.sh
 make
@@ -394,17 +404,21 @@ echo
 echo -e "\e[1;32mInstalling & Building phonetisaurus...\e[0m"
 cd ~/.config/naomi/sources
 git clone https://github.com/AdolfVonKleist/Phonetisaurus.git
+if [ $? -ne 0 ]; then
+    printf "${ERROR}Error cloning Phonetisaurus${NC}${NL}"
+    exit 1
+fi
 cd Phonetisaurus
 ./configure --enable-python
 make
 echo "Installing Phonetisaurus"
 SUDO_COMMAND "sudo make install"
 
-echo "cd python"
+printf "[$(pwd)]\$ ${GREEN}cd python${NC}${NL}"
 cd python
 echo $(pwd)
 
-cp -iv ../.libs/Phonetisaurus.so ./
+cp -v ../.libs/Phonetisaurus.so ./
 if [ "$OPTION" = "1" ]; then
     SUDO_COMMAND "sudo python setup.py install"
 fi

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -364,10 +364,12 @@ fi
 echo
 echo -e "\e[1;32mInstalling & Building mitlm-0.4.2...\e[0m"
 cd ~/.config/naomi/sources
-git clone https://github.com/mitlm/mitlm.git
-if [ $? -ne 0 ]; then
-    printf "${ERROR}Error cloning mitlm${NC}${NL}"
-    exit 1
+if [ ! -d "mitlm" ]; then
+    git clone https://github.com/mitlm/mitlm.git
+    if [ $? -ne 0 ]; then
+        printf "${ERROR}Error cloning mitlm${NC}${NL}"
+        exit 1
+    fi
 fi
 
 cd mitlm
@@ -403,10 +405,12 @@ SUDO_COMMAND "sudo ldconfig"
 echo
 echo -e "\e[1;32mInstalling & Building phonetisaurus...\e[0m"
 cd ~/.config/naomi/sources
-git clone https://github.com/AdolfVonKleist/Phonetisaurus.git
-if [ $? -ne 0 ]; then
-    printf "${ERROR}Error cloning Phonetisaurus${NC}${NL}"
-    exit 1
+if [ ! -d "Phonetisaurus" ]; then
+    git clone https://github.com/AdolfVonKleist/Phonetisaurus.git
+    if [ $? -ne 0 ]; then
+        printf "${ERROR}Error cloning Phonetisaurus${NC}${NL}"
+        exit 1
+    fi
 fi
 cd Phonetisaurus
 ./configure --enable-python
@@ -438,10 +442,12 @@ fi
 echo
 echo -e "\e[1;32mBuilding and installing sphinxbase...\e[0m"
 cd ~/.config/naomi/sources
-git clone --recursive https://github.com/cmusphinx/pocketsphinx-python.git
-if [ $? -ne 0 ]; then
-    printf "${ERROR}Error cloning pocketsphinx${NC}${NL}"
-    exit 1
+if [ ! -d "pocketsphinx-python" ]; then
+    git clone --recursive https://github.com/cmusphinx/pocketsphinx-python.git
+    if [ $? -ne 0 ]; then
+        printf "${ERROR}Error cloning pocketsphinx${NC}${NL}"
+        exit 1
+    fi
 fi
 
 cd pocketsphinx-python/sphinxbase

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -26,7 +26,7 @@ LT_CYAN='\033[1;36m'
 WHITE='\033[1;37m'
 NC='\033[0m' # No Color
 OPTION="0"
-SUDO_APPROVE="n"
+SUDO_APPROVE=""
 
 CONTINUE() {
     read -n1 -p "Press 'q' to quit, any other key to continue: " CONTINUE

--- a/naomi_apt_requirements.sh
+++ b/naomi_apt_requirements.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
-xargs -a <(awk '! /^ *(#|$)/' apt_requirements.txt) -r -- sudo apt install
+SUDO_APPROVE=""
+for var in "$@"; do
+    if [ "$var" = "-y" ] || [ "$var" = "--yes" ]; then
+        SUDO_APPROVE="-y"
+    fi
+done
+xargs -a <(awk '! /^ *(#|$)/' apt_requirements.txt) -r -- apt install $SUDO_APPROVE
 

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -1,7 +1,7 @@
 # Naomi core dependencies
 APScheduler
 argparse
-mock
+mock==3.0.5
 pytz
 PyYAML
 requests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I'm working on getting the naomi-setup.sh script working in a basic way.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue #67 Friendlier initial configuration](https://github.com/NaomiProject/Naomi/issues/67)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to make it easy for a new user to get Naomi up and running in a basic way using a default configuration. For right now, that is pyaudio, pulseaudio, pocketsphinx and flite. The goal is to direct the user to this one file, have them run it, and have it come up with a usable system. After that, they can decide if they are interested in working on configuring and training it.

The script describes what it is doing and asks permission every time it needs to use the sudo command, which can be annoying since building Phonetisaurus takes so long. Just run `./naomi-setup.sh --help for a list of command line options. If you pass in an option instead of selecting it from the menu, you won't have to keep pressing keys to keep the installer going.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this on a Raspberry Pi 4B running Raspbian Buster.
So far I have only tested the VirtualEnvWrapper option. I need to re-flash my pi and try both the custom Python and direct install options and have all of them 

Discovered that the modules installed for the main python instance
do not automatically become available for the virtual python
environment of the same type, so using apt to install
python3-pocketsphinx did not work, since the pocketsphinx module
would not be available to the virtual environment.

I could have just installed the Pypi version through pip, which
should be fine, but it could lead to a situation where the
python module is a different version from the main pocketsphinx.

It's not that big a deal to build pocketsphinx, so I'm opting to
just do that and install the python version from that same build
process.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
