### PR TITLE
New NotificationClient plugin type

### DIFF
--- a/naomi/app_utils.py
+++ b/naomi/app_utils.py
@@ -274,8 +274,6 @@ def get_message_text(msg):
                 break
     else:
         body = re.sub('[\\r\\n\\t]+', ' ', msg.get_payload())
-    if(body[:len(subject)] != subject):
-        body = " ".join([subject, body])
     return body
 
 

--- a/naomi/app_utils.py
+++ b/naomi/app_utils.py
@@ -79,7 +79,14 @@ def check_smtp_config():
     PORT = profile.get(['email', 'smtp', 'port'], 587)
     if(success):
         try:
-            session = smtplib.SMTP(SERVER, PORT)
+            session = smtplib.SMTP(
+                SERVER,
+                PORT,
+                profile.get(
+                    ['email', 'smtp', 'timeout'],
+                    10
+                )
+            )
             session.starttls()
             session.login(USERNAME, PASSWORD)
             session.quit()

--- a/naomi/app_utils.py
+++ b/naomi/app_utils.py
@@ -264,7 +264,6 @@ def get_sender_email(msg):
 
 
 def get_message_text(msg):
-    subject = msg['Subject']
     if(msg.is_multipart()):
         for part in msg.walk():
             ctype = part.get_content_type()

--- a/naomi/brain.py
+++ b/naomi/brain.py
@@ -120,6 +120,8 @@ class Brain(object):
             A tuple containing a text and the module that can handle it
         """
         for text in texts:
+            # convert text to upper case and remove any punctuation
+            text = self._intentparser.cleantext(text)
             intents = self._intentparser.determine_intent(text)
             for intent in intents:
                 # Add the intent to the response so the handler method

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -61,6 +61,7 @@ class commandline(object):
             affirmative = 'yes'
             negative = 'no'
 
+    # FIXME this does not belong here.
     def get_language(self, language=None, once=False):
         global _
         languages = {

--- a/naomi/notifier.py
+++ b/naomi/notifier.py
@@ -10,9 +10,9 @@ class Notifier(object):
         self._logger = logging.getLogger(__name__)
         self._logger.info("Setting up notifier")
         self.notifiers = []
-        
+
         # add all notifier plugins
-        notification_clients=pluginstore.PluginStore()
+        notification_clients = pluginstore.PluginStore()
         notification_clients.detect_plugins("notificationclient")
         for info in notification_clients.get_plugins():
             notifier = info.plugin_class(

--- a/naomi/notifier.py
+++ b/naomi/notifier.py
@@ -28,6 +28,7 @@ class Notifier(object):
 
         sched = BackgroundScheduler(timezone="UTC", daemon=True)
         sched.start()
+        # FIXME add an interval setting to profile so this can be overridden
         sched.add_job(self.gather, 'interval', seconds=30)
         atexit.register(lambda: sched.shutdown(wait=False))
 

--- a/naomi/notifier.py
+++ b/naomi/notifier.py
@@ -1,60 +1,31 @@
 # -*- coding: utf-8 -*-
 import atexit
-import contextlib
 import logging
-import random
-import queue
 from apscheduler.schedulers.background import BackgroundScheduler
-from naomi import app_utils
-from naomi import i18n
-from naomi import paths
-from naomi import profile
+from naomi import pluginstore
 
 
 class Notifier(object):
-
-    class NotificationClient(object):
-
-        def __init__(self, gather, timestamp):
-            self.gather = gather
-            self.timestamp = timestamp
-
-        def run(self):
-            self.timestamp = self.gather(self.timestamp)
-
     def __init__(self, mic, brain, *args, **kwargs):
         self._logger = logging.getLogger(__name__)
         self._logger.info("Setting up notifier")
-        translations = i18n.parse_translations(paths.data('locale'))
-        translator = i18n.GettextMixin(translations)
-        self.gettext = translator.gettext
-        self._mic = mic
-        self._brain = brain
-        self.q = queue.Queue()
         self.notifiers = []
+        
+        # add all notifier plugins
+        notification_clients=pluginstore.PluginStore()
+        notification_clients.detect_plugins("notificationclient")
+        for info in notification_clients.get_plugins():
+            notifier = info.plugin_class(
+                info,
+                mic=mic,
+                brain=brain,
+                timestamp=None
+            )
+            if(hasattr(notifier, "gather")):
+                self.notifiers.append(
+                    notifier
+                )
 
-        # check to see if we can connect to an email account
-        if(app_utils.check_imap_config()):
-            self.notifiers.append(
-                self.NotificationClient(
-                    self.handle_email_notifications,
-                    None
-                )
-            )
-            if(not app_utils.check_smtp_config()):
-                self._logger.warning(
-                    " ".join([
-                        'Email smtp access is not configured,',
-                        'I will not be able to respond.'
-                    ])
-                )
-        else:
-            self._logger.warning(
-                " ".join([
-                    'Email imap access is not configured,',
-                    'notifier will not be used'
-                ])
-            )
         sched = BackgroundScheduler(timezone="UTC", daemon=True)
         sched.start()
         sched.add_job(self.gather, 'interval', seconds=30)
@@ -62,130 +33,3 @@ class Notifier(object):
 
     def gather(self):
         [client.run() for client in self.notifiers]
-
-    def handle_email_notifications(self, last_date):
-        """Places new Gmail notifications in the Notifier's queue."""
-        def handle_email(e):
-            # if the subject line matches the first line of the email, then
-            # discard the subject line. If not, then append the body to the
-            # subject line.
-            message = app_utils.get_message_text(e)
-            if(any(x in message for x in profile.get(["keyword"]))):
-                # This message should be marked as read
-                app_utils.mark_read(e)
-                emailmic = EmailMic(
-                    address=e['From'],
-                    subject=e["Subject"]
-                )
-                intent = self._brain.query([message])
-                if intent:
-                    try:
-                        self._logger.info(intent)
-                        intent['action'](intent, emailmic)
-                    except Exception:
-                        self._logger.error(
-                            'Failed to execute module',
-                            exc_info=True
-                        )
-                        self.mic.say(
-                            " ".join([
-                                self.gettext("I'm sorry."),
-                                self.gettext("I had some trouble with that operation."),
-                                self.gettext("Please try again later.")
-                            ])
-                        )
-                    else:
-                        self._logger.debug(
-                            " ".join([
-                                "Handling of phrase '{}'",
-                                "by module '{}' completed"
-                            ]).format(
-                                message,
-                                intent
-                            )
-                        )
-                else:
-                    emailmic.say(random.choice([  # nosec
-                        self.gettext("I'm sorry, could you repeat that?"),
-                        self.gettext("My apologies, could you try saying that again?"),
-                        self.gettext("Say that again?"),
-                        self.gettext("I beg your pardon?")
-                    ]))
-            else:
-                self._mic.say("New email from %s." % app_utils.get_sender(e))
-            return True
-
-        self._logger.info("Checking email since {}".format(last_date))
-        try:
-            emails = app_utils.fetch_emails(since=last_date, email_filter="(UNSEEN)")
-            self._logger.info("{} new emails".format(len(emails)))
-            if emails:
-                last_date = app_utils.get_most_recent_date(emails)
-            for e in emails:
-                self.q.put(handle_email(e))
-        except Exception:
-            self._logger.warn("Problem checking email")
-
-        return last_date
-
-    def get_notification(self):
-        """Returns a notification. Note that this function is consuming."""
-        try:
-            notif = self.q.get(block=False)
-            return notif
-        except queue.Empty:
-            return None
-
-    def get_all_notifications(self):
-        """
-            Return a list of notifications in chronological order.
-            Note that this function is consuming, so consecutive calls
-            will yield different results.
-        """
-        notifs = []
-
-        notif = self.get_notification()
-        while notif:
-            notifs.append(notif)
-            notif = self.get_notification()
-
-        return notifs
-
-
-# This is a replacement for the Mic object but it sends an email.
-class EmailMic(object):
-    prev = None
-
-    def __init__(self, address, subject, *args, **kwargs):
-        self._to = address
-        self._subject = subject
-        return
-
-    @staticmethod
-    @contextlib.contextmanager
-    def special_mode(name, phrases):
-        yield
-
-    def wait_for_keyword(self, keyword="NAOMI"):
-        if(self.passive_listen):
-            return self.active_listen()
-        else:
-            return
-
-    # This gets called if the handler is supposed to wait for input.
-    @staticmethod
-    def active_listen(timeout=3):
-        # input_text = input("YOU: ")
-        # unicodedata.normalize('NFD', input_text).encode('ascii', 'ignore')
-        # self.prev = input_text
-        return [""]
-
-    def listen(self):
-        return self.active_listen(timeout=3)
-
-    def say(self, phrase, OPTIONS=None):
-        app_utils.send_email(
-            "Re: {}".format(self._subject),
-            phrase,
-            self._to
-        )

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -2,19 +2,19 @@
 import abc
 import collections
 import logging
+import mad
 import tempfile
 import wave
-import mad
-from . import paths
-from . import vocabcompiler
 from . import audioengine
-from . import i18n
 from . import commandline
+from . import i18n
+from . import paths
 from . import profile
+from . import vocabcompiler
 
 
 class GenericPlugin(object):
-    def __init__(self, info, *args):
+    def __init__(self, info, *args, **kwargs):
         self._plugin_info = info
         if(not hasattr(self, '_logger')):
             self._logger = logging.getLogger(__name__)
@@ -259,6 +259,155 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
     def determine_intent(self, phrase):
         pass
 
+    @staticmethod
+    def cleantext(text):
+        language = profile.get(["language"], "en-US")[:2]
+        if language=="en":
+            # upper case
+            text = text.upper()
+            words = text.split(" ")
+            # Adapted from a list at https://stackoverflow.com/questions/19790188/expanding-english-language-contractions-in-python
+            contractions = { 
+                "AIN'T": "ARE NOT", # "am not / are not / is not / has not / have not"
+                "AREN'T": "ARE NOT",
+                "CAN'T": "CAN NOT",
+                "CAN'T'VE": "CAN NOT HAVE",
+                "'CAUSE": "BECAUSE",
+                "COULD'VE": "COULD HAVE",
+                "COULDN'T": "COULD NOT",
+                "COULDN'T'VE": "COULD NOT HAVE",
+                "DIDN'T": "DID NOT",
+                "DOESN'T": "DOES NOT",
+                "DON'T": "DO NOT",
+                "HADN'T": "HAD NOT",
+                "HADN'T'VE": "HAD NOT HAVE",
+                "HASN'T": "HAS NOT",
+                "HAVEN'T": "HAVE NOT",
+                "HE'D": "HE WOULD", # "he had / he would",
+                "HE'D'VE": "HE WOULD HAVE",
+                "HE'LL": "HE WILL", # "he shall / he will",
+                "HE'LL'VE": "HE WILL HAVE", # "he shall have / he will have",
+                "HE'S": "HE IS", # "he has / he is",
+                "HOW'D": "HOW DID",
+                "HOW'D'Y": "HOW DO YOU",
+                "HOW'LL": "HOW WILL",
+                "HOW'S": "HOW IS", # "how has / how is / how does",
+                "I'D": "I WOULD", # "I had / I would",
+                "I'D'VE": "I WOULD HAVE",
+                "I'LL": "I WILL", # "I shall / I will",
+                "I'LL'VE": "I WILL HAVE", # "I shall have / I will have",
+                "I'M": "I AM",
+                "I'VE": "I HAVE",
+                "ISN'T": "IS NOT",
+                "IT'D": "IT WOULD", # "it had / it would",
+                "IT'D'VE": "IT WOULD HAVE",
+                "IT'LL": "IT WILL", # "it shall / it will",
+                "IT'LL'VE": "IT WILL HAVE", # "it shall have / it will have",
+                "IT'S": "IT IS", # "it has / it is",
+                "LET'S": "LET US",
+                "MA'AM": "MADAM",
+                "MAYN'T": "MAY NOT",
+                "MIGHT'VE": "MIGHT HAVE",
+                "MIGHTN'T": "MIGHT NOT",
+                "MIGHTN'T'VE": "MIGHT NOT HAVE",
+                "MUST'VE": "MUST HAVE",
+                "MUSTN'T": "MUST NOT",
+                "MUSTN'T'VE": "MUST NOT HAVE",
+                "NEEDN'T": "NEED NOT",
+                "NEEDN'T'VE": "NEED NOT HAVE",
+                "OUGHTN'T": "OUGHT NOT",
+                "OUGHTN'T'VE": "OUGHT NOT HAVE",
+                "SHAN'T": "SHALL NOT",
+                "SHAN'T'VE": "SHALL NOT HAVE",
+                "SHE'D": "SHE WOULD", # "she had / she would",
+                "SHE'D'VE": "SHE WOULD HAVE",
+                "SHE'LL": "SHE WILL", # "she shall / she will",
+                "SHE'LL'VE": "SHE WILL HAVE", # "she shall have / she will have",
+                "SHE'S": "SHE IS", # "she has / she is",
+                "SHOULD'VE": "SHOULD HAVE",
+                "SHOULDN'T": "SHOULD NOT",
+                "SHOULDN'T'VE": "SHOULD NOT HAVE",
+                "SO'VE": "SO HAVE",
+                "SO'S": "SO IS", # "so as / so is",
+                "THAT'D": "THAT WOULD", # "that would / that had",
+                "THAT'WOULD'VE": "THAT WOULD HAVE",
+                "THAT'S": "THAT IS", # "that has / that is",
+                "THERE'D": "THERE WOULD", # "there had / there would",
+                "THERE'D'VE": "THERE WOULD HAVE",
+                "THERE'S": "THERE IS", # "there has / there is",
+                "THEY'D": "THEY WOULD", # "they had / they would",
+                "THEY'D'VE": "THEY WOULD HAVE",
+                "THEY'LL": "THEY WILL", # "they shall / they will",
+                "THEY'LL'VE": "THEY WILL HAVE", # "they shall have / they will have",
+                "THEY'RE": "THEY ARE",
+                "THEY'VE": "THEY HAVE",
+                "TO'VE": "TO HAVE",
+                "WASN'T": "WAS NOT",
+                "WE'D": "WE WOULD", # "we had / we would",
+                "WE'D'VE": "WE WOULD HAVE",
+                "WE'LL": "WE WILL",
+                "WE'LL'VE": "WE WILL HAVE",
+                "WE'RE": "WE ARE",
+                "WE'VE": "WE HAVE",
+                "WEREN'T": "WERE NOT",
+                "WHAT'LL": "WHAT WILL", # "what shall / what will",
+                "WHAT'LL'VE": "WHAT WILL HAVE", # "what shall have / what will have",
+                "WHAT'RE": "WHAT ARE",
+                "WHAT'S": "WHAT IS", # "what has / what is",
+                "WHAT'VE": "WHAT HAVE",
+                "WHEN'S": "WHEN IS", # "when has / when is",
+                "WHEN'VE": "WHEN HAVE",
+                "WHERE'D": "WHERE DID",
+                "WHERE'S": "WHERE IS", # "where has / where is",
+                "WHERE'VE": "WHERE HAVE",
+                "WHO'LL": "WHO WILL", # "who shall / who will",
+                "WHO'LL'VE": "WHO WILL HAVE", # "who shall have / who will have",
+                "WHO'S": "WHO IS", # "who has / who is",
+                "WHO'VE": "WHO HAVE",
+                "WHY'S": "WHY IS", # "why has / why is",
+                "WHY'VE": "WHY HAVE",
+                "WILL'VE": "WILL HAVE",
+                "WON'T": "WILL NOT",
+                "WON'T'VE": "WILL NOT HAVE",
+                "WOULD'VE": "WOULD HAVE",
+                "WOULDN'T": "WOULD NOT",
+                "WOULDN'T'VE": "WOULD NOT HAVE",
+                "Y'ALL": "YOU ALL",
+                "Y'ALL'D": "YOU ALL WOULD",
+                "Y'ALL'D'VE": "YOU ALL WOULD HAVE",
+                "Y'ALL'RE": "YOU ALL ARE",
+                "Y'ALL'VE": "YOU ALL HAVE",
+                "YOU'D": "YOU WOULD", # "you had / you would",
+                "YOU'D'VE": "YOU WOULD HAVE",
+                "YOU'LL": "YOU WILL", # "you shall / you will",
+                "YOU'LL'VE": "YOU WILL HAVE", # "you shall have / you will have",
+                "YOU'RE": "YOU ARE",
+                "YOU'VE": "YOU HAVE"
+            }
+            for i in range(len(words)):
+                # expand contractions
+                if words[i] in contractions:
+                    words[i]=contractions[words[i]]
+                # remove punctuation from beginning and end of words
+                while len(words[i])>0 and words[i][:1] not in [chr(i) for i in range(65, 91)]:
+                    words[i]=words[i][1:]
+                while len(words[i])>0 and words[i][-1:] not in [chr(i) for i in range(65,91)]:
+                    words[i]=words[i][:-1]
+            # put it all back together
+            text = " ".join(words)
+        return text
 
 class VisualizationsPlugin(GenericPlugin):
     pass
+
+
+class NotificationClientPlugin(GenericPlugin):
+
+    def __init__(self, *args, **kwargs):
+        GenericPlugin.__init__(self, *args, **kwargs)
+        self._mic = kwargs["mic"]
+        self._brain = kwargs["brain"]
+        self.timestamp = kwargs["timestamp"]
+
+    def run(self):
+        self.timestamp = self.gather(self.timestamp)

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -262,13 +262,13 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
     @staticmethod
     def cleantext(text):
         language = profile.get(["language"], "en-US")[:2]
-        if language=="en":
+        if language == "en":
             # upper case
             text = text.upper()
             words = text.split(" ")
             # Adapted from a list at https://stackoverflow.com/questions/19790188/expanding-english-language-contractions-in-python
-            contractions = { 
-                "AIN'T": "ARE NOT", # "am not / are not / is not / has not / have not"
+            contractions = {
+                "AIN'T": "ARE NOT",  # "am not / are not / is not / has not / have not"
                 "AREN'T": "ARE NOT",
                 "CAN'T": "CAN NOT",
                 "CAN'T'VE": "CAN NOT HAVE",
@@ -283,27 +283,27 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
                 "HADN'T'VE": "HAD NOT HAVE",
                 "HASN'T": "HAS NOT",
                 "HAVEN'T": "HAVE NOT",
-                "HE'D": "HE WOULD", # "he had / he would",
+                "HE'D": "HE WOULD",  # "he had / he would",
                 "HE'D'VE": "HE WOULD HAVE",
-                "HE'LL": "HE WILL", # "he shall / he will",
-                "HE'LL'VE": "HE WILL HAVE", # "he shall have / he will have",
-                "HE'S": "HE IS", # "he has / he is",
+                "HE'LL": "HE WILL",  # "he shall / he will",
+                "HE'LL'VE": "HE WILL HAVE",  # "he shall have / he will have",
+                "HE'S": "HE IS",  # "he has / he is",
                 "HOW'D": "HOW DID",
                 "HOW'D'Y": "HOW DO YOU",
                 "HOW'LL": "HOW WILL",
-                "HOW'S": "HOW IS", # "how has / how is / how does",
-                "I'D": "I WOULD", # "I had / I would",
+                "HOW'S": "HOW IS",  # "how has / how is / how does",
+                "I'D": "I WOULD",  # "I had / I would",
                 "I'D'VE": "I WOULD HAVE",
-                "I'LL": "I WILL", # "I shall / I will",
-                "I'LL'VE": "I WILL HAVE", # "I shall have / I will have",
+                "I'LL": "I WILL",  # "I shall / I will",
+                "I'LL'VE": "I WILL HAVE",  # "I shall have / I will have",
                 "I'M": "I AM",
                 "I'VE": "I HAVE",
                 "ISN'T": "IS NOT",
-                "IT'D": "IT WOULD", # "it had / it would",
+                "IT'D": "IT WOULD",  # "it had / it would",
                 "IT'D'VE": "IT WOULD HAVE",
-                "IT'LL": "IT WILL", # "it shall / it will",
-                "IT'LL'VE": "IT WILL HAVE", # "it shall have / it will have",
-                "IT'S": "IT IS", # "it has / it is",
+                "IT'LL": "IT WILL",  # "it shall / it will",
+                "IT'LL'VE": "IT WILL HAVE",  # "it shall have / it will have",
+                "IT'S": "IT IS",  # "it has / it is",
                 "LET'S": "LET US",
                 "MA'AM": "MADAM",
                 "MAYN'T": "MAY NOT",
@@ -319,52 +319,52 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
                 "OUGHTN'T'VE": "OUGHT NOT HAVE",
                 "SHAN'T": "SHALL NOT",
                 "SHAN'T'VE": "SHALL NOT HAVE",
-                "SHE'D": "SHE WOULD", # "she had / she would",
+                "SHE'D": "SHE WOULD",  # "she had / she would",
                 "SHE'D'VE": "SHE WOULD HAVE",
-                "SHE'LL": "SHE WILL", # "she shall / she will",
-                "SHE'LL'VE": "SHE WILL HAVE", # "she shall have / she will have",
-                "SHE'S": "SHE IS", # "she has / she is",
+                "SHE'LL": "SHE WILL",  # "she shall / she will",
+                "SHE'LL'VE": "SHE WILL HAVE",  # "she shall have / she will have",
+                "SHE'S": "SHE IS",  # "she has / she is",
                 "SHOULD'VE": "SHOULD HAVE",
                 "SHOULDN'T": "SHOULD NOT",
                 "SHOULDN'T'VE": "SHOULD NOT HAVE",
                 "SO'VE": "SO HAVE",
-                "SO'S": "SO IS", # "so as / so is",
-                "THAT'D": "THAT WOULD", # "that would / that had",
+                "SO'S": "SO IS",  # "so as / so is",
+                "THAT'D": "THAT WOULD",  # "that would / that had",
                 "THAT'WOULD'VE": "THAT WOULD HAVE",
-                "THAT'S": "THAT IS", # "that has / that is",
-                "THERE'D": "THERE WOULD", # "there had / there would",
+                "THAT'S": "THAT IS",  # "that has / that is",
+                "THERE'D": "THERE WOULD",  # "there had / there would",
                 "THERE'D'VE": "THERE WOULD HAVE",
-                "THERE'S": "THERE IS", # "there has / there is",
-                "THEY'D": "THEY WOULD", # "they had / they would",
+                "THERE'S": "THERE IS",  # "there has / there is",
+                "THEY'D": "THEY WOULD",  # "they had / they would",
                 "THEY'D'VE": "THEY WOULD HAVE",
-                "THEY'LL": "THEY WILL", # "they shall / they will",
-                "THEY'LL'VE": "THEY WILL HAVE", # "they shall have / they will have",
+                "THEY'LL": "THEY WILL",  # "they shall / they will",
+                "THEY'LL'VE": "THEY WILL HAVE",  # "they shall have / they will have",
                 "THEY'RE": "THEY ARE",
                 "THEY'VE": "THEY HAVE",
                 "TO'VE": "TO HAVE",
                 "WASN'T": "WAS NOT",
-                "WE'D": "WE WOULD", # "we had / we would",
+                "WE'D": "WE WOULD",  # "we had / we would",
                 "WE'D'VE": "WE WOULD HAVE",
                 "WE'LL": "WE WILL",
                 "WE'LL'VE": "WE WILL HAVE",
                 "WE'RE": "WE ARE",
                 "WE'VE": "WE HAVE",
                 "WEREN'T": "WERE NOT",
-                "WHAT'LL": "WHAT WILL", # "what shall / what will",
-                "WHAT'LL'VE": "WHAT WILL HAVE", # "what shall have / what will have",
+                "WHAT'LL": "WHAT WILL",  # "what shall / what will",
+                "WHAT'LL'VE": "WHAT WILL HAVE",  # "what shall have / what will have",
                 "WHAT'RE": "WHAT ARE",
-                "WHAT'S": "WHAT IS", # "what has / what is",
+                "WHAT'S": "WHAT IS",  # "what has / what is",
                 "WHAT'VE": "WHAT HAVE",
-                "WHEN'S": "WHEN IS", # "when has / when is",
+                "WHEN'S": "WHEN IS",  # "when has / when is",
                 "WHEN'VE": "WHEN HAVE",
                 "WHERE'D": "WHERE DID",
-                "WHERE'S": "WHERE IS", # "where has / where is",
+                "WHERE'S": "WHERE IS",  # "where has / where is",
                 "WHERE'VE": "WHERE HAVE",
-                "WHO'LL": "WHO WILL", # "who shall / who will",
-                "WHO'LL'VE": "WHO WILL HAVE", # "who shall have / who will have",
-                "WHO'S": "WHO IS", # "who has / who is",
+                "WHO'LL": "WHO WILL",  # "who shall / who will",
+                "WHO'LL'VE": "WHO WILL HAVE",  # "who shall have / who will have",
+                "WHO'S": "WHO IS",  # "who has / who is",
                 "WHO'VE": "WHO HAVE",
-                "WHY'S": "WHY IS", # "why has / why is",
+                "WHY'S": "WHY IS",  # "why has / why is",
                 "WHY'VE": "WHY HAVE",
                 "WILL'VE": "WILL HAVE",
                 "WON'T": "WILL NOT",
@@ -377,25 +377,26 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
                 "Y'ALL'D'VE": "YOU ALL WOULD HAVE",
                 "Y'ALL'RE": "YOU ALL ARE",
                 "Y'ALL'VE": "YOU ALL HAVE",
-                "YOU'D": "YOU WOULD", # "you had / you would",
+                "YOU'D": "YOU WOULD",  # "you had / you would",
                 "YOU'D'VE": "YOU WOULD HAVE",
-                "YOU'LL": "YOU WILL", # "you shall / you will",
-                "YOU'LL'VE": "YOU WILL HAVE", # "you shall have / you will have",
+                "YOU'LL": "YOU WILL",  # "you shall / you will",
+                "YOU'LL'VE": "YOU WILL HAVE",  # "you shall have / you will have",
                 "YOU'RE": "YOU ARE",
                 "YOU'VE": "YOU HAVE"
             }
             for i in range(len(words)):
                 # expand contractions
                 if words[i] in contractions:
-                    words[i]=contractions[words[i]]
+                    words[i] = contractions[words[i]]
                 # remove punctuation from beginning and end of words
-                while len(words[i])>0 and words[i][:1] not in [chr(i) for i in range(65, 91)]:
-                    words[i]=words[i][1:]
-                while len(words[i])>0 and words[i][-1:] not in [chr(i) for i in range(65,91)]:
-                    words[i]=words[i][:-1]
+                while len(words[i]) > 0 and words[i][:1] not in [chr(i) for i in range(65, 91)]:
+                    words[i] = words[i][1:]
+                while len(words[i]) > 0 and words[i][-1:] not in [chr(i) for i in range(65, 91)]:
+                    words[i] = words[i][:-1]
             # put it all back together
             text = " ".join(words)
         return text
+
 
 class VisualizationsPlugin(GenericPlugin):
     pass

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -259,6 +259,7 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
     def determine_intent(self, phrase):
         pass
 
+    # FIXME this does not belong here. It should be in a special language object
     @staticmethod
     def cleantext(text):
         language = profile.get(["language"], "en-US")[:2]

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -384,10 +384,10 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
                 "YOU'RE": "YOU ARE",
                 "YOU'VE": "YOU HAVE"
             }
-            for i in range(len(words)):
+            for i, word in enumerate(words):
                 # expand contractions
-                if words[i] in contractions:
-                    words[i] = contractions[words[i]]
+                if word in contractions:
+                    words[i] = contractions[word]
                 # remove punctuation from beginning and end of words
                 while len(words[i]) > 0 and words[i][:1] not in [chr(i) for i in range(65, 91)]:
                     words[i] = words[i][1:]

--- a/naomi/pluginstore.py
+++ b/naomi/pluginstore.py
@@ -204,6 +204,7 @@ class PluginStore(object):
         self._translations_dirname = PLUGIN_TRANSLATIONS_DIRNAME
         self._categories_map = {
             'audioengine': plugin.AudioEnginePlugin,
+            'notificationclient': plugin.NotificationClientPlugin,
             'speechhandler': plugin.SpeechHandlerPlugin,
             'tti': plugin.TTIPlugin,
             'tts': plugin.TTSPlugin,

--- a/naomi/testutils.py
+++ b/naomi/testutils.py
@@ -37,6 +37,11 @@ def test_profile():
         TEST_PROFILE['google']['credentials_json'] = config['google']['credentials_json']
     except(KeyError, NameError):
         pass
+    try:
+        TEST_PROFILE['key'] = config['key']
+        TEST_PROFILE['email'] = config['email']
+    except(KeyError, NameError):
+        pass
     return TEST_PROFILE
 
 

--- a/plugins/notificationclient/respondtoemail/__init__.py
+++ b/plugins/notificationclient/respondtoemail/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .respondtoemail import RespondToEmailPlugin

--- a/plugins/notificationclient/respondtoemail/plugin.info
+++ b/plugins/notificationclient/respondtoemail/plugin.info
@@ -1,0 +1,10 @@
+[Plugin]
+Name = Respond to Email
+Version = 1.0.0
+License = MIT
+URL = https://github.com/NaomiProject/Naomi
+Description = Responds to emails containing the wake word
+
+[Author]
+Name = Naomi Project
+URL = https://github.com/NaomiProject/Naomi

--- a/plugins/notificationclient/respondtoemail/respondtoemail.py
+++ b/plugins/notificationclient/respondtoemail/respondtoemail.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import contextlib
-import queue
 import random
 from naomi import app_utils
 from naomi import plugin
@@ -10,7 +9,6 @@ from naomi import profile
 class RespondToEmailPlugin(plugin.NotificationClientPlugin):
     def __init__(self, *args, **kwargs):
         super(RespondToEmailPlugin, self).__init__(*args, **kwargs)
-        self.q = queue.Queue()
         # check to see if we can connect to an email account
         if(app_utils.check_imap_config()):
             self.gather = self.handle_email_notifications
@@ -95,7 +93,7 @@ class RespondToEmailPlugin(plugin.NotificationClientPlugin):
             if emails:
                 last_date = app_utils.get_most_recent_date(emails)
             for e in emails:
-                self.q.put(handle_email(e))
+                handle_email(e)
         except Exception as ex:
             self._logger.warn(str(ex))
 

--- a/plugins/notificationclient/respondtoemail/respondtoemail.py
+++ b/plugins/notificationclient/respondtoemail/respondtoemail.py
@@ -41,7 +41,18 @@ class RespondToEmailPlugin(plugin.NotificationClientPlugin):
             keywords = profile.get(["keyword"], ['NAOMI'])
             if(isinstance(keywords, str)):
                 keywords = [keywords]
-            if(any(x.upper() in message for x in keywords)):
+            handleEmail = False
+            respond_to_emails = profile.get(['respond_to_emails'], None)
+            if(respond_to_emails is not None):  # check respond_to_email exists
+                print("respond to emails is {}".format(respond_to_emails))
+                print("len: {}".format(len(respond_to_emails)))
+                print("From: {}".format(app_utils.get_sender_email(e)))
+                if((len(respond_to_emails) == 0)or(app_utils.get_sender_email(e) in respond_to_emails)):  # sender is okay
+                    print("sender okay")
+                    if(any(x.upper() in message for x in keywords)):  # wake word detected
+                        print("wake word detected")
+                        handleEmail = True
+            if(handleEmail):
                 # This message should be marked as read
                 app_utils.mark_read(e)
                 emailmic = EmailMic(

--- a/plugins/notificationclient/respondtoemail/respondtoemail.py
+++ b/plugins/notificationclient/respondtoemail/respondtoemail.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+import contextlib
+import queue
+import random
+from naomi import app_utils
+from naomi import plugin
+from naomi import profile
+
+
+class RespondToEmailPlugin(plugin.NotificationClientPlugin):
+    def __init__(self, *args, **kwargs):
+        super(RespondToEmailPlugin, self).__init__(*args, **kwargs)
+        self.q = queue.Queue()
+        # check to see if we can connect to an email account
+        if(app_utils.check_imap_config()):
+            self.gather = self.handle_email_notifications
+            if(not app_utils.check_smtp_config()):
+                self._logger.warning(
+                    " ".join([
+                        'Email smtp access is not configured,',
+                        'I will not be able to respond.'
+                    ])
+                )
+        else:
+            self._logger.warning(
+                " ".join([
+                    'Email imap access is not configured,',
+                    'notifier will not be used'
+                ])
+            )
+
+    def handle_email_notifications(self, last_date):
+        """Places new Gmail notifications in the Notifier's queue."""
+        def handle_email(e):
+            # if the subject line matches the first line of the email, then
+            # discard the subject line. If not, then append the body to the
+            # subject line.
+            subject=e["Subject"]
+            body=app_utils.get_message_text(e)
+            if(body[:len(subject)] != subject):
+                body = " ".join([subject, body])
+            message = self._brain._intentparser.cleantext(body)
+            keywords = profile.get(["keyword"], ['NAOMI'])
+            if(isinstance(keywords, str)):
+                keywords = [keywords]
+            if(any(x.upper() in message for x in keywords)):
+                # This message should be marked as read
+                app_utils.mark_read(e)
+                emailmic = EmailMic(
+                    address=e['From'],
+                    subject=e["Subject"]
+                )
+                intent = self._brain.query([message])
+                if intent:
+                    try:
+                        self._logger.info(intent)
+                        intent['action'](intent, emailmic)
+                    except Exception:
+                        self._logger.error(
+                            'Failed to execute module',
+                            exc_info=True
+                        )
+                        emailmic.say(
+                            " ".join([
+                                self.gettext("I'm sorry."),
+                                self.gettext("I had some trouble with that operation."),
+                                self.gettext("Please try again later.")
+                            ])
+                        )
+                    else:
+                        self._logger.debug(
+                            " ".join([
+                                "Handling of phrase '{}'",
+                                "by module '{}' completed"
+                            ]).format(
+                                message,
+                                intent
+                            )
+                        )
+                else:
+                    emailmic.say(random.choice([  # nosec
+                        self.gettext("I'm sorry, could you repeat that?"),
+                        self.gettext("My apologies, could you try saying that again?"),
+                        self.gettext("Say that again?"),
+                        self.gettext("I beg your pardon?")
+                    ]))
+            else:
+                self._mic.say("New email from %s." % app_utils.get_sender(e))
+            return True
+
+        self._logger.info("Checking email since {}".format(last_date))
+        try:
+            emails = app_utils.fetch_emails(since=last_date, email_filter="(UNSEEN)")
+            self._logger.info("{} new emails".format(len(emails)))
+            if emails:
+                last_date = app_utils.get_most_recent_date(emails)
+            for e in emails:
+                self.q.put(handle_email(e))
+        except Exception as ex:
+            self._logger.warn(str(ex))
+
+        return last_date
+
+
+# This is a replacement for the Mic object but it sends an email.
+class EmailMic(object):
+    prev = None
+
+    def __init__(self, address, subject, *args, **kwargs):
+        self._to = address
+        self._subject = subject
+        return
+
+    @staticmethod
+    @contextlib.contextmanager
+    def special_mode(name, phrases):
+        yield
+
+    def wait_for_keyword(self, keyword="NAOMI"):
+        if(self.passive_listen):
+            return self.active_listen()
+        else:
+            return
+
+    # This gets called if the handler is supposed to wait for input.
+    @staticmethod
+    def active_listen(timeout=3):
+        # input_text = input("YOU: ")
+        # unicodedata.normalize('NFD', input_text).encode('ascii', 'ignore')
+        # self.prev = input_text
+        return [""]
+
+    def listen(self):
+        return self.active_listen(timeout=3)
+
+    def say(self, phrase, OPTIONS=None):
+        app_utils.send_email(
+            "Re: {}".format(self._subject),
+            phrase,
+            self._to
+        )

--- a/plugins/notificationclient/respondtoemail/respondtoemail.py
+++ b/plugins/notificationclient/respondtoemail/respondtoemail.py
@@ -35,8 +35,8 @@ class RespondToEmailPlugin(plugin.NotificationClientPlugin):
             # if the subject line matches the first line of the email, then
             # discard the subject line. If not, then append the body to the
             # subject line.
-            subject=e["Subject"]
-            body=app_utils.get_message_text(e)
+            subject = e["Subject"]
+            body = app_utils.get_message_text(e)
             if(body[:len(subject)] != subject):
                 body = " ".join([subject, body])
             message = self._brain._intentparser.cleantext(body)

--- a/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
+++ b/plugins/stt_trainer/pocketsphinx_adapt/pocketsphinx_adapt.py
@@ -84,7 +84,7 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
             response = []
             continue_next = True
             nextcommand = ""
-            if(command == "checkenviron"):
+            if(command == ""):
                 response.append(
                     "<h2>Preparing to adapt Pocketsphinx model</h2>"
                 )
@@ -93,6 +93,8 @@ class PocketsphinxAdaptPlugin(plugin.STTTrainerPlugin):
                         self.language
                     )
                 )
+                nextcommand = "checkenviron"
+            if(command == "checkenviron"):
                 # Now run through the steps to adapt the standard model
                 # Start by checking to see if we have a copy of the standard
                 # model for this user's chosen language and download it if not.

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -47,3 +47,7 @@ cython
 pandas
 sklearn
 jiwer
+
+# Development
+flake8
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Notifications can now be written as plugins. This demonstrates
writing a NotificationClient plugin that checks an email address
for new emails. If the email contains one of Naomi's wake words,
the email is parsed as a request and Naomi's response is returned
to the emailer. Otherwise, Naomi announces the email to the user.

This is a separate thread that polls every 30 seconds and can
respond to an external change.

Right now, there is only one "notifier" thread that contains
all of the "notificationclient" objects, so you can't set one
notification to run every 30 seconds and another to run every
12 hours, for instance. The 30 seconds is also hard coded and
should be replaced with a profile setting that the user could
override.

If a user wants to create a notification object, they just need
to create an object that inherits from NotificationClientPlugin
and has a "gather" method (as demonstrated by the respondtoemail
plugin, you can prevent a plugin from operating simply by not
setting the "gather" method to anything). The "gather()" method
will be called every time the notifier runs.

This is a fairly complex example. The respond_to_email setting
in profile.yml is used to filter the list of email addresses to which
Naomi will respond. If the setting is missing, Naomi will only
announce incoming emails and will not attempt to process them.
If the setting is the empty list, then Naomi will respond to any
incoming email that contains the wake word. If the list contains
entries, Naomi will only respond to emails where the from address
is one of the addresses in the list. 

As part of my testing, I discovered that the wake word was case
sensitive and that punctuation connected to words was messing
with the intent parser. These are things that don't come up when
using the voice interface, but do come up when using a text
interface like the local mic or sending an email or text message.
Because of this, I added a new "cleantext()" method to the intent
parser base class which I am using to prepare the text for parsing.
This includes uppercasing the text, expanding contractions and
removing any punctuation surrounding the words.
This should also be done for any intents being added to Brain.
Almost all the code for this is language dependent. For example,
the list of characters that should not be considered punctuation
and the list of contractions are both specific to English. We should
probably have a language or locale object that can be customized
to each locale and is located in an obvious place rather than hiding
this functionality down in Plugins.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Re-adding notification plugin functionality](https://github.com/NaomiProject/Naomi/issues/47)
[Introducing NLP](https://github.com/NaomiProject/Naomi/issues/43)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We wanted to restore the notifier functionality from the original Jasper client.
This was a simple method that just checked for emails every 30 seconds and
announced the from address of any new ones. I wanted to go beyond just
restoring the original functionality and create a Plugin type that any developer
could use to create a polling function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a Raspberry Pi 4B. I also ran the unittests and everything came up
good. Actually discovered that the check_email unittest was being skipped
whether or not you have your email client configured since the test profile
did not include email settings. Fixed that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
