### PR TITLE
Naomi tti fix

### DIFF
--- a/plugins/tti/naomi_tti/naomi_tti.py
+++ b/plugins/tti/naomi_tti/naomi_tti.py
@@ -40,6 +40,10 @@ def is_keyword(word):
         response = True
     return response
 
+# converts all non-keyword words to upper case in a template. This allows
+# case insensitive matching.
+def convert_template_to_upper(template):
+    return " ".join([word if is_keyword(word) else word.upper() for word in template.split()])
 
 class NaomiTTIPlugin(plugin.TTIPlugin):
     def __init__(self, *args, **kwargs):
@@ -79,6 +83,8 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
             }
             for phrase in intents[intent_base]['locale'][locale]['templates']:
                 # Save the phrase so we can search for undefined keywords
+                # Convert the template to upper case
+                phrase = convert_template_to_upper(phrase)
                 self.intent_map['intents'][intent]['templates'].append(phrase)
                 for word in phrase.split():
                     if not is_keyword(word):

--- a/plugins/tti/naomi_tti/naomi_tti.py
+++ b/plugins/tti/naomi_tti/naomi_tti.py
@@ -6,7 +6,7 @@ from jiwer import wer
 from naomi import paths
 from naomi import plugin
 from naomi import profile
-from pprint import pprint
+# from pprint import pprint
 
 
 # Replace the nth occurrance of sub

--- a/plugins/tti/naomi_tti/naomi_tti.py
+++ b/plugins/tti/naomi_tti/naomi_tti.py
@@ -6,6 +6,7 @@ from jiwer import wer
 from naomi import paths
 from naomi import plugin
 from naomi import profile
+from pprint import pprint
 
 
 # Replace the nth occurrance of sub
@@ -15,11 +16,15 @@ def replacenth(search_for, replace_with, string, n):
     try:
         # print("Searching for: '{}' in '{}'".format(search_for, string))
         # pprint([m.start() for m in re.finditer(search_for, string)])
-        where = [m.start() for m in re.finditer("{}{}{}".format(r"\b", search_for, r"\b"), string)][n - 1]
+        where = [m.start() for m in re.finditer(search_for, string)][n - 1]
         before = string[:where]
+        # print("Before: {}".format(before))
         after = string[where:]
+        # print("After: {}".format(after))
         after = after.replace(search_for, replace_with, 1)
+        # print("After: {}".format(after))
         string = before + after
+        # print("String: {}".format(string))
     except IndexError:
         # print("IndexError {}".format(n))
         pass
@@ -170,7 +175,6 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
         return sorted(list(set(phrases)))
 
     def determine_intent(self, phrase):
-        # print(phrase)
         phrase = phrase.upper()
         score = {}
         allvariants = {phrase: {}}
@@ -318,13 +322,19 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
                 # substitutions in the template
                 if(possiblesubstitutions > 0):
                     for i in range(possiblesubstitutions):
-                        # print("i={}".format(i))
+                        # print("replacenth('{}','{}','{}',{})".format(
+                        #     '{}{}{}'.format('{', matchlist, '}'),
+                        #     word,
+                        #     currenttemplate,
+                        #     i + 1
+                        # ))
                         currenttemplate = replacenth(
                             '{}{}{}'.format('{', matchlist, '}'),
                             word,
                             currenttemplate,
                             i + 1
                         )
+                        # print("CurrentTemplate = {}".format(currenttemplate))
                         templates[currenttemplate] = wer(
                             currentvariant,
                             currenttemplate
@@ -339,7 +349,8 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
         # Now that we have a matching template, run through a list of all
         # substitutions in the template and see if there are any we have not
         # identified yet.
-        substitutions = re.findall('\{(.*?)\}', currenttemplate)
+        substitutions = re.findall(r'{(.*?)}', currenttemplate)
+        # print("Substitutions: {}".format(substitutions))
         if(substitutions):
             for substitution in substitutions:
                 subvar = "{}{}{}".format('{', substitution, '}')
@@ -352,8 +363,10 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
                 # print("Minimizing distance from '{}' to '{}' by substituting in '{}'".format(currentvariant,currenttemplate,subvar))
                 # print("Variant: {}".format(currentvariant))
                 variant = currentvariant.split()
+                variant.append("<END>")
                 # print("Template: {}".format(currenttemplate))
                 template = currenttemplate.split()
+                template.append("<END>")
                 n = len(variant) + 1
                 m = len(template) + 1
                 # print("Variant: '{}' length: {}".format(variant,n))
@@ -370,15 +383,11 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
                     a[0][j] = j
                 for i in range(1, n):
                     for j in range(1, m):
+                        # print("{},{} V: {} T: {}".format(i,j,variant[i-1],template[j-1]))
                         if(variant[i - 1] == template[j - 1]):
                             c = 0
                         else:
                             c = 1
-                        a[i][j] = min(
-                            a[i - 1][j] + 1,
-                            a[i][j - 1] + 1,
-                            a[i - 1][j - 1] + c
-                        )
                         a[i][j] = c
                 # pprint(a)
                 # examine the resulting list of matched words
@@ -412,8 +421,8 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
                         substitutedvariant = variant[:start]
                         substitutedvariant.append(subvar)
                         substitutedvariant.extend(variant[end:])
-                        break
                         # print("SubstitutedVariant: {}".format(substitutedvariant))
+                        break
                     elif(a[i + 1][s + 1] == 0):
                         # the next item is a match, so start working backward
                         k = i
@@ -437,8 +446,8 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
                         substitutedvariant = variant[:start]
                         substitutedvariant.append(subvar)
                         substitutedvariant.extend(variant[end:])
-                        break
                         # print("SubstitutedVariant: {}".format(substitutedvariant))
+                        break
                 if(len(matched)):
                     # print("Match: '{}' to '{}'".format(substitution, matched))
                     try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes two issues with the Naomi_TTI engine that only became apparent once Austin started writing some more complex intents. First, when matching the keyword tags, the \b does not match when placed outside the tags, so I had to remove them. This would only be an issue if the author missed a space between a tag and the next word, and that would be an issue anyway. Second, I added an "&lt;END&gt;" marker to both the template and the text when doing a non-keyword match. Otherwise, the engine would be unable to match a non-keyword at the end of the text.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Naomi_tti not matching correctly at end of line](https://github.com/NaomiProject/Naomi/issues/292)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes the handling

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested on a Raspberry Pi 4 running Raspbian Buster using Austin's "news2" plugin. 
```
YOU: search for naomi using popular mechanics
NewsIntent 0.10335435779816507
{'action': <bound method NewsPlugin.handle of <news2_2_0_0.news2.NewsPlugin object at 0xb52e9e90>>,
 'input': 'SEARCH FOR NAOMI USING POPULAR MECHANICS',
 'intent': 'NewsIntent',
 'matches': {'Query': ['NAOMI'], 'Source': ['POPULAR MECHANICS']},
 'score': 0.10335435779816507}
MAGICVOICE: Searching news
YOU: top headlines about smart speakers
NewsIntent 0.42144495412844035
{'action': <bound method NewsPlugin.handle of <news2_2_0_0.news2.NewsPlugin object at 0xb52e9e90>>,
 'input': 'TOP HEADLINES ABOUT SMART SPEAKERS',
 'intent': 'NewsIntent',
 'matches': {'NewsKeyword': ['HEADLINES'], 'Query': ['SMART SPEAKERS']},
 'score': 0.42144495412844035}
MAGICVOICE: Searching news
YOU: top articles in the united states
NewsIntent 0.3096330275229358
{'action': <bound method NewsPlugin.handle of <news2_2_0_0.news2.NewsPlugin object at 0xb52e9e90>>,
 'input': 'TOP ARTICLES IN THE UNITED STATES',
 'intent': 'NewsIntent',
 'matches': {'CountryKeyword': ['THE UNITED STATES'],
             'NewsKeyword': ['ARTICLES']},
 'score': 0.3096330275229358}
MAGICVOICE: Searching news
```
(the final query here displays a small flaw in the system. Since CountryKeyword is a keyword list, it should match "UNITED STATES" not "THE UNITED STATES") and the standard unit tests:
```
~/Naomi $ python -m unittest discover
...
...sss......sssss
----------------------------------------------------------------------
Ran 25 tests in 18.171s

OK (skipped=11)
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
