### PR TITLE
SNR_VAD hearing

### DIFF
--- a/plugins/vad/snr_vad/snr_vad.py
+++ b/plugins/vad/snr_vad/snr_vad.py
@@ -97,12 +97,13 @@ class SNRPlugin(plugin.VADPlugin, unittest.TestCase):
                 threshold=self._threshold
             )
         if(items > 100):
-            # Every 100 samples, rescale, allowing changes in
-            # the environment to be recognized more quickly.
+            # Every 50 samples (about 1-3 seconds), rescale,
+            # allowing changes in the environment to be
+            # recognized more quickly.
             self.distribution = {
                 key: (
                     (value + 1) / 2
-                ) for key, value in self.distribution.items()
+                ) for key, value in self.distribution.items() if value > 1
             }
         threshold = self._threshold
         # If we are already recording, reduce the threshold so as


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have noticed that Naomi seems to grow hard of hearing as time
goes on when using the SNR_VAD Voice Activity Detector. This
appears to be because I am updating entries by adding 1 and
dividing by 2. If the count is at 1, then the count will be
updated to 1, and that level will never be removed from the list.
over time, bumps and crashes will build up and affect the
standard deviation calculation.

This update only updates keys with a count greater than 1, so
allows older keys to time out, allowing the system to generate
a more accurate standard deviation. This should allow Naomi to
recover from hearing a loud background noise or adjust to a new
noise in the environment in only a few seconds to a minute, and
make it listen harder when things get quiet.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Naomi becomes hard of hearing #229](https://github.com/NaomiProject/Naomi/issues/229)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes a problem with SNR_VAD where after leaving Naomi running all night, I would have to shout at it to get it to register that I was speaking to it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested by leaving Naomi running for several days. I don't think this change affects anything else. Unit tests passed:
```
$ python -m unittest discover
...sss.....ss.....sssss
----------------------------------------------------------------------
Ran 23 tests in 6.263s

OK (skipped=10)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
