### PR TITLE
Change Naomi TTI score to a confidence percent

### DIFF
--- a/plugins/tti/naomi_tti/naomi_tti.py
+++ b/plugins/tti/naomi_tti/naomi_tti.py
@@ -6,7 +6,6 @@ from jiwer import wer
 from naomi import paths
 from naomi import plugin
 from naomi import profile
-# from pprint import pprint
 
 
 # Replace the nth occurrance of sub
@@ -270,10 +269,16 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
             # print("==========intentscores============")
             # pprint(intentscores)
             bestintent = max(intentscores, key=lambda key: intentscores[key])
+            # Change the intent scores into probabilities
+            totalscore = sum(intentscores.values())
+            if(totalscore > 0):
+                bestscore = intentscores[bestintent] / totalscore
+            else:
+                bestscore = 0
             variantscores[variant] = {
                 'intent': bestintent,
                 'input': phrase,
-                'score': intentscores[bestintent],
+                'score': bestscore,
                 'matches': allvariants[variant],
                 'action': self.intent_map['intents'][bestintent]['action']
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Just a slight change to the Naomi TTI scoring. After generating
scores for all the intents, add those scores up and divide
individual scores by the total. This makes the score always fall
between 0 and 1 (currently there is no upper limit and I have
seen scores as high as between 6 and 7).

This should also make Naomi more confident in some cases. Right
now if one intent scores .01 and all the other intents are zero,
Naomi will respond with "unclear" since no intent has scored
above .05 (5%). With this new system, .01/.01=1 (100%). I don't
know if this will turn out to be a good thing or not. I think
it will be good, but if it causes problems, we might need to add
a filter before the conversion.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Responding with a confidence score is just more normal for an intent parser.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Raspberry Pi 4 running Raspbian Buster

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
