### PR TITLE
Fix play_fp parameters

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -799,9 +799,7 @@ class Naomi(object):
         )
         try:
             output_device.play_file(
-                filename,
-                chunksize=output_chunksize,
-                add_padding=output_add_padding
+                filename
             )
         except Exception as e:
             print(e)
@@ -912,9 +910,7 @@ class Naomi(object):
             )
             if(os.path.isfile(filename)):
                 output_device.play_file(
-                    filename,
-                    chunksize=output_chunksize,
-                    add_padding=output_add_padding
+                    filename
                 )
             started = False
             for frame in input_device.record(
@@ -996,9 +992,7 @@ class Naomi(object):
                         wav_fp.writeframes(fragment)
                         wav_fp.close()
                         output_device.play_file(
-                            f.name,
-                            chunksize=output_chunksize,
-                            add_padding=output_add_padding
+                            f.name
                         )
                     heard = self._interface.simple_yes_no(
                         _("Did you hear yourself?")

--- a/naomi/audioengine.py
+++ b/naomi/audioengine.py
@@ -5,11 +5,14 @@ import slugify
 import time
 import wave
 from naomi import profile
+from pprint import pprint
+
 
 STANDARD_SAMPLE_RATES = (
     8000, 9600, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000, 88200,
     96000, 192000
 )
+
 
 DEVICE_TYPE_ALL = 'all'
 DEVICE_TYPE_INPUT = 'input'
@@ -97,9 +100,15 @@ class AudioDevice(object):
                 else:
                     yield frame
 
-    def play_fp(self, fp):
-        chunksize = profile.get(['audio','output_chunksize'], 1024)
-        add_padding = profile.get(['audio','output_padding'], False)
+    def play_fp(self, fp, *args, **kwargs):
+        if('chunksize' in kwargs):
+            chunksize = kwargs['chunksize']
+        else:
+            chunksize = profile.get(['audio','output_chunksize'], 1024)
+        if('add_padding' in kwargs):
+            add_padding = kwargs['add_padding']
+        else:
+            add_padding = profile.get(['audio','output_padding'], False)
         pause = profile.get(['audio', 'output_pause'], 0)
         w = wave.open(fp, 'rb')
         channels = w.getnchannels()


### PR DESCRIPTION
In pull request #309, I removed the chunksize and add_padding
optional parameters from play_fp, and pulled those values
directly from the profile.

This worked fine in normal operation, but introduced issues with
the configuration routines in application.py which are passing
parameters to play_file which are being passed along to play_fp.

This update restores legacy compatibility by using *args and
**kwargs to allow values to be passed in optionally, which makes
it compatible with the call from play_file. If chunksize and
add_padding are passed in as keyword arguments for some reason,
those values are used instead of the profile values. In general,
developers should not pass values directly to play_file or play_fp.

I also removed the parameters from the play_file calls in
application.py.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
