### PR TITLE
Expect and Confirm

### DIFF
--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -58,11 +58,14 @@ class Conversation(i18n.GettextMixin):
                     try:
                         self._logger.info(intent)
                         response = intent['action'](intent, self.mic)
-                        if response is None:
-                            handled = True
+                        if(isinstance(response, tuple) and len(response) == 2):
+                            (handled, utterance) = response
+                        elif(isinstance(response, bool)):
+                            handled = response
                             utterance = ""
                         else:
-                            (handled, utterance) = response
+                            handled = True
+                            utterance = ""
                     except Exception:
                         self._logger.error(
                             'Failed to execute module',

--- a/naomi/local_mic.py
+++ b/naomi/local_mic.py
@@ -6,13 +6,18 @@ implementation, Naomi is always active listening with local_mic.
 """
 import contextlib
 import unicodedata
+from jiwer import wer
+from naomi import i18n
+from naomi import paths
 from naomi import profile
 
 
-class Mic(object):
+class Mic(i18n.GettextMixin):
     prev = None
 
     def __init__(self, *args, **kwargs):
+        translations = i18n.parse_translations(paths.data('locale'))
+        i18n.GettextMixin.__init__(self, translations, profile)
         self.passive_listen = profile.get_profile_flag(["passive_listen"])
         keyword = profile.get_profile_var(['keyword'], 'NAOMI')
         if isinstance(keyword, list):
@@ -33,13 +38,71 @@ class Mic(object):
             return
 
     def active_listen(self, timeout=3):
-        input_text = input("YOU: ")
+        input_text = input("YOU: ").upper()
         unicodedata.normalize('NFD', input_text).encode('ascii', 'ignore')
         self.prev = input_text
         return [input_text]
 
     def listen(self):
         return self.active_listen(timeout=3)
+
+    def expect(self, name, prompt, phrases):
+        self.say(prompt)
+        transcribed = self.listen()
+        phrase, score = self.match_phrase(transcribed, phrases)
+        # If it does, then return True and the phrase
+        if(score > .5):
+            response = (True, phrase)
+        # Otherwise, return False and the active transcription
+        else:
+            response = (False, transcribed)
+        return response
+
+    def confirm(self, prompt):
+        # default to english
+        language = profile.get(['language'], 'en-US')[:2]
+        POSITIVE = ['YES', 'SURE']
+        NEGATIVE = ['NO', 'NOPE']
+        if(language == "fr"):
+            POSITIVE = ['OUI']
+            NEGATIVE = ['NON']
+        elif(language == "de"):
+            POSITIVE = ['JA']
+            NEGATIVE = ['NEIN']
+        (matched, phrase) = self.expect(
+            "confirm",
+            prompt,
+            POSITIVE + NEGATIVE
+        )
+        if(matched):
+            if phrase in POSITIVE:
+                return (matched, "Y")
+            else:
+                return (matched, "N")
+        else:
+            return (matched, phrase)
+
+    @staticmethod
+    def match_phrase(phrase, phrases):
+        # If phrase is a list, convert to a string
+        # (otherwise the "split" below throws an error)
+        if(isinstance(phrase, list)):
+            phrase = " ".join(phrase)
+        if phrase == "":
+            return ("", 0.0)
+        else:
+            # Just implement a quick edit distance
+            # FIXME replace this with a call to a real intent parser
+            templates = {}
+            for template in phrases:
+                phrase_len = len(phrase.split())
+                template_len = len(template.split())
+                if(phrase_len > template_len):
+                    templates[template] = (phrase_len - wer(template, phrase)) / phrase_len
+                else:
+                    templates[template] = (template_len - wer(phrase, template)) / template_len
+            besttemplate = max(templates, key=lambda key: templates[key])
+            return(besttemplate, templates[besttemplate])
 
     def say(self, phrase, OPTIONS=None):
         print("{}: {}".format(self._keyword, phrase))

--- a/naomi/testutils.py
+++ b/naomi/testutils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from . import paths
+from naomi import paths
 import contextlib
 import gettext
 import logging
@@ -58,10 +58,27 @@ class TestMic(object):
     def active_listen(self, timeout=3):
         if self.idx < len(self.inputs):
             self.idx += 1
+            # print("YOU: {}".format(self.inputs[self.idx - 1]))
             return [self.inputs[self.idx - 1]]
         return [""]
 
+    # For now, assume the input matches a phrase
+    def expect(self, name, prompt, phrases):
+        self.say(prompt)
+        return (True, " ".join(self.active_listen()))
+
+    # For now, assume the input is "YES" or "NO"
+    def confirm(self, prompt):
+        (matched, phrase) = self.expect("confirm", prompt, ['YES', 'NO'])
+        if(matched):
+            if(phrase in ['YES']):
+                phrase = 'Y'
+            else:
+                phrase = 'N'
+        return (matched, phrase)
+
     def say(self, phrase):
+        # print("NAOMI: {}".format(phrase))
         self.outputs.append(phrase)
 
 

--- a/plugins/speechhandler/joke/test_joke.py
+++ b/plugins/speechhandler/joke/test_joke.py
@@ -9,11 +9,11 @@ class TestJokePlugin(unittest.TestCase):
         self.plugin = testutils.get_plugin_instance(joke.JokePlugin)
 
     def test_handle_method(self):
-        mic = testutils.TestMic(inputs=["Who's there?", "Random response"])
+        mic = testutils.TestMic(inputs=["WHO'S THERE", "RANDOM RESPONSE", "YES"])
         jokes = joke.get_jokes()
         self.plugin.handle(
             {'input': "Tell me a joke."},
             mic
         )
-        self.assertEqual(len(mic.outputs), 3)
+        self.assertEqual(len(mic.outputs), 5)
         self.assertIn((mic.outputs[1], mic.outputs[2]), jokes)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This demonstrates the use of the Expect and Confirm functions.
This is a first step in a demonstration project for a new
conversation engine.

Right now, this only works when the "listen when speaking" option
is turned off. I'll work this week on getting these functions to
work with the asyncronous speaking.

The syntax is somewhat convoluted. The return value is a tuple
consisting of both a boolean indicating whether the computer
thinks it heard one of the options and a second parameter that
either returns the option it believes it heard (so the author
can do exact matching against the list of options passed in) or
the transcript generated by the active listener. At the moment,
the conversation engine does not check for the wake word when
handling this active listener transcription. This is so that
"conversation" can examine the output of your plugin and handle
the transcription if the plugin was unable to.

I have included a new implementation of the "joke" speechhandler
which demonstrates the use of both new functions, plus provides a
proper return value to "conversation".

When using either, use "(matched, phrase) = mic.expect(name, phrases)"
or "(matched, phrase) = mic.confirm(prompt)". Check the "matched"
parameter to see if any of the phrases passed in were matched. If
this is True, then you can go ahead and match against the list of
options passed in. If this is false, then the user was most likely
not responding to your prompt, and the active listener transcription
should be passed back to "conversation" for intent parsing and
handling. I know that's a really confusing word salad, but please
examine the "joke" plugin for examples.

You can try this out with regular Naomi or with the --local mic.
A local conversation looks something like this:

COMPUTER: My name is COMPUTER.
COMPUTER: How can I be of service?
YOU: tell me a joke
JokeIntent 0.8555247923483513
COMPUTER: Knock knock
YOU: who's there?
COMPUTER: arizona
YOU: arizona who?
COMPUTER: arizona room for only one of us in this room
COMPUTER: Was that joke funny?
YOU: what time is it?
ClockIntent 1.0
COMPUTER: It is  8:44 PM right now.

As you can see, I was able to escape from the confirmation dialog
by entering a query that activated another intent without having
to answer the question.

This has a couple of problems. First, if you are using async_say
(listen while talking) it will start listening for the response
before it asks the question, and may answer its own question if
it hears itself talking. I'm going to try to add this to the
"say" queue so it will run in a synchronous way with "say".
Second, it needs some cruft added to the dictionary because right
now it hears almost everything as its expected words regardless of
what you actually say. Third, I really should use the user's
selected intent parser to match what naomi hears to the phrases
but right now I'm just using edit distance, and a threshold of
50% which is hard coded in. Finally, the syntax is not at all intuitive
and I'd like to make it easier on developers. For instance, instead of

(matched, phrase) = confirm("Would you like me to send you these articles?")
if matched:
    if phrase == "Y":
        mic.say("Okay, I will send you the articles")
    else:
        mic.say("I will not send any articles")
return (matched, phrase)

I'd like to be able to do

if confirm("Would you like me to send you these articles?")
    mic.say("Okay, I will send you these articles")
else:
    mic.say("I will not send any articles")

and make the "expect()" method break out of the plugin in a way
that is invisible to the developer. I'm just not sure the best way to
do that right now.

One final problem that needs to be dealt with is the same problem
I am having with creating intents. I can't use gettext to create
translations for expected responses since there may be more ways
to say something in one language than another. gettext seems to
be more aimed at providing translations for output, not translations
for possible inputs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
