### PR TITLE
Remove python-pip apt package

### DIFF
--- a/apt_requirements.txt
+++ b/apt_requirements.txt
@@ -37,7 +37,6 @@ libpulse-dev
 gcc
 g++
 make
-python-pip
 autoconf
 libtool
 git


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove python-pip from the list of required apt packages.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Unable to Install via `naomi-setup.sh` #314](https://github.com/NaomiProject/Naomi/issues/314)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Phonetisaurus used to require python2, but it appears to run
fine under python3 now, and Ubuntu 20.04 no longer has a
python-pip package.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by installing Naomi on an Ubuntu 20.04 virtual machine running on Virtualbox.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
