### PR TITLE
NPE plugins apt_requirements.txt file

### DIFF
--- a/naomi/npe.py
+++ b/naomi/npe.py
@@ -245,8 +245,24 @@ class npe:
                             # run that
                             run_command(install_file)
                         else:
+                            # Check for an apt_requirements.txt file
                             required_file = os.path.join(
-                                install_dir,
+                                install_to,
+                                'apt_requirements.txt'
+                            )
+                            if os.path.isfile(required_file):
+                                packages = []
+                                with open(required_file, 'r') as f_input:
+                                    for line in f_input:
+                                        if not line.lstrip().startswith("#"):
+                                            packages.append(line.strip())
+                                if(len(packages) > 0):
+                                    cmd = ['sudo', 'apt', 'install']
+                                    cmd.extend(packages)
+                                    print(' '.join(cmd))
+                                    run_command(cmd)
+                            required_file = os.path.join(
+                                install_to,
                                 "python_requirements.txt"
                             )
                             if os.path.isfile(required_file):
@@ -254,7 +270,6 @@ class npe:
                                 cmd = [
                                     'pip3',
                                     'install',
-                                    '--user',
                                     '--requirement',
                                     required_file
                                 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Get NPE to read a list of packages from an apt_requirements.txt
file in the plugin root directory and install them.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Mozilla Deepspeech PyPi module is not available for x86 #310](https://github.com/NaomiProject/Naomi/issues/310)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Naomi plugins may have both python requirements that can be taken care of through pip and system requirements which would have to be taken care of through package managers like apt, yum, zypper, pacman, etc.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by installing the new Deepspeech plugin through the NPE. All unittests passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
