### PR TITLE
Multiple Wakewords bug

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -539,7 +539,7 @@ class Naomi(object):
                         "title": _("By what name would you like to call me?"),
                         "description": _("A good choice for a name would have multiple syllables and not sound like any common words."),
                         "default": "Naomi",
-                        "return_type": "list"
+                        "return_list": True
                     }
                 ),
                 (

--- a/naomi/application.py
+++ b/naomi/application.py
@@ -538,7 +538,8 @@ class Naomi(object):
                     ("keyword",), {
                         "title": _("By what name would you like to call me?"),
                         "description": _("A good choice for a name would have multiple syllables and not sound like any common words."),
-                        "default": "Naomi"
+                        "default": "Naomi",
+                        "return_type": "list"
                     }
                 ),
                 (

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -357,6 +357,10 @@ class commandline(object):
     # This is a higher level control that takes a "setting" as input
     def get_setting(self, setting, definition):
         active = True
+        if("return_type" in definition):
+            return_type = definition["return_type"].upper()
+        else:
+            return_type = "STR"
         if("active" in definition):
             try:
                 # check if definition["active"] is a function
@@ -385,8 +389,6 @@ class commandline(object):
             if("type" in definition):
                 controltype = definition["type"].lower()
             return_list = False
-            if("allow_multiple" in definition):
-                return_list = definition["allow_multiple"]
             if(controltype == "listbox"):
                 try:
                     options = definition["options"]()
@@ -513,7 +515,6 @@ class commandline(object):
                     response
                 )
             elif(controltype == "number"):
-                # this is the default (textbox)
                 print("")
                 response = value
                 once = False
@@ -529,9 +530,6 @@ class commandline(object):
                         print(self.instruction_text(definition["description"]))
                         once = False
                         continue
-                    response = float(tmp_response)
-                    if((response % 1) == 0):
-                        response = int(tmp_response)
                     print("")
                     profile.set_profile_var(
                         setting,
@@ -555,13 +553,20 @@ class commandline(object):
                         once = False
                         continue
                     response = tmp_response
-                    if(return_list):
+                    if(return_type == "LIST"):
                         response = [x.strip() for x in response.split(",")]
+                    elif(return_type == "NUMBER"):
+                        response = float(response)
+                        if((response % 1) == 0):
+                            response = int(tmp_response)
+                    elif(return_type == "BOOLEAN"):
+                        response = app_utils.is_positive(response)
                     print("")
                     profile.set_profile_var(
                         setting,
                         response
                     )
+                
         else:
             # Just set the value to an empty value so we know we don't need to
             # address this again.

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -388,7 +388,6 @@ class commandline(object):
             controltype = "textbox"
             if("type" in definition):
                 controltype = definition["type"].lower()
-            return_list = False
             if(controltype == "listbox"):
                 try:
                     options = definition["options"]()

--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -19,14 +19,20 @@ class Conversation(i18n.GettextMixin):
 
     # Add way for the system to ask for name if is not found in the config
     def askName(self):
-        if profile.get(['keyword']):
-            salutation = self.gettext("My name is {}.").format(
-                ' or '.join(
-                    profile.get(['keyword'])
+        keywords = profile.get(['keyword'], ['NAOMI'])
+        if(isinstance(keywords, str)):
+            keywords = [keywords]
+        if(len(keywords) > 1):
+            salutation = self.gettext(
+                "My name is {} but you can also call me {}".format(
+                    keywords[0],
+                    "or ".join(keywords[1:])
                 )
             )
         else:
-            salutation = self.gettext("My name is Naomi")
+            salutation = self.gettext(
+                "My name is {}".format(keywords[0])
+            )
         self.mic.say(salutation)
 
     def greet(self):
@@ -51,7 +57,8 @@ class Conversation(i18n.GettextMixin):
 
             utterance = self.mic.listen()
 
-            if utterance:
+            # If the utterance is empty, don't respond
+            if(" ".join(utterance) != ""):
                 intent = self.brain.query(utterance)
                 if intent:
                     try:
@@ -84,7 +91,6 @@ class Conversation(i18n.GettextMixin):
                         self.gettext("I'm sorry, could you repeat that?"),
                         self.gettext("My apologies, could you try saying that again?"),
                         self.gettext("Say that again?"),
-                        self.gettext("I beg your pardon?")
+                        self.gettext("I beg your pardon?"),
+                        self.gettext("Pardon?")
                     ]))
-            else:
-                self.mic.say(self.gettext("Pardon?"))

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -319,10 +319,9 @@ class Mic(object):
                                     dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
                                     self._logger.error("Active transcription failed!", exc_info=dbg)
                                 else:
-                                    print("'{}'".format(" ".join(transcribed)))
-                                    if(" ".join(transcribed) == ""):
+                                    if(" ".join(transcribed).strip() == ""):
                                         if(self._print_transcript):
-                                            println("<< <noise>")
+                                            println("<< <noise>\n")
                                         self._log_audio(f, transcribed, "noise")
                                     else:
                                         if(self._print_transcript):
@@ -366,10 +365,9 @@ class Mic(object):
                 dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
                 self._logger.error("Active transcription failed!", exc_info=dbg)
             else:
-                print("'{}'".format(" ".join(transcribed)))
-                if(" ".join(transcribed) == ""):
+                if(" ".join(transcribed).strip() == ""):
                     if(self._print_transcript):
-                        println("<< <noise>")
+                        println("<< <noise>\n")
                     self._log_audio(f, transcribed, "noise")
                 else:
                     if(self._print_transcript):

--- a/naomi/populate.py
+++ b/naomi/populate.py
@@ -187,7 +187,7 @@ def get_wakeword():
                 "?",
                 _("First, what name would you like to call me by?")
             ),
-            keyword, True
+            keyword
         )
     )
 

--- a/plugins/stt/pocketsphinx-stt/g2p.py
+++ b/plugins/stt/pocketsphinx-stt/g2p.py
@@ -71,7 +71,6 @@ def execute(executable, fst_model, input, is_file=False, nbest=None):
             # It is important to raise this error so we can try lower() in sphinxvocab.py
             if(len(RE_ISYMNOTFOUND.findall(nextline)) > 0):
                 logger.error('%s - Input symbol not found' % nextline)
-                proc.kill()
                 raise ValueError('Input symbol not found')
         stdoutdata_byte, stderrdata_byte = proc.communicate()
         stdoutdata = stdoutdata_byte.decode("utf-8")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This includes a fix for multiple keywords and some small changes to
the NaomiSTTTrainer.py app, plus removing some unnecessary imports added in the last pull request.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Comma in Keyword List #335](https://github.com/NaomiProject/Naomi/issues/335)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves an odd problem where having multiple keywords and running repopulate causes Naomi to fail. I solved it by adding a "return_type" parameter to settings. Right now this can only be a string literal and can only be "list", otherwise is assumed to be "string"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Raspberry Pi using Pocketsphinx_KWS for passive listening and Deepspeech for active listening.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
