### PR TITLE
Add a message when a notifier is loaded

### DIFF
--- a/naomi/notifier.py
+++ b/naomi/notifier.py
@@ -25,6 +25,7 @@ class Notifier(object):
                 self.notifiers.append(
                     notifier
                 )
+                print("Added notifier notification client {}".format(info.name))
 
         sched = BackgroundScheduler(timezone="UTC", daemon=True)
         sched.start()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This just prints a notification to stdout when a notifier is loaded

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[List NotificationClient plugins as they are enabled #350](https://github.com/NaomiProject/Naomi/issues/350)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted to know not only whether my NotificationClient had been skipped, but also if it had been loaded. I had no way of telling without using the --debug option, which produces way too much output.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on RaspberryPi 4B
Passed all existing unittests and naomi/notifier.py had a clean bill of health from flake8.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
