### PR TITLE
Expect and Confirm

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -38,6 +38,7 @@ class Naomi(object):
         save_noise=False
     ):
         global _
+        profile.set_arg("application", self)
         self._logger = logging.getLogger(__name__)
         self._interface = interface.commandline()
         # check that the values we need in order to run Naomi
@@ -361,16 +362,27 @@ class Naomi(object):
                 plugin = info.plugin_class(info)
                 self.brain.add_plugin(plugin)
             except Exception as e:
+                reason = ''
+                if hasattr(e, 'strerror') and e.strerror:
+                    reason = e.strerror
+                    if hasattr(e, 'errno') and e.errno:
+                        reason += ' [Errno %d]' % e.errno
+                elif hasattr(e, 'message'):
+                    reason = e.message
+                elif hasattr(e, 'msg'):
+                    reason = e.msg
+                if not reason:
+                    reason = str(e)
                 if(self._logger.getEffectiveLevel() > logging.DEBUG):
                     print(
                         "Plugin {} skipped! (Reason: {})".format(
                             info.name,
-                            e.message if hasattr(e, 'message') else 'Unknown'
+                            reason
                         )
                     )
                 self._logger.warning(
                     "Plugin '%s' skipped! (Reason: %s)", info.name,
-                    e.message if hasattr(e, 'message') else 'Unknown',
+                    reason,
                     exc_info=(
                         self._logger.getEffectiveLevel() == logging.DEBUG
                     )

--- a/naomi/local_mic.py
+++ b/naomi/local_mic.py
@@ -46,7 +46,7 @@ class Mic(object):
         self.say(prompt)
         transcribed = self.listen()
         phrase, score = profile.get_arg("application").brain._intentparser.match_phrase(transcribed, phrases)
-        if(score > 0.5):
+        if(score > 0.1):
             response = phrase
         else:
             raise Unexpected(transcribed)

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -315,7 +315,7 @@ class Mic(object):
                 self.passive_stt_engine._volume_normalization
             ) as f:
                 try:
-                    transcribed = self.passive_stt_engine.transcribe(f).upper()
+                    transcribed = [word.upper() for word in self.passive_stt_engine.transcribe(f)]
                 except Exception:
                     transcribed = []
                     dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
@@ -334,7 +334,7 @@ class Mic(object):
                                 # through the active listener
                                 f.seek(0)
                                 try:
-                                    transcribed = self.active_stt_engine.transcribe(f).upper()
+                                    transcribed = [word.upper() for word in self.active_stt_engine.transcribe(f)]
                                 except Exception:
                                     transcribed = []
                                     dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
@@ -360,7 +360,7 @@ class Mic(object):
                                     return transcribed
                             else:
                                 if(profile.get_profile_flag(['passive_stt', 'verify_wakeword'], False)):
-                                    transcribed = self.active_stt_engine.transcribe(f).upper()
+                                    transcribed = [word.upper() for word in self.active_stt_engine.transcribe(f)]
                                     if self.check_for_keyword(transcribed, keyword):
                                         return transcribed
                                     else:
@@ -400,7 +400,7 @@ class Mic(object):
                         println(">> <boop>\n")
                     self.play_file(paths.data('audio', 'beep_lo.wav'))
             try:
-                transcribed = self.active_stt_engine.transcribe(f).upper()
+                transcribed = [word.upper() for word in self.active_stt_engine.transcribe(f)]
             except Exception:
                 transcribed = []
                 dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
@@ -476,7 +476,7 @@ class Mic(object):
                     # If it does, then return the phrase
                     self._logger.info("Expecting: {} Got: {}".format(expected_phrases, transcribed))
                     self._logger.info("Score: {}".format(score))
-                    if(score > .5):
+                    if(score > .1):
                         return phrase
                     # Otherwise, raise an exception with the active transcription.
                     # This will break us back into the main conversation loop

--- a/naomi/testutils.py
+++ b/naomi/testutils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from . import paths
+from naomi import paths
 import contextlib
 import gettext
 import logging
@@ -60,6 +60,21 @@ class TestMic(object):
             self.idx += 1
             return [self.inputs[self.idx - 1]]
         return [""]
+
+    # For now, assume the input matches a phrase
+    def expect(self, prompt, phrases, name='expect', instructions=None):
+        self.say(prompt)
+        return (True, " ".join(self.active_listen()))
+
+    # For now, assume the input is "YES" or "NO"
+    def confirm(self, prompt):
+        (matched, phrase) = self.expect("confirm", prompt, ['YES', 'NO'])
+        if(matched):
+            if(phrase in ['YES']):
+                phrase = 'Y'
+            else:
+                phrase = 'N'
+        return (matched, phrase)
 
     def say(self, phrase):
         self.outputs.append(phrase)

--- a/plugins/speechhandler/hackernews/hackernews.py
+++ b/plugins/speechhandler/hackernews/hackernews.py
@@ -33,12 +33,20 @@ class HackerNewsPlugin(plugin.SpeechHandlerPlugin):
             'HackerNewsIntent': {
                 'locale': {
                     'en-US': {
+                        'keywords': {
+                            'NewsKeyword': [
+                                'news',
+                                'headlines'
+                            ]
+                        },
                         'templates': [
-                            "READ HACKER NEWS",
-                            "WHAT IS IN HACKER NEWS",
-                            "WHAT ARE THE HACKER NEWS HEADLINES",
-                            "WHAT IS HAPPENING IN HACKER NEWS"
-                        ]
+                            "read hacker {NewsKeyword}",
+                            "read me hacker {NewsKeyword}",
+                            "tell me the hacker {NewsKeyword}",
+                            "what is in the hacker {NewsKeyword}",
+                            "what is happening in hacker {NewsKeyword}",
+                            "what are today's hacker {NewsKeyword}"
+                        ],
                     },
                     'fr-FR': {
                         'templates': [
@@ -101,14 +109,7 @@ class HackerNewsPlugin(plugin.SpeechHandlerPlugin):
         mic.say(text)
 
         if profile.get_profile_flag(['allows_email']):
-            mic.say(_('Would you like me to send you these articles?'))
-
-            answers = mic.active_listen()
-            if any(
-                _('YES').upper(
-                ) in answer.upper(
-                ) for answer in answers
-            ):
+            if(mic.confirm(_('Would you like me to send you these articles?'))):
                 mic.say(_("Sure, just give me a moment."))
                 email_text = self.make_email_text(articles)
                 email_sent = app_utils.email_user(

--- a/plugins/speechhandler/joke/joke.py
+++ b/plugins/speechhandler/joke/joke.py
@@ -82,9 +82,6 @@ class JokePlugin(plugin.SpeechHandlerPlugin):
         mic -- used to interact with the user (for both input and output)
         """
         joke = random.choice(self._jokes)
-
-        mic.say(self.gettext("Knock knock"))
-        mic.active_listen()
-        mic.say(joke[0])
-        mic.active_listen()
+        mic.expect(self.gettext("Knock knock"), ["WHO'S THERE"])
+        mic.expect(joke[0], ["{} WHO".format(joke[0])])
         mic.say(joke[1])

--- a/plugins/speechhandler/news/news.py
+++ b/plugins/speechhandler/news/news.py
@@ -55,6 +55,8 @@ class NewsPlugin(plugin.SpeechHandlerPlugin):
                         },
                         'templates': [
                             "READ THE {NewsKeyword}",
+                            "READ ME THE {NewsKeyword}",
+                            "TELL ME THE {NewsKeyword}",
                             "WHAT IS IN THE {NewsKeyword}",
                             "WHAT IS HAPPENING IN THE {NewsKeyword}",
                             "WHAT ARE TODAY'S {NewsKeyword}"
@@ -75,7 +77,7 @@ class NewsPlugin(plugin.SpeechHandlerPlugin):
                         ]
                     },
                     'de-DE': {
-                        'keywords':{
+                        'keywords': {
                             'NewsKeyword': [
                                 "NACHRICHTEN",
                                 "SCHLAGZEILEN"
@@ -129,14 +131,7 @@ class NewsPlugin(plugin.SpeechHandlerPlugin):
 
         if profile.get_profile_flag(['allows_email'], False):
 
-            mic.say(_('Would you like me to send you these articles?'))
-
-            answers = mic.active_listen()
-            if any(
-                self.gettext('YES').upper(
-                ) in answer.upper(
-                ) for answer in answers
-            ):
+            if(mic.confirm(_('Would you like me to send you these articles?'))):
                 mic.say(self.gettext("Sure, just give me a moment."))
                 SUBJECT = self.gettext("Your Top Headlines")
                 email_text = self.make_email_text(articles)

--- a/plugins/tti/naomi_tti/naomi_tti.py
+++ b/plugins/tti/naomi_tti/naomi_tti.py
@@ -8,50 +8,9 @@ from naomi import plugin
 from naomi import profile
 
 
-# Replace the nth occurrance of sub
-# based on an answer by aleskva at
-# https://stackoverflow.com/questions/35091557/replace-nth-occurrence-of-substring-in-string
-def replacenth(search_for, replace_with, string, n):
-    try:
-        # print("Searching for: '{}' in '{}'".format(search_for, string))
-        # pprint([m.start() for m in re.finditer(search_for, string)])
-        if(is_keyword(search_for)):
-            where = [m.start() for m in re.finditer(r"{}".format(search_for), string)][n - 1]
-        else:
-            where = [m.start() for m in re.finditer(r"\b{}\b".format(search_for), string)][n - 1]
-        before = string[:where]
-        # print("Before: {}".format(before))
-        after = string[where:]
-        # print("After: {}".format(after))
-        after = after.replace(search_for, replace_with, 1)
-        # print("After: {}".format(after))
-        string = before + after
-        # print("String: {}".format(string))
-    except IndexError:
-        # print("IndexError {}".format(n))
-        pass
-    return string
-
-
-# is_keyword just checks to see if the word is a normal word or a keyword
-# (surrounded by curly brackets)
-def is_keyword(word):
-    word = word.strip()
-    response = False
-    if("{}{}".format(word[:1], word[-1:]) == "{}"):
-        response = True
-    return response
-
-
 # Convert a word ("word") to a keyword ("{word}")
 def to_keyword(word):
     return "{}{}{}".format("{", word, "}")
-
-
-# converts all non-keyword words to upper case in a template. This allows
-# case insensitive matching.
-def convert_template_to_upper(template):
-    return " ".join([word if is_keyword(word) else word.upper() for word in template.split()])
 
 
 class NaomiTTIPlugin(plugin.TTIPlugin):
@@ -93,10 +52,10 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
             for phrase in intents[intent_base]['locale'][locale]['templates']:
                 # Save the phrase so we can search for undefined keywords
                 # Convert the template to upper case
-                phrase = self.cleantext(convert_template_to_upper(phrase))
+                phrase = self.cleantext(phrase)
                 self.intent_map['intents'][intent]['templates'].append(phrase)
                 for word in phrase.split():
-                    if not is_keyword(word):
+                    if not self.is_keyword(word):
                         word = word.upper()
                     # Make a list of words to ignore when building intents
                     # This should get better over time, but at the moment
@@ -212,7 +171,7 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
                             # check and see if we can make a substitution and
                             # generate a new variant.
                             # print("replacenth('{}', '{}', '{}', {})".format(word, '{'+keyword+'}', variant, count))
-                            new = replacenth(word, "{}{}{}".format('{', keyword, '}'), variant, count)
+                            new = self.replacenth(word, "{}{}{}".format('{', keyword, '}'), variant, count)
                             # print(new)
                             # print()
                             # print(new)
@@ -351,7 +310,7 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
                         #     currenttemplate,
                         #     i + 1
                         # ))
-                        currenttemplate = replacenth(
+                        currenttemplate = self.replacenth(
                             '{}{}{}'.format('{', matchlist, '}'),
                             word,
                             currenttemplate,

--- a/plugins/tti/naomi_tti/naomi_tti.py
+++ b/plugins/tti/naomi_tti/naomi_tti.py
@@ -15,7 +15,10 @@ def replacenth(search_for, replace_with, string, n):
     try:
         # print("Searching for: '{}' in '{}'".format(search_for, string))
         # pprint([m.start() for m in re.finditer(search_for, string)])
-        where = [m.start() for m in re.finditer(search_for, string)][n - 1]
+        if(is_keyword(search_for)):
+            where = [m.start() for m in re.finditer(r"{}".format(search_for), string)][n - 1]
+        else:
+            where = [m.start() for m in re.finditer(r"\b{}\b".format(search_for), string)][n - 1]
         before = string[:where]
         # print("Before: {}".format(before))
         after = string[where:]
@@ -90,7 +93,7 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
             for phrase in intents[intent_base]['locale'][locale]['templates']:
                 # Save the phrase so we can search for undefined keywords
                 # Convert the template to upper case
-                phrase = convert_template_to_upper(phrase)
+                phrase = self.cleantext(convert_template_to_upper(phrase))
                 self.intent_map['intents'][intent]['templates'].append(phrase)
                 for word in phrase.split():
                     if not is_keyword(word):
@@ -188,7 +191,7 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
         return sorted(phrases)
 
     def determine_intent(self, phrase):
-        phrase = phrase.upper()
+        phrase = self.cleantext(phrase.upper())
         score = {}
         allvariants = {phrase: {}}
         for intent in self.keywords:
@@ -252,6 +255,7 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
                         intents_count = len(self.intent_map['intents'])
                         word_appears_in = len(self.words[word])
                         score += self.intent_map['intents'][intent]['words'][word] * (intents_count - word_appears_in) / intents_count
+                        # print(f"Score: {score}")
                 # penalize the variant if it does not contain important words
                 # highscore would be if the variant contains at least each of
                 # the keywords

--- a/plugins/tti/naomi_tti/naomi_tti.py
+++ b/plugins/tti/naomi_tti/naomi_tti.py
@@ -150,7 +150,7 @@ class NaomiTTIPlugin(plugin.TTIPlugin):
         return sorted(phrases)
 
     def determine_intent(self, phrase):
-        phrase = self.cleantext(phrase.upper())
+        phrase = self.cleantext(phrase)
         score = {}
         allvariants = {phrase: {}}
         for intent in self.keywords:

--- a/plugins/tti/padatious_tti/padatious_tti.py
+++ b/plugins/tti/padatious_tti/padatious_tti.py
@@ -10,16 +10,6 @@ except ModuleNotFoundError:
     raise unittest.SkipTest("padatious module not found")
 
 
-# is_keyword just checks to see if the word is a normal word or a keyword
-# (surrounded by curly brackets)
-def is_keyword(word):
-    word = word.strip()
-    response = False
-    if("{}{}".format(word[:1], word[-1:]) == "{}"):
-        response = True
-    return response
-
-
 # Convert a word ("word") to a keyword ("{word}")
 def to_keyword(word):
     return "{}{}{}".format("{", word, "}")
@@ -53,7 +43,7 @@ class PadatiousTTIPlugin(plugin.TTIPlugin):
                 'name': intent_base,
                 'templates': []
             }
-            templates = intents[intent_base]['locale'][locale]['templates']
+            templates = [self.cleantext(template) for template in intents[intent_base]['locale'][locale]['templates']]
             if('keywords' in intents[intent_base]['locale'][locale]):
                 for keyword in intents[intent_base]['locale'][locale]['keywords']:
                     keyword_token = "{}_{}".format(intent, keyword)

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -32,7 +32,11 @@ class WebRTCPlugin(plugin.VADPlugin, unittest.TestCase):
         )
 
         threshold = profile.get_profile_var(["webrtc_vad", "threshold"], 30)
-        super(WebRTCPlugin, self).__init__(input_device, timeout, minimum_capture)
+        super(WebRTCPlugin, self).__init__(
+            input_device,
+            timeout,
+            minimum_capture
+        )
         # if the audio decibel is greater than threshold, then consider this
         # having detected a voice.
         self._threshold = threshold
@@ -78,7 +82,7 @@ class WebRTCPlugin(plugin.VADPlugin, unittest.TestCase):
 
     def _voice_detected(self, *args, **kwargs):
         frame = args[0]
-        self._logger.info("Frame length: {} bytes".format(len(frame)))
+        # self._logger.info("Frame length: {} bytes".format(len(frame)))
         # The frame length must be either .01, .02 or .02 ms.
         # Sometimes the audio card will refuse to obey the chunksize
         # directive. In this case, we have to cut down the sample to
@@ -88,9 +92,9 @@ class WebRTCPlugin(plugin.VADPlugin, unittest.TestCase):
         sample_length = len(frame) / input_bytes / sample_rate
         if not((
             sample_length == 0.01
-        )or(
+        ) or (
             sample_length == 0.02
-        )or(
+        ) or (
             sample_length == 0.03
         )):
             if(sample_length > 0.03):

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -64,7 +64,7 @@ class TestBrain(unittest.TestCase):
     # Every element of expected_phrases must exist in extracted_phrases,
     # but they do not have to be equal.
     def testPluginPhraseExtraction(self):
-        expected_phrases = ['MOCK1', 'MOCK2']
+        expected_phrases = ['MOCK ONE', 'MOCK TWO']
 
         self.plugins = pluginstore.PluginStore()
         self.plugins.detect_plugins()
@@ -77,8 +77,8 @@ class TestBrain(unittest.TestCase):
         profile.set_profile(testutils.test_profile())
         my_brain = brain.Brain(intent_parser)
 
-        my_brain.add_plugin(ExampleSpeechHandlerPlugin(['MOCK2']))
-        my_brain.add_plugin(ExampleSpeechHandlerPlugin(['MOCK1']))
+        my_brain.add_plugin(ExampleSpeechHandlerPlugin(['MOCK TWO']))
+        my_brain.add_plugin(ExampleSpeechHandlerPlugin(['MOCK ONE']))
 
         extracted_phrases = my_brain.get_plugin_phrases()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added two new functions to the Mic class - Expect and Confirm.
These allow more complex scripting in speechhandler plugins.

I have updated the News, Hacker News, and Joke plugins to
demonstrate.

### expect(prompt, phrases, name='expect', instructions=None)
This new function takes a prompt which is spoken and a list of phrases for the user to choose from. It also takes an optional 'name' argument which allows Naomi to reuse the stt model between calls, and an optional 'instructions' argument which allows the plugin author to specify a message for Naomi to deliver if the response is not recognized. By default, Naomi will list the phrases passed in if the response is not recognized.

When the verbal response matches a phrase, the phrase (in upper case) is returned rather than the actual transcription. The idea was to make it easy to process the response using a series of "if" statements.

If the response does not match a phrase, Naomi checks to see if the response contains any wake word. If it does, Naomi assumes the user attempting to start a new command and uses a custom exception to escape back into the main conversation loop, abandoning the current dialog. If it does not, then Naomi either reads the instructions or lists the phrases it is expecting.

Usage:
```
        response = mic.expect(
            "What is your favorite flavor of ice cream?",
            ["Chocolate", "Strawberry", "Vanilla", "Rocky Road"]
        )
        if response == "Chocolate".upper():
            mic.say("Yum, mine too!")
        else:
            mic.say(f"{response.title()} is okay, but I prefer chocolate")
```

### confirm(prompt)
This is a special case for the expect function which only accepts a positive or negative response and returns a boolean. The only argument it takes is a prompt.

Usage:
```
        if(mic.confirm("Should I order a five gallon tub of ice cream?")):
            mic.say("Okay, I’m placing your order")
            place_order(5)
        else:
            mic.say("Good thinking, I’ll order ten gallons!")
            place_order(10)
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Expect and confirm #355](https://github.com/NaomiProject/Naomi/issues/355)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This makes scripting interactive speechhandler plugins easier, and also provides a standard interface for interactive plugins.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested using a matrix of "listen_while_talking" and "passive_listen"
and it worked with both of those both on and off.

I have tested with the regular, local, and test mics.

I have tested with Naomi TTI, Adapt TTI and Padatious TTI.

All unit tests passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
