### PR TITLE
Moved the Naomi.sh file to ~/.config

### DIFF
--- a/installers/naomi-setup.sh
+++ b/installers/naomi-setup.sh
@@ -245,7 +245,7 @@ apt_setup_wizard() {
       printf "${B_W}Please type '${B_G}Naomi --repopulate${B_W}' on the prompt below to populate your profile...${NL}"
       sudo rm -Rf ~/Naomi-Temp
       # Launch Naomi Population
-      cd ~/Naomi
+      cd ~/.config/naomi
       chmod a+x Naomi.sh
       cd ~
       exec bash
@@ -274,7 +274,7 @@ apt_setup_wizard() {
       printf "${B_W}Please type '${B_G}Naomi --repopulate${B_W}' on the prompt below to populate your profile...${NL}"
       sudo rm -Rf ~/Naomi-Temp
       # Launch Naomi Population
-      cd ~/Naomi
+      cd ~/.config/naomi
       chmod a+x Naomi.sh
       cd ~
       exec bash
@@ -318,7 +318,7 @@ yum_setup_wizard() {
       printf "${B_W}Please type '${B_G}Naomi --repopulate${B_W}' on the prompt below to populate your profile...${NL}"
       sudo rm -Rf ~/Naomi-Temp
       # Launch Naomi Population
-      cd ~/Naomi
+      cd ~/.config/naomi
       chmod a+x Naomi.sh
       cd ~
       exec bash
@@ -347,7 +347,7 @@ yum_setup_wizard() {
       printf "${B_W}Please type '${B_G}Naomi --repopulate${B_W}' on the prompt below to populate your profile...${NL}"
       sudo rm -Rf ~/Naomi-Temp
       # Launch Naomi Population
-      cd ~/Naomi
+      cd ~/.config/naomi
       chmod a+x Naomi.sh
       cd ~
       exec bash

--- a/installers/script.deb.sh
+++ b/installers/script.deb.sh
@@ -387,7 +387,7 @@ setup_wizard() {
     echo '######################################################################' >> ~/.bashrc
     echo '# Initialize Naomi to start on command' >> ~/.bashrc
     echo '######################################################################' >> ~/.bashrc
-    echo 'source ~/Naomi/Naomi.sh' >> ~/.bashrc
+    echo 'source ~/.config/naomi/Naomi.sh' >> ~/.bashrc
     echo
     echo
     echo '[Desktop Entry]' > ~/Desktop/Naomi.desktop
@@ -401,87 +401,87 @@ setup_wizard() {
     echo 'Categories=None;' >> ~/Desktop/Naomi.desktop
     echo
     echo
-    echo "#!/bin/bash" > ~/Naomi/Naomi.sh
-    echo "" >> ~/Naomi/Naomi.sh
-    echo "B_W='\033[1;97m' #Bright White  For standard text output" >> ~/Naomi/Naomi.sh
-    echo "B_R='\033[1;91m' #Bright Red    For alerts/errors" >> ~/Naomi/Naomi.sh
-    echo "B_Blue='\033[1;94m' #Bright Blue For prompt question" >> ~/Naomi/Naomi.sh
-    echo "B_M='\033[1;95m' #Bright Magenta For prompt choices" >> ~/Naomi/Naomi.sh
-    echo 'NL="' >> ~/Naomi/Naomi.sh
-    echo '"' >> ~/Naomi/Naomi.sh
-    echo 'version="3.0"' >> ~/Naomi/Naomi.sh
-    echo 'theDateRightNow=$(date +%m-%d-%Y-%H:%M:%S)' >> ~/Naomi/Naomi.sh
-    echo 'gitURL="https://github.com/naomiproject/naomi"' >> ~/Naomi/Naomi.sh
-    echo "" >> ~/Naomi/Naomi.sh
-    echo "function Naomi() {" >> ~/Naomi/Naomi.sh
-    echo "  if [ \"\$(jq '.auto_update' ~/.config/naomi/configs/.naomi_options.json)\" = '\"true\"' ]; then" >> ~/Naomi/Naomi.sh
-    echo '    printf "${B_W}=========================================================================${NL}"' >> ~/Naomi/Naomi.sh
-    echo '    printf "${B_W}Checking for Naomi Updates...${NL}"' >> ~/Naomi/Naomi.sh
-    echo "    cd ~/Naomi" >> ~/Naomi/Naomi.sh
-    echo "    git fetch -q " >> ~/Naomi/Naomi.sh
-    echo '    if [ "$(git rev-parse HEAD)" != "$(git rev-parse @{u})" ] ; then' >> ~/Naomi/Naomi.sh
-    echo '      printf "${B_W}Downloading & Installing Updates...${NL}"' >> ~/Naomi/Naomi.sh
-    echo "      git pull" >> ~/Naomi/Naomi.sh
-    echo "      sudo apt-get -o Acquire::ForceIPv4=true update -y" >> ~/Naomi/Naomi.sh
-    echo "      sudo apt -o upgrade -y" >> ~/Naomi/Naomi.sh
-    echo "      sudo ./naomi_apt_requirements.sh -y" >> ~/Naomi/Naomi.sh
-    echo "    else" >> ~/Naomi/Naomi.sh
-    echo '      printf "${B_W}No Updates Found.${NL}"' >> ~/Naomi/Naomi.sh
-    echo "    fi" >> ~/Naomi/Naomi.sh
-    echo "  else" >> ~/Naomi/Naomi.sh
-    echo '    printf "${B_R}Notice: ${B_W}Naomi Auto Update Failed!${NL}"' >> ~/Naomi/Naomi.sh
-    echo '    printf "${B_R}Notice: ${B_W}Would you like to force update Naomi?${NL}"' >> ~/Naomi/Naomi.sh
-    echo '    printf "${B_Blue}Choice [${B_M}Y${B_Blue}/${B_M}N${B_Blue}]: ${B_W}"' >> ~/Naomi/Naomi.sh
-    echo '    while true; do' >> ~/Naomi/Naomi.sh
-    echo '      read -N1 -s key' >> ~/Naomi/Naomi.sh
-    echo '      case $key in' >> ~/Naomi/Naomi.sh
-    echo '        Y)' >> ~/Naomi/Naomi.sh
-    echo '          printf "${B_M}$key ${B_W}- Forcing Update${NL}"' >> ~/Naomi/Naomi.sh
-    echo '          mv ~/Naomi ~/Naomi-Temp' >> ~/Naomi/Naomi.sh
-    echo '          cd ~' >> ~/Naomi/Naomi.sh
-    echo "          if [ \"\$(jq '.use_release' ~/.config/naomi/configs/.naomi_options.json)\" = '\"nightly\"' ]; then" >> ~/Naomi/Naomi.sh
-    echo '            printf "${B_M}$key ${B_W}- Forcing Update${NL}"' >> ~/Naomi/Naomi.sh
-    echo '            mv ~/Naomi ~/Naomi-Temp' >> ~/Naomi/Naomi.sh
-    echo '            cd ~' >> ~/Naomi/Naomi.sh
-    echo "            git clone \$gitURL.git -b naomi-dev Naomi" >> ~/Naomi/Naomi.sh
-    echo '            cd Naomi' >> ~/Naomi/Naomi.sh
-    echo "            echo '{\"use_release\":\"nightly\", \"branch\":\"naomi-dev\", \"version\":\"Naomi-\$version.\$(git rev-parse --short HEAD)\", \"date\":\"\$theDateRightNow\", \"auto_update\":\"true\"}' > ~/.config/naomi/configs/.naomi_options.json" >> ~/Naomi/Naomi.sh
-    echo '            cd ~' >> ~/Naomi/Naomi.sh
-    echo '            break' >> ~/Naomi/Naomi.sh
-    echo "          elif [ \"\$(jq '.use_release' ~/.config/naomi/configs/.naomi_options.json)\" = '\"milestone\"' ]; then" >> ~/Naomi/Naomi.sh
-    echo '            printf "${B_M}$key ${B_W}- Forcing Update${NL}"' >> ~/Naomi/Naomi.sh
-    echo '            mv ~/Naomi ~/Naomi-Temp' >> ~/Naomi/Naomi.sh
-    echo '            cd ~' >> ~/Naomi/Naomi.sh
-    echo "            git clone \$gitURL.git -b naomi-dev Naomi" >> ~/Naomi/Naomi.sh
-    echo '            cd Naomi' >> ~/Naomi/Naomi.sh
-    echo "            echo '{\"use_release\":\"milestone\", \"branch\":\"naomi-dev\", \"version\":\"Naomi-\$version.\$(git rev-parse --short HEAD)\", \"date\":\"\$theDateRightNow\", \"auto_update\":\"true\"}' > ~/.config/naomi/configs/.naomi_options.json" >> ~/Naomi/Naomi.sh
-    echo '            cd ~' >> ~/Naomi/Naomi.sh
-    echo '            break' >> ~/Naomi/Naomi.sh
-    echo "          elif [ \"\$(jq '.use_release' ~/.config/naomi/configs/.naomi_options.json)\" = '\"stable\"' ]; then" >> ~/Naomi/Naomi.sh
-    echo '            printf "${B_M}$key ${B_W}- Forcing Update${NL}"' >> ~/Naomi/Naomi.sh
-    echo '            mv ~/Naomi ~/Naomi-Temp' >> ~/Naomi/Naomi.sh
-    echo '            cd ~' >> ~/Naomi/Naomi.sh
-    echo "            git clone \$gitURL.git -b master Naomi" >> ~/Naomi/Naomi.sh
-    echo '            cd Naomi' >> ~/Naomi/Naomi.sh
-    echo "            echo '{\"use_release\":\"stable\", \"branch\":\"master\", \"version\":\"Naomi-\$version.\$(git rev-parse --short HEAD)\", \"date\":\"\$theDateRightNow\", \"auto_update\":\"false\"}' > ~/.config/naomi/configs/.naomi_options.json" >> ~/Naomi/Naomi.sh
-    echo '            cd ~' >> ~/Naomi/Naomi.sh
-    echo '          fi' >> ~/Naomi/Naomi.sh
-    echo '          break' >> ~/Naomi/Naomi.sh
-    echo '          ;;' >> ~/Naomi/Naomi.sh
-    echo '         N)' >> ~/Naomi/Naomi.sh
-    echo '          printf "${B_M}$key ${B_W}- Launching Naomi!${NL}"' >> ~/Naomi/Naomi.sh
-    echo '          break' >> ~/Naomi/Naomi.sh
-    echo '          ;;' >> ~/Naomi/Naomi.sh
-    echo '       esac' >> ~/Naomi/Naomi.sh
-    echo '   done' >> ~/Naomi/Naomi.sh
-    echo "  fi" >> ~/Naomi/Naomi.sh
-    echo "  export WORKON_HOME=$HOME/.virtualenvs" >> ~/Naomi/Naomi.sh
-    echo "  export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3" >> ~/Naomi/Naomi.sh
-    echo "  export VIRTUALENVWRAPPER_VIRTUALENV=~/.local/bin/virtualenv" >> ~/Naomi/Naomi.sh
-    echo "  source ~/.local/bin/virtualenvwrapper.sh" >> ~/Naomi/Naomi.sh
-    echo "  workon Naomi" >> ~/Naomi/Naomi.sh
-    echo "  python $NAOMI_DIR/Naomi.py \"\$@\"" >> ~/Naomi/Naomi.sh
-    echo "}" >> ~/Naomi/Naomi.sh
+    echo "#!/bin/bash" > ~/.config/naomi/Naomi.sh
+    echo "" >> ~/.config/naomi/Naomi.sh
+    echo "B_W='\033[1;97m' #Bright White  For standard text output" >> ~/.config/naomi/Naomi.sh
+    echo "B_R='\033[1;91m' #Bright Red    For alerts/errors" >> ~/.config/naomi/Naomi.sh
+    echo "B_Blue='\033[1;94m' #Bright Blue For prompt question" >> ~/.config/naomi/Naomi.sh
+    echo "B_M='\033[1;95m' #Bright Magenta For prompt choices" >> ~/.config/naomi/Naomi.sh
+    echo 'NL="' >> ~/.config/naomi/Naomi.sh
+    echo '"' >> ~/.config/naomi/Naomi.sh
+    echo 'version="3.0"' >> ~/.config/naomi/Naomi.sh
+    echo 'theDateRightNow=$(date +%m-%d-%Y-%H:%M:%S)' >> ~/.config/naomi/Naomi.sh
+    echo 'gitURL="https://github.com/naomiproject/naomi"' >> ~/.config/naomi/Naomi.sh
+    echo "" >> ~/.config/naomi/Naomi.sh
+    echo "function Naomi() {" >> ~/.config/naomi/Naomi.sh
+    echo "  if [ \"\$(jq '.auto_update' ~/.config/naomi/configs/.naomi_options.json)\" = '\"true\"' ]; then" >> ~/.config/naomi/Naomi.sh
+    echo '    printf "${B_W}=========================================================================${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo '    printf "${B_W}Checking for Naomi Updates...${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo "    cd ~/Naomi" >> ~/.config/naomi/Naomi.sh
+    echo "    git fetch -q " >> ~/.config/naomi/Naomi.sh
+    echo '    if [ "$(git rev-parse HEAD)" != "$(git rev-parse @{u})" ] ; then' >> ~/.config/naomi/Naomi.sh
+    echo '      printf "${B_W}Downloading & Installing Updates...${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo "      git pull" >> ~/.config/naomi/Naomi.sh
+    echo "      sudo apt-get -o Acquire::ForceIPv4=true update -y" >> ~/.config/naomi/Naomi.sh
+    echo "      sudo apt -o upgrade -y" >> ~/.config/naomi/Naomi.sh
+    echo "      sudo ./naomi_apt_requirements.sh -y" >> ~/.config/naomi/Naomi.sh
+    echo "    else" >> ~/.config/naomi/Naomi.sh
+    echo '      printf "${B_W}No Updates Found.${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo "    fi" >> ~/.config/naomi/Naomi.sh
+    echo "  else" >> ~/.config/naomi/Naomi.sh
+    echo '    printf "${B_R}Notice: ${B_W}Naomi Auto Update Failed!${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo '    printf "${B_R}Notice: ${B_W}Would you like to force update Naomi?${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo '    printf "${B_Blue}Choice [${B_M}Y${B_Blue}/${B_M}N${B_Blue}]: ${B_W}"' >> ~/.config/naomi/Naomi.sh
+    echo '    while true; do' >> ~/.config/naomi/Naomi.sh
+    echo '      read -N1 -s key' >> ~/.config/naomi/Naomi.sh
+    echo '      case $key in' >> ~/.config/naomi/Naomi.sh
+    echo '        Y)' >> ~/.config/naomi/Naomi.sh
+    echo '          printf "${B_M}$key ${B_W}- Forcing Update${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo '          mv ~/Naomi ~/Naomi-Temp' >> ~/.config/naomi/Naomi.sh
+    echo '          cd ~' >> ~/.config/naomi/Naomi.sh
+    echo "          if [ \"\$(jq '.use_release' ~/.config/naomi/configs/.naomi_options.json)\" = '\"nightly\"' ]; then" >> ~/.config/naomi/Naomi.sh
+    echo '            printf "${B_M}$key ${B_W}- Forcing Update${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo '            mv ~/Naomi ~/Naomi-Temp' >> ~/.config/naomi/Naomi.sh
+    echo '            cd ~' >> ~/.config/naomi/Naomi.sh
+    echo "            git clone \$gitURL.git -b naomi-dev Naomi" >> ~/.config/naomi/Naomi.sh
+    echo '            cd Naomi' >> ~/.config/naomi/Naomi.sh
+    echo "            echo '{\"use_release\":\"nightly\", \"branch\":\"naomi-dev\", \"version\":\"Naomi-\$version.\$(git rev-parse --short HEAD)\", \"date\":\"\$theDateRightNow\", \"auto_update\":\"true\"}' > ~/.config/naomi/configs/.naomi_options.json" >> ~/.config/naomi/Naomi.sh
+    echo '            cd ~' >> ~/.config/naomi/Naomi.sh
+    echo '            break' >> ~/.config/naomi/Naomi.sh
+    echo "          elif [ \"\$(jq '.use_release' ~/.config/naomi/configs/.naomi_options.json)\" = '\"milestone\"' ]; then" >> ~/.config/naomi/Naomi.sh
+    echo '            printf "${B_M}$key ${B_W}- Forcing Update${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo '            mv ~/Naomi ~/Naomi-Temp' >> ~/.config/naomi/Naomi.sh
+    echo '            cd ~' >> ~/.config/naomi/Naomi.sh
+    echo "            git clone \$gitURL.git -b naomi-dev Naomi" >> ~/.config/naomi/Naomi.sh
+    echo '            cd Naomi' >> ~/.config/naomi/Naomi.sh
+    echo "            echo '{\"use_release\":\"milestone\", \"branch\":\"naomi-dev\", \"version\":\"Naomi-\$version.\$(git rev-parse --short HEAD)\", \"date\":\"\$theDateRightNow\", \"auto_update\":\"true\"}' > ~/.config/naomi/configs/.naomi_options.json" >> ~/.config/naomi/Naomi.sh
+    echo '            cd ~' >> ~/.config/naomi/Naomi.sh
+    echo '            break' >> ~/.config/naomi/Naomi.sh
+    echo "          elif [ \"\$(jq '.use_release' ~/.config/naomi/configs/.naomi_options.json)\" = '\"stable\"' ]; then" >> ~/.config/naomi/Naomi.sh
+    echo '            printf "${B_M}$key ${B_W}- Forcing Update${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo '            mv ~/Naomi ~/Naomi-Temp' >> ~/.config/naomi/Naomi.sh
+    echo '            cd ~' >> ~/.config/naomi/Naomi.sh
+    echo "            git clone \$gitURL.git -b master Naomi" >> ~/.config/naomi/Naomi.sh
+    echo '            cd Naomi' >> ~/.config/naomi/Naomi.sh
+    echo "            echo '{\"use_release\":\"stable\", \"branch\":\"master\", \"version\":\"Naomi-\$version.\$(git rev-parse --short HEAD)\", \"date\":\"\$theDateRightNow\", \"auto_update\":\"false\"}' > ~/.config/naomi/configs/.naomi_options.json" >> ~/.config/naomi/Naomi.sh
+    echo '            cd ~' >> ~/.config/naomi/Naomi.sh
+    echo '          fi' >> ~/.config/naomi/Naomi.sh
+    echo '          break' >> ~/.config/naomi/Naomi.sh
+    echo '          ;;' >> ~/.config/naomi/Naomi.sh
+    echo '         N)' >> ~/.config/naomi/Naomi.sh
+    echo '          printf "${B_M}$key ${B_W}- Launching Naomi!${NL}"' >> ~/.config/naomi/Naomi.sh
+    echo '          break' >> ~/.config/naomi/Naomi.sh
+    echo '          ;;' >> ~/.config/naomi/Naomi.sh
+    echo '       esac' >> ~/.config/naomi/Naomi.sh
+    echo '   done' >> ~/.config/naomi/Naomi.sh
+    echo "  fi" >> ~/.config/naomi/Naomi.sh
+    echo "  export WORKON_HOME=$HOME/.virtualenvs" >> ~/.config/naomi/Naomi.sh
+    echo "  export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3" >> ~/.config/naomi/Naomi.sh
+    echo "  export VIRTUALENVWRAPPER_VIRTUALENV=~/.local/bin/virtualenv" >> ~/.config/naomi/Naomi.sh
+    echo "  source ~/.local/bin/virtualenvwrapper.sh" >> ~/.config/naomi/Naomi.sh
+    echo "  workon Naomi" >> ~/.config/naomi/Naomi.sh
+    echo "  python $NAOMI_DIR/Naomi.py \"\$@\"" >> ~/.config/naomi/Naomi.sh
+    echo "}" >> ~/.config/naomi/Naomi.sh
     echo
     echo
     echo
@@ -489,6 +489,7 @@ setup_wizard() {
 
     find ~/Naomi -maxdepth 1 -iname '*.py' -type f -exec chmod a+x {} \;
     find ~/Naomi -maxdepth 1 -iname '*.sh' -type f -exec chmod a+x {} \;
+    find ~/.config/naomi -maxdepth 1 -iname '*.sh' -type f -exec chmod a+x {} \;
     find ~/Naomi/installers -maxdepth 1 -iname '*.sh' -type f -exec chmod a+x {} \;
 
     echo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We currently add a call to Naomi.sh to the end of ~/.bashrc to initialize the virtualenvwrapper environment so the user just has to type workon Naomi to get into the environment. Naomi.sh also creates a function in the user's bash shell which allows them to run Naomi by typing Naomi at the command prompt, rather than having to type ~/Naomi/Naomi.py.

This is the only user file we are adding to the Naomi directory. Other than this one file, the user would be able to delete the Naomi directory and re-clone it and it would most likely run fine without rerunning the installer.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #360

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the user deleted the Naomi folder and then clones it directly from Github, they will have to copy or move the Naomi.sh file to another folder first. Otherwise, they will get an error every time they start a bash session stating that ~/Naomi/Naomi.sh cannot be found.

Sometimes a user needs to reset their working directory by deleting it and re-cloning it from Github, but should not have to go through the setup procedure again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
