### PR TITLE
Slight changes to log and output

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -82,11 +82,14 @@ class Naomi(object):
             keyword = profile.get_profile_var(['keyword'], ['Naomi'])
             if(isinstance(keyword, list)):
                 keyword = keyword[0]
-            print(self._interface.status_text(_(
-                "Configuring {}"
-            ).format(
-                keyword
-            )))
+            visualizations.run_visualization(
+                "output",
+                self._interface.status_text(_(
+                    "Configuring {}"
+                ).format(
+                    keyword
+                ))
+            )
             for setting in self.settings():
                 self._interface.get_setting(
                     setting, self.settings()[setting]
@@ -361,6 +364,7 @@ class Naomi(object):
             try:
                 plugin = info.plugin_class(info)
                 self.brain.add_plugin(plugin)
+                self._logger.info('Loaded {} into brain'.format(plugin.info.name))
             except Exception as e:
                 reason = ''
                 if hasattr(e, 'strerror') and e.strerror:
@@ -373,15 +377,16 @@ class Naomi(object):
                     reason = e.msg
                 if not reason:
                     reason = str(e)
-                if(self._logger.getEffectiveLevel() > logging.DEBUG):
-                    print(
-                        "Plugin {} skipped! (Reason: {})".format(
-                            info.name,
-                            reason
-                        )
+                visualizations.run_visualization(
+                    "output",
+                    "Plugin {} skipped! (Reason: {})".format(
+                        info.name,
+                        reason
                     )
+                )
                 self._logger.warning(
-                    "Plugin '%s' skipped! (Reason: %s)", info.name,
+                    "Plugin '%s' skipped! (Reason: %s)",
+                    info.name,
                     reason,
                     exc_info=(
                         self._logger.getEffectiveLevel() == logging.DEBUG
@@ -787,9 +792,12 @@ class Naomi(object):
 
     def validate_output_device(self, output_device_slug):
         response = True
-        print(self._interface.instruction_text(
-            _("Testing device by playing a sound")
-        ))
+        visualizations.run_visualization(
+            "output",
+            self._interface.instruction_text(
+                _("Testing device by playing a sound")
+            )
+        )
         ae_info = profile.get_arg('plugins').get_plugin(
             profile.get_profile_var(['audio_engine']),
             category='audioengine'
@@ -810,7 +818,10 @@ class Naomi(object):
                 filename
             )
         except Exception as e:
-            print(e)
+            visualizations.run_visualization(
+                "output",
+                e
+            )
         heard = self._interface.simple_yes_no(
             _("Were you able to hear the beep?")
         )
@@ -826,7 +837,8 @@ class Naomi(object):
                 )
                 if(troubleshoot):
                     response = False
-                    print(
+                    visualizations.run_visualization(
+                        "output",
                         self._interface.instruction_text(" ".join([
                             _("The volume on your device may be too low."),
                             _("You should be able to use 'alsamixer'"),
@@ -866,21 +878,32 @@ class Naomi(object):
                     heard = True
 
         except audioengine.UnsupportedFormat as e:
-            print(self._interface.alert_text(str(e)))
-            print(
+            visualizations.run_visualization(
+                "output",
+                self._interface.alert_text(str(e))
+            )
+            visualizations.run_visualization(
+                "output",
                 self._interface.instruction_text(
                     _("Output format not supported on this device.")
                 )
             )
-            print(
+            visualizations.run_visualization(
+                "output",
                 self._interface.instruction_text(
                     _("Please choose a different device.")
                 )
             )
-            print("")
+            visualizations.run_visualization(
+                "output",
+                ""
+            )
             response = False
         except Exception as e:
-            print(str(e))
+            visualizations.run_visualization(
+                "output",
+                str(e)
+            )
         return response
 
     def validate_input_device(self, input_device_slug):
@@ -943,7 +966,8 @@ class Naomi(object):
                 vad_plugin
             )
 
-            print(
+            visualizations.run_visualization(
+                "output",
                 self._interface.instruction_text(
                     _("Please speak into the mic now")
                 )
@@ -964,7 +988,10 @@ class Naomi(object):
                 while (replay):
                     response = True
                     output_device.play_fp(f)
-                    print("")
+                    visualizations.run_visualization(
+                        "output",
+                        ""
+                    )
                     heard = self._interface.simple_yes_no(
                         _("Did you hear yourself?")
                     )

--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -73,13 +73,10 @@ class Conversation(i18n.GettextMixin):
                     'Failed to service intent {}: {}'.format(intent, str(e)),
                     exc_info=True
                 )
-                self.mic.say(
-                    " ".join([
-                        self.gettext("I'm sorry."),
-                        self.gettext("I had some trouble with that operation."),
-                        self.gettext("Please try again later.")
-                    ])
-                )
+                self.mic.say(self.gettext("I'm sorry."))
+                self.mic.say(self.gettext("I had some trouble with that operation."))
+                self.mic.say(str(e))
+                self.mic.say(self.gettext("Please try again later."))
                 handled = True
             else:
                 self._logger.debug(

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -312,11 +312,18 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
     # upper case and expanding all contractions. We might also want to do
     # stemming or lemmatization here. This function should be moved to the
     # locale directory and overridden on a per locale basis.
+
+    # 2022-04-07 When this is used to add a list of words to the dictionary,
+    # we want both the contraction and the expanded words.
     def cleantext(self, text):
         language = profile.get(["language"], "en-US")[:2]
         if language == "en":
             words = text.split(" ")
-            # Adapted from a list at https://stackoverflow.com/questions/19790188/expanding-english-language-contractions-in-python
+            # Adapted from a list at
+            # https://stackoverflow.com/questions/19790188/expanding-english-language-contractions-in-python
+            # It does not work for contractions with multiple possible
+            # expansions (eg: Don't do that: Do not do that
+            #                 She don't do that: She does not do that)
             contractions = {
                 "AIN'T": "ARE NOT",  # "am not / are not / is not / has not / have not"
                 "AREN'T": "ARE NOT",
@@ -451,8 +458,7 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
             text = " ".join(words)
         return text
 
-    @staticmethod
-    def match_phrase(phrase, choices):
+    def match_phrase(self, phrase, choices):
         # If phrase is a list, convert to a string
         # (otherwise the "split" below throws an error)
         if(isinstance(phrase, list)):
@@ -462,7 +468,7 @@ class TTIPlugin(GenericPlugin, metaclass=abc.ABCMeta):
         else:
             # Just implement a quick edit distance
             # FIXME replace this with a call to a real intent parser
-            phrase = phrase.upper()
+            phrase = self.cleantext(phrase)
             choices = [choice.upper() for choice in choices]
             templates = {}
             for template in choices:

--- a/plugins/audioengine/pyaudio-ae/pyaudioengine.py
+++ b/plugins/audioengine/pyaudio-ae/pyaudioengine.py
@@ -29,17 +29,11 @@ class PyAudioEnginePlugin(plugin.AudioEnginePlugin):
                           "that pop up during this process are normal and " +
                           "can usually be safely ignored.")
 
-        # AaronC Sept 18 2018 Temporarily redirect errors
-        # while instantiating PyAudio object if we are not
-        # in DEBUG mode
-        if (self._logger.getEffectiveLevel() > logging.DEBUG):
-            dev_null = os.open('/dev/null', os.O_WRONLY)
-            std_err = os.dup(2)
-            os.dup2(dev_null, 2)
-            self._pyaudio = pyaudio.PyAudio()
-            os.dup2(std_err, 2)
-        else:
-            self._pyaudio = pyaudio.PyAudio()
+        dev_null = os.open('/dev/null', os.O_WRONLY)
+        std_err = os.dup(2)
+        os.dup2(dev_null, 2)
+        self._pyaudio = pyaudio.PyAudio()
+        os.dup2(std_err, 2)
 
         self._logger.info("Initialization of PyAudio engine finished")
 

--- a/plugins/speechhandler/mpdcontrol/mpdcontrol.py
+++ b/plugins/speechhandler/mpdcontrol/mpdcontrol.py
@@ -181,8 +181,12 @@ class MPDControlPlugin(plugin.SpeechHandlerPlugin):
 
     def stop(self, intent, mic):
         _ = self.gettext  # Alias for better readability
+        playback_state = self._music.get_playback_state()
+        # stop playback even if playback appears to already be stopped
         self._music.stop()
-        self.say(mic, _('Music stopped.'))
+        # if music is playing or paused, tell the user that playback is stopped
+        if playback_state != mpdclient.PLAYBACK_STATE_STOPPED:
+            self.say(mic, _('Music stopped.'))
 
     def load_playlist(self, playlist):
         playlists = self._music.get_playlists()

--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import random
-import time
 from naomi import plugin
 from naomi import profile
 

--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -54,12 +54,5 @@ class ShutdownPlugin(plugin.SpeechHandlerPlugin):
         message = random.choice(messages)
 
         mic.say(message)
-        # specifically wait for Naomi to finish talking
-        # here, otherwise it will exit before getting to
-        # speak.
-        if(profile.get_arg('listen_while_talking', False)):
-            if hasattr(mic, "current_thread"):
-                while(mic.current_thread.is_alive()):
-                    time.sleep(1)
 
         quit()

--- a/plugins/vad/webrtc_vad/webrtc_vad.py
+++ b/plugins/vad/webrtc_vad/webrtc_vad.py
@@ -152,6 +152,8 @@ class WebRTCPlugin(plugin.VADPlugin, unittest.TestCase):
                 [key * value for key, value in self.distribution.items()]
             ) / items
             stddev = math.sqrt((sum1 - (items * (mean ** 2))) / (items - 1))
+            if stddev < 1:
+                stddev = 1
             self._threshold = mean + (
                 stddev * profile.get(
                     ['snr_vad', 'tolerance'],

--- a/plugins/visualizations/terminal/terminal.py
+++ b/plugins/visualizations/terminal/terminal.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+import datetime
 from blessings import Terminal
 from naomi.commandline import println
+from naomi import app_utils
 from naomi import plugin
 
 
@@ -40,3 +42,8 @@ class TerminalVisualizationsPlugin(plugin.VisualizationsPlugin):
             feedback[int(displaywidth * ((threshold - minsnr) / snrrange))] = 't'
         println("".join(feedback))
 
+    @staticmethod
+    def output(message):
+        tz = app_utils.get_timezone()
+        now = datetime.datetime.now(tz=tz)
+        println(f"{now:%l}:{now:%M} {now:%p} - {message}\n")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated logging so python log messages are sent to a log file
instead of simply displaying to the screen. The default log file
is naomi.log in your "sub" directory (default is ~/.config/naomi).

Created an "output" visualization instead of simply printing to
the terminal. Used like:

```
from naomi import visualizations
visualizations.run_visualization('output', message)
```

Changelog:
  naomi/__main__.py - Use a file for logging
  naomi/application.py - use a visualization to print messages
  naomi/conversation.py - include error messages in spoken response
  naomi/mic.py - use visualization for messages, add time to input/output log.
  naomi/plugin.py - expand english language contractions before processing utterance.
  plugins/audioengine/pyaudio-ae/pyaudioengine.py - suppress warnings and errors.
  plugins/speechhandler/mpdcontrol/mpdcontrol.py - only announce that Naomi is stopping the music if the music is currently playing.
  plugins/speechhandler/shutdownplugin/shutdown.py - it is no longer necessary to wait for Naomi to finish speaking before shutting down since the asynchronous speaking thread is now daemonized.
  plugins/speechhandler/stop/stop.py - wait until the first time the "stop" command is received before creating a list of plugins with "stop" methods.
  plugins/speechhandler/wwis_weather/wwis_weather.py - Don't check for connectivity in the init method.
  plugins/tti/naomi_tti/naomi_tti.py - send debugging information to log.
  plugins/vad/webrtc_vad/webrtc_vad.py - set lower limit on stddev.
  plugins/visualizations/terminal/terminal.py - create an "output" visualization to use for writing messages to the user.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Don't access the internet when initializing speechhandler plugin #359](https://github.com/NaomiProject/Naomi/issues/359)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The log file was suggested by Malcolm a while ago, and it seemed like a good way to clean up some of the output on the user's screen, plus provide a good place to look for debugging information. I would like to add a standard way to redirect output from non-python programs to the log, and we might want a way to send output to the screen instead of a log for anyone who is used to Naomi working that way.

Using a visualization to write to the screen instead of simply printing to it should make it easier for someone to override that method and send the output to something else (an lcd screen, or curses window or web interface perhaps?)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've been running with these changes for the last 6 months or so.

Unittests OK:
```
(Naomi) pi@Naomi:~/Naomi$ python -m unittest discover
...s.....ss.....sssssssss
----------------------------------------------------------------------
Ran 25 tests in 3.585s

OK (skipped=12)
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
