### PR TITLE
Keep output stream open

### DIFF
--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -294,12 +294,12 @@ class Mic(object):
     def check_for_keyword(self, phrase, keyword=None):
         if not keyword:
             keyword = self._keyword
-        wakewords = [
-            word.upper()
-            for word in keyword
-            for w in phrase if w
-            if word.upper() in w.upper()
-        ]
+        # This allows multi-word keywords like 'Hey Naomi' or 'You there'
+        wakewords = []
+        for word in keyword:
+            for w in phrase:
+                if word.upper() in w.upper():
+                    wakewords.append(word.upper())
         if any(wakewords):
             return True
         return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Keep the output stream open between playing back messages. This solves the problem of Naomi closing the stream after writing data to it, but before the data has been completely played back. It also should reduce "popping" for devices that "pop" when being opened and closed.

I implemented this in pyaudio. The same thing could probably be done in Alsa. I'll try copying the updated play_fp method from pyaudioengine.py to audiodevice.py and see what blows up when I try to use Alsa.

This update also contains a fix to the mic.py script which allows multi-word wakewords (like "Hey Naomi" or "Naomi Bot") to be used.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Naomi's output audio gets clipped #365](https://github.com/NaomiProject/Naomi/issues/365)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is one way to prevent output from getting clipped at the end when the output stream gets closed before the file has finished playing. Other methods include adding a pause for the length of the recording (or the length of the recording minus the time that has passed since first starting to add audio chunks to the buffer). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
~/Naomi $ python -m unittest discover
Ran 25 tests in 19.288s

OK (skipped=12)
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
