### PR TITLE
Fix issue with path to CMU Dictionary

### DIFF
--- a/plugins/stt/pocketsphinx-stt/sphinxplugin.py
+++ b/plugins/stt/pocketsphinx-stt/sphinxplugin.py
@@ -191,40 +191,7 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
         if (not hmm_dir):
             # Make a list of possible paths to check
             hmm_dir_paths = [
-                os.path.join(
-                    os.path.expanduser("~"),
-                    "pocketsphinx-python",
-                    "pocketsphinx",
-                    "model",
-                    "en-us",
-                    "en-us"
-                ),
-                os.path.join(
-                    os.path.expanduser("~"),
-                    "pocketsphinx",
-                    "model",
-                    "en-us",
-                    "en-us"
-                ),
-                os.path.join(
-                    "/",
-                    "usr",
-                    "share",
-                    "pocketsphinx",
-                    "model",
-                    "en-us",
-                    "en-us"
-                ),
-                os.path.join(
-                    "/usr",
-                    "local",
-                    "share",
-                    "pocketsphinx",
-                    "model",
-                    "hmm",
-                    "en_US",
-                    "hub4wsj_sc_8k"
-                )
+                paths.sub("pocketsphinx", "standard")
             ]
             # see if any of these paths exist
             for path in hmm_dir_paths:
@@ -246,10 +213,6 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
             if not os.path.isdir(standard_dir):
                 os.mkdir(standard_dir)
             hmm_dir = standard_dir
-            cmudict_path = os.path.join(
-                hmm_dir,
-                "cmudict.dict"
-            )
             if (not check_pocketsphinx_model(hmm_dir)):
                 # Check and see if we already have a copy of the standard
                 # language model
@@ -268,6 +231,11 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
                 self._logger.info(process_completedprocess(completedprocess))
                 if completedprocess.returncode != 0:
                     raise Exception("Error downloading standard language model")
+        # path to CMU dictionary
+        cmudict_path = os.path.join(
+            hmm_dir,
+            "cmudict.dict"
+        )
         # fst_model
         fst_model = os.path.join(hmm_dir, 'g2p_model.fst')
         if (not os.path.isfile(fst_model)):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Back in the old days, we used to require the user to download their own HMM model and CMU dictionary. The HMM model might be installed by installing a system package, along with the download of the pocketsphinx source code, or independently. Same with the CMU dictionary file.

At one point, it just seemed easier to host copies of the HMM model and dictionary ourselves. That way we would know where to download them from and could help the user with that, and would know what format everything is in.

Recently, I decided instead of asking for the locations of both the HMM model and the dictionary, just ask for the HMM model and assume that the dictionary is in that same folder and named CMUDict.dict.

Unfortunately, if it isn't, then that causes problems. I may need to revert to keeping the two settings separate in the future, but for right now, I am going to stop searching in all the odd places for the HMM model and dictionary and just assume we are using our hosted version. If the user does not have that installed, then download it for them.

There was an additional problem where if you did not download the HMM model and CMUDict during startup, the CMUDict variable did not get set. I have moved the initialization of that variable outside of that if/then block.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Fix issue with CMU Dictionary path #382](https://github.com/NaomiProject/Naomi/issues/382)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes an error that occurs under certain circumstances

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on several computers. All unit tests passed. Flake8 reported no issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
