### PR TITLE
This environment is externally managed

### DIFF
--- a/apt_requirements.txt
+++ b/apt_requirements.txt
@@ -10,6 +10,7 @@ libncurses5-dev
 libssl-dev
 python3-dev
 python3-pip
+python3-virtualenvwrapper
 util-linux
 
 # Plugins

--- a/installers/script.deb.sh
+++ b/installers/script.deb.sh
@@ -304,18 +304,15 @@ setup_wizard() {
       pulseaudio -D
     fi
 
-    pip3 install --user virtualenv virtualenvwrapper=='4.8.4'
     printf "${B_G}sourcing virtualenvwrapper.sh${B_W}${NL}"
     export WORKON_HOME=$HOME/.virtualenvs
     export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
-    export VIRTUALENVWRAPPER_VIRTUALENV=~/.local/bin/virtualenv
-    source ~/.local/bin/virtualenvwrapper.sh
-    export VIRTUALENVWRAPPER_ENV_BIN_DIR=bin
+    source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
     printf "${B_G}checking if Naomi virtualenv exists${B_W}${NL}"
     workon Naomi > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         printf "${B_G}Naomi virtualenv does not exist. Creating.${B_W}${NL}"
-        PATH=$PATH:~/.local/bin mkvirtualenv -p python3 Naomi
+        PATH=$PATH:~/.local/bin mkvirtualenv -p $VIRTUALENVWRAPPER_PYTHON Naomi
     fi
     workon Naomi
     if [ "$(which pip)" = "$HOME/.virtualenvs/Naomi/bin/pip" ]; then
@@ -329,8 +326,7 @@ setup_wizard() {
         printf "${B_W}dependencies, all you have to type is '${B_G}workon Naomi${B_W}'${NL}"
         echo
         printf "${B_W}Otherwise, you will need to enter:${NL}"
-        printf "${B_W}'${B_G}VIRTUALENVWRAPPER_VIRTUALENV=~/.local/bin/virtualenv${B_W}'${NL}"
-        printf "${B_W}'${B_G}source ~/.local/bin/virtualenvwrapper.sh${B_W}'${NL}"
+        printf "${B_W}'${B_G}source /usr/share/virtualenvwrapper/virtualenvwrapper.sh${B_W}'${NL}"
         printf "${B_W}before you will be able activate the Naomi environment with '${B_G}workon Naomi${B_W}'${NL}"
         echo
         printf "${B_W}All of this will be incorporated into the Naomi script, so to simply${NL}"
@@ -365,8 +361,7 @@ setup_wizard() {
             echo '######################################################################' >> ~/.bashrc
             echo "export WORKON_HOME=$HOME/.virtualenvs" >> ~/.bashrc
             echo "export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3" >> ~/.bashrc
-            echo "export VIRTUALENVWRAPPER_VIRTUALENV=~/.local/bin/virtualenv" >> ~/.bashrc
-            echo "source ~/.local/bin/virtualenvwrapper.sh" >> ~/.bashrc
+            echo "source /usr/share/virtualenvwrapper/virtualenvwrapper.sh" >> ~/.bashrc
         fi
         pip install -r python_requirements.txt
         if [ $? -ne 0 ]; then
@@ -470,8 +465,7 @@ setup_wizard() {
     echo "  fi" >> ~/.config/naomi/Naomi.sh
     echo "  export WORKON_HOME=$HOME/.virtualenvs" >> ~/.config/naomi/Naomi.sh
     echo "  export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3" >> ~/.config/naomi/Naomi.sh
-    echo "  export VIRTUALENVWRAPPER_VIRTUALENV=~/.local/bin/virtualenv" >> ~/.config/naomi/Naomi.sh
-    echo "  source ~/.local/bin/virtualenvwrapper.sh" >> ~/.config/naomi/Naomi.sh
+    echo "  source /usr/share/virtualenvwrapper/virtualenvwrapper.sh" >> ~/.config/naomi/Naomi.sh
     echo "  workon Naomi" >> ~/.config/naomi/Naomi.sh
     echo "  python $NAOMI_DIR/Naomi.py \"\$@\"" >> ~/.config/naomi/Naomi.sh
     echo "}" >> ~/.config/naomi/Naomi.sh

--- a/plugins/stt/pocketsphinx-stt/sphinxplugin.py
+++ b/plugins/stt/pocketsphinx-stt/sphinxplugin.py
@@ -89,8 +89,6 @@ def check_pocketsphinx_model(directory):
         FilesExist = False
     if (not os.path.isfile(os.path.join(directory, "variances"))):
         FilesExist = False
-    if (not os.path.isfile(os.path.join(directory, "model", "train.fst"))):
-        FilesExist = False
     return FilesExist
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I just tried installing Naomi on my new Bookworm computer and got the above error message. It seems that Python now allows the OS to lock down the main python environment so you can't install to it using pip or conda or whatnot. You have to use the OS repositories if you want to install packages on the main python environment.

This is good, and I'm sure it's the right way to do it. But although almost all of our packages are installed within the Naomi virtual environment, we have been using pip to install virtualenvwrapper itself to the main python environment as a user package. Since we can't, the install script breaks.

To fix this issue, I had to add the python3-virtualenvwrapper package to the apt_requirements.txt file, then remove the pip3 install --user virtualenvwrapper line from script.deb.sh.

The location of the virtualenvwrapper.sh script changes from ~/.local/bin/virtualenvwrapper.sh to
/usr/share/virtualenvwrapper/virtualenvwrapper.sh
since it is now being installed by the OS.

The location of virtualenv also changes. In this case, it worked to simply remove all the VIRTUALENVWRAPPER_VIRTUALENV lines.

I also made a small change to sphinxplugin.py where I am no longer checking for the g2p fst model when deciding whether to clone the CMUSphinx standard language model, since that file is generated after the model is downloaded. If something happens between downloading the language model and generating the g2p model things would get confused.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[This environment is externally managed #387](https://github.com/NaomiProject/Naomi/issues/387)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It moves the installation of virtualenvwrapper from pip to apt. This is better for allowing the operating system to detect conflicts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested by running the program. I also ran the unittests, but there appears to be another, unrelated error related to them where the object being returned by pkgutil.get_loader() may or may not have a get_filename() method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
