### PR TITLE
Fix check_python_import()

### DIFF
--- a/naomi/diagnose.py
+++ b/naomi/diagnose.py
@@ -8,7 +8,7 @@ if sys.version_info < (3, 3):
     from distutils.spawn import find_executable
 else:
     from shutil import which as find_executable
-from . import testutils
+
 
 logger = logging.getLogger(__name__)
 
@@ -78,9 +78,18 @@ def check_python_import(package_or_module):
     loader = pkgutil.get_loader(package_or_module)
     found = loader is not None
     if found:
-        logger.debug("Python %s '%s' found: %r",
-                     "package" if loader.is_package(package_or_module)
-                     else "module", package_or_module, loader.get_filename())
+        # 2023-11-21 - AaronC - loader no longer has .get_filename(),
+        # use _resolve_filename() function instead
+        if hasattr(loader, "_resolve_filename"):
+            filename = loader._resolve_filename(package_or_module)
+        else:
+            filename = loader.get_filename()
+        logger.debug(
+            "Python %s '%s' found: %r",
+            "package" if loader.is_package(package_or_module) else "module",
+            package_or_module,
+            filename
+        )
     else:
         logger.debug("Python import '%s' not found", package_or_module)
     return found


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The file diagnose.py has a test called check_python_import which is run during the unit testing. This function is failing with the message "'FrozenImporter' has no attribute 'get_filename'".

Apparently pkgutil.get_loader() can return different types of loaders.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Error "'FrozenImporter' has no attribute 'get_filename'" when running unit tests #395](https://github.com/NaomiProject/Naomi/issues/395)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes an issue creating false failures on unit tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Raspberry Pi 5 and x86_64 laptop. This should not affect other areas of the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
