### PR TITLE
Restore logging to screen

### DIFF
--- a/naomi/__main__.py
+++ b/naomi/__main__.py
@@ -153,20 +153,31 @@ def main(args=None):
         if profile.get(['logging', 'level'], 'error') == "debug":
             loglevel = logging.DEBUG
     logfile = profile.get(['logging', 'logfile'], paths.sub('Naomi.log'))
-    handler = logging.handlers.TimedRotatingFileHandler(
-        logfile,
-        interval=24,
-        when="h",
-        backupCount=5
-    )
-    if(os.path.isfile(logfile)):
-        handler.doRollover()
-    logging.basicConfig(
-        level=loglevel,
-        filename=logfile
-    )
-    logger = logging.getLogger(__name__)
-    logger.addHandler(handler)
+    if logfile:
+        handler = logging.handlers.TimedRotatingFileHandler(
+            logfile,
+            interval=24,
+            when="h",
+            backupCount=5
+        )
+        if(os.path.isfile(logfile)):
+            handler.doRollover()
+        logging.basicConfig(
+            level=loglevel,
+            filename=logfile
+        )
+        # When using a logfile, only print ERROR or CRITICAL messages
+        # to the screen
+        screenhandler = logging.StreamHandler(sys.stderr)
+        screenhandler.setLevel(logging.ERROR)
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+        logger.addHandler(screenhandler)
+    else:
+        logging.basicConfig(
+            level=loglevel
+        )
+        logger = logging.getLogger(__name__)
     language = profile.get_profile_var(['language'])
     if(not language):
         language = 'en-US'
@@ -179,7 +190,8 @@ def main(args=None):
     translations = i18n.parse_translations(paths.data('locale'))
     translator = i18n.GettextMixin(translations)
     _ = translator.gettext
-    print(_("Logging to {}").format(logfile))
+    if logfile:
+        print(_("Logging to {}").format(logfile))
 
     print(logo)
     print("      ___           ___           ___           ___                  ")

--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -12,6 +12,7 @@ class ShutdownPlugin(plugin.SpeechHandlerPlugin):
                     'en-US': {
                         'templates': [
                             "SHUTDOWN",
+                            "SHUT DOWN",
                             "TURN YOURSELF OFF"
                         ]
                     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Because of excessive messages being written to the screen, I set the logging to write to the ~/.config/naomi/Naomi.log file by default. The problem with that is that critical error messages would not get written to the screen.

Here I have set logging to log to a log file if one is explicitly set in the profile.yml file, but also to write ERROR and CRITICAL level messages to the screen. If running in DEBUG mode with a log file, then DEBUG, INFO and WARN messages are written to the log file and only ERROR or CRITICAL messages appear on the screen.

We might want to think about having Naomi attempt to also speak ERROR and CRITICAL level messages.

I also removed the redirect of stderr to /dev/null that surrounded calls to opening pyAudio output streams, which was causing buffer underflow error messages to write to the screen. The constant stream redirects were causing "Too many open files" errors, which eventually cause Naomi to crash.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Critical and Error level log messages not written to the screen #397](https://github.com/NaomiProject/Naomi/issues/397)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This just improves the error logging system

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
