### PR TITLE
Fix Translations

### DIFF
--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -21,19 +21,19 @@ class Conversation(i18n.GettextMixin):
     # Add way for the system to ask for name if is not found in the config
     def askName(self):
         keywords = profile.get(['keyword'], ['NAOMI'])
-        if(isinstance(keywords, str)):
+        if isinstance(keywords, str):
             keywords = [keywords]
-        if(len(keywords) > 1):
+        if len(keywords) > 1:
             salutation = self.gettext(
-                "My name is {} but you can also call me {}".format(
-                    keywords[0],
-                    " or ".join(keywords[1:])
-                )
+                "My name is {} but you can also call me {}"
+            ).format(
+                keywords[0],
+                self.gettext(" or ").join(keywords[1:])
             )
         else:
             salutation = self.gettext(
-                "My name is {}".format(keywords[0])
-            )
+                "My name is {}"
+            ).format(keywords[0])
         self.mic.say(salutation)
 
     def greet(self):
@@ -55,7 +55,7 @@ class Conversation(i18n.GettextMixin):
             # if listen() returns False, just ignore it
             if not isinstance(utterance, bool):
                 handled = False
-                while(" ".join(utterance) != "" and not handled):
+                while " ".join(utterance) != "" and not handled:
                     utterance, handled = self.handleRequest(utterance)
 
     def handleRequest(self, utterance):

--- a/naomi/data/locale/fr-FR.po
+++ b/naomi/data/locale/fr-FR.po
@@ -25,9 +25,17 @@ msgstr ""
 msgid "My name is, %s."
 msgstr "Mon nom est %s."
 
-#: client/conversation.py:26
-msgid "My name is Naomi"
-msgstr "Je suis Naomi"
+#: client/conversation.py:35
+msgid "My name is {}"
+msgstr "Je suis {}"
+
+#: client/conversation.py:28
+msgid "My name is {} but you can also call me {}"
+msgstr "Je suis {} mais tu peux aussi m'appeler {}"
+
+#: naomi/conversation.py:21
+msgid " or "
+msgstr " ou "
 
 #: client/conversation.py:32
 #, python-format


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We ran into several problems with translations today. The biggest was that because the i18n module is being initialized in the GenericPlugin class in naomi/plugin.py, every plugin was looking for its phrases in naomi/data/locale, so most translations were failing even after updating the .po files.

The next was that the first line Naomi speaks "My name is {}" had the format inside the parameter being passed to GetText, so the string was getting the name substituted before attempting to find a matching string in the .po file, so most names were causing that to default to english.

Finally, even when passing the "My name is {}" string correctly, the French .po file had no translation in the match for it, and the "My name is {} but you can also call me {}" line was not even included in the translation file, plus I was not even attempting to use gettext on the " or " string.

Now that all these issues are fixed, when I start Naomi in French I get the proper startup message:
```
Computer: Je suis Computer
Computer: Comment puis-je être utile?
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
