### PR TITLE
Synchronous and Asynchronous Mic

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -526,7 +526,7 @@ class Naomi(object):
             )
             self._logger.info('Using batched mode')
         else:
-            if(profile.get_arg('listen_while_talking', False)):
+            if profile.get_arg('listen_while_talking', False):
                 self.mic = mic_asynchronous.MicAsynchronous(
                     keywords=keyword,
                     input_device=input_device,
@@ -550,10 +550,9 @@ class Naomi(object):
                     tts_engine=tts_plugin,
                     brain=self.brain
                 )
-
-
         self.conversation = conversation.Conversation(
-            self.mic, self.brain
+            self.mic,
+            self.brain
         )
 
     def settings(self):
@@ -971,7 +970,7 @@ class Naomi(object):
                     filename
                 )
             visualizations.load_visualizations(self)
-            testMic = mic.Mic(
+            testMic = local_mic.Mic(
                 input_device,
                 output_device,
                 profile.get(['active_stt', 'reply']),

--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -21,14 +21,14 @@ class Conversation(i18n.GettextMixin):
     # Add way for the system to ask for name if is not found in the config
     def askName(self):
         keywords = profile.get(['keyword'], ['NAOMI'])
-        if isinstance(keywords, str):
+        if(isinstance(keywords, str)):
             keywords = [keywords]
-        if len(keywords) > 1:
+        if(len(keywords) > 1):
             salutation = self.gettext(
                 "My name is {} but you can also call me {}"
             ).format(
                 keywords[0],
-                self.gettext(" or ").join(keywords[1:])
+                " or ".join(keywords[1:])
             )
         else:
             salutation = self.gettext(
@@ -49,69 +49,4 @@ class Conversation(i18n.GettextMixin):
         """
         Delegates user input to the handling function when activated.
         """
-        self._logger.debug('Starting to handle conversation.')
-        while True:
-            utterance = self.mic.listen()
-            # if listen() returns False, just ignore it
-            if not isinstance(utterance, bool):
-                handled = False
-                while " ".join(utterance) != "" and not handled:
-                    utterance, handled = self.handleRequest(utterance)
-
-    def handleRequest(self, utterance):
-        handled = False
-        intent = self.brain.query(utterance)
-        if intent:
-            try:
-                self._logger.info(intent)
-                intent['action'](intent, self.mic)
-                handled = True
-            except Unexpected as e:
-                utterance = e.utterance
-            except Exception as e:
-                self._logger.error(
-                    'Failed to service intent {}: {}'.format(intent, str(e)),
-                    exc_info=True
-                )
-                self.mic.say(self.gettext("I'm sorry."))
-                self.mic.say(self.gettext("I had some trouble with that operation."))
-                self.mic.say(str(e))
-                self.mic.say(self.gettext("Please try again later."))
-                handled = True
-            else:
-                self._logger.debug(
-                    " ".join([
-                        "Handling of phrase '{}'",
-                        "by plugin '{}' completed"
-                    ]).format(
-                        utterance,
-                        intent
-                    )
-                )
-        else:
-            self.say_i_do_not_understand()
-            handled = True
-        return utterance, handled
-
-    def say_i_do_not_understand(self):
-        self.mic.say(
-            random.choice(
-                [  # nosec
-                    self.gettext("I'm sorry, could you repeat that?"),
-                    self.gettext("My apologies, could you try saying that again?"),
-                    self.gettext("Say that again?"),
-                    self.gettext("I beg your pardon?"),
-                    self.gettext("Pardon?")
-                ]
-            )
-        )
-
-    def list_choices(self, choices):
-        if len(choices) == 1:
-            self.mic.say(self.gettext("Please say {}").format(choices[0]))
-        elif len(choices) == 2:
-            self.mic.say(self.gettext("Please respond with {} or {}").format(choices[0], choices[1]))
-        else:
-            self.mic.say(
-                self.gettext("Please respond with one of the following: {}").format(choices)
-            )
+        self.mic.main_loop()

--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
-import random
 from . import i18n
 from . import paths
 from . import profile
-from .mic import Unexpected
 from .notifier import Notifier
 
 
@@ -21,9 +19,9 @@ class Conversation(i18n.GettextMixin):
     # Add way for the system to ask for name if is not found in the config
     def askName(self):
         keywords = profile.get(['keyword'], ['NAOMI'])
-        if(isinstance(keywords, str)):
+        if isinstance(keywords, str):
             keywords = [keywords]
-        if(len(keywords) > 1):
+        if len(keywords) > 1:
             salutation = self.gettext(
                 "My name is {} but you can also call me {}"
             ).format(

--- a/naomi/local_mic.py
+++ b/naomi/local_mic.py
@@ -5,17 +5,25 @@ over the terminal. Useful for debugging. Unlike with the typical Mic
 implementation, Naomi is always active listening with local_mic.
 """
 import contextlib
+import logging
 import unicodedata
+from naomi import i18n
+from naomi import paths
 from naomi import profile
 from naomi.mic import Unexpected
 
 
-class Mic(object):
+class Mic(i18n.GettextMixin):
     prev = None
+    Continue = True
 
     def __init__(self, *args, **kwargs):
         self.passive_listen = profile.get_profile_flag(["passive_listen"])
         keyword = profile.get_profile_var(['keyword'], 'NAOMI')
+        self.brain = kwargs['brain']
+        self._logger = logging.getLogger(__name__)
+        translations = i18n.parse_translations(paths.data('locale'))
+        i18n.GettextMixin.__init__(self, translations, profile)
         if isinstance(keyword, list):
             self._keyword = keyword[0]
         else:
@@ -80,3 +88,59 @@ class Mic(object):
 
     def say(self, phrase, OPTIONS=None):
         print("{}: {}".format(self._keyword, phrase))
+
+    def main_loop(self):
+        while self.Continue:
+            utterance = self.listen()
+            if not isinstance(utterance, bool):
+                handled = False
+                while(" ".join(utterance) != "" and not handled):
+                    utterance, handled = self.handleRequest(utterance)
+
+    def handleRequest(self, utterance):
+        handled = False
+        intent = self.brain.query(utterance)
+        if intent:
+            try:
+                self._logger.info(intent)
+                intent['action'](intent, self)
+                handled = True
+            except Unexpected as e:
+                utterance = e.utterance
+            except Exception as e:
+                self._logger.error(
+                    'Failed to service intent {}: {}'.format(intent, str(e)),
+                    exc_info=True
+                )
+                self.say(self.gettext("I'm sorry."))
+                self.say(self.gettext("I had some trouble with that operation."))
+                self.say(str(e))
+                self.say(self.gettext("Please try again later."))
+                handled = True
+            else:
+                self._logger.debug(
+                    " ".join([
+                        "Handling of phrase '{}'",
+                        "by plugin '{}' completed"
+                    ]).format(
+                        utterance,
+                        intent
+                    )
+                )
+        else:
+            self.say_i_do_not_understand()
+            handled = True
+        return utterance, handled
+
+    def say_i_do_not_understand(self):
+        self.say(
+            random.choice(
+                [  # nosec
+                    self.gettext("I'm sorry, could you repeat that?"),
+                    self.gettext("My apologies, could you try saying that again?"),
+                    self.gettext("Say that again?"),
+                    self.gettext("I beg your pardon?"),
+                    self.gettext("Pardon?")
+                ]
+            )
+        )

--- a/naomi/local_mic.py
+++ b/naomi/local_mic.py
@@ -6,6 +6,7 @@ implementation, Naomi is always active listening with local_mic.
 """
 import contextlib
 import logging
+import random
 import unicodedata
 from naomi import i18n
 from naomi import paths
@@ -36,7 +37,7 @@ class Mic(i18n.GettextMixin):
         yield
 
     def wait_for_keyword(self, keyword="NAOMI"):
-        if(self.passive_listen):
+        if self.passive_listen:
             return self.active_listen()
         else:
             return
@@ -54,7 +55,7 @@ class Mic(i18n.GettextMixin):
         self.say(prompt)
         transcribed = self.listen()
         phrase, score = profile.get_arg("application").brain._intentparser.match_phrase(transcribed, phrases)
-        if(score > 0.1):
+        if score > 0.1:
             response = phrase
         else:
             raise Unexpected(transcribed)
@@ -67,10 +68,10 @@ class Mic(i18n.GettextMixin):
         language = profile.get(['language'], 'en-US')[:2]
         POSITIVE = ['YES', 'SURE']
         NEGATIVE = ['NO', 'NOPE']
-        if(language == "fr"):
+        if language == "fr":
             POSITIVE = ['OUI']
             NEGATIVE = ['NON']
-        elif(language == "de"):
+        elif language == "de":
             POSITIVE = ['JA']
             NEGATIVE = ['NEIN']
         phrase = self.expect(
@@ -94,7 +95,7 @@ class Mic(i18n.GettextMixin):
             utterance = self.listen()
             if not isinstance(utterance, bool):
                 handled = False
-                while(" ".join(utterance) != "" and not handled):
+                while " ".join(utterance) != "" and not handled:
                     utterance, handled = self.handleRequest(utterance)
 
     def handleRequest(self, utterance):

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -1,110 +1,94 @@
-# -*- coding: utf-8 -*-
+import abc
+import collections
+import contextlib
+import logging
+import random
+import tempfile
+import time
+import wave
 from datetime import datetime
-from naomi import alteration
+from naomi import i18n
 from naomi import paths
 from naomi import profile
 from naomi import visualizations
-import audioop
-import contextlib
-import logging
-import os
-import sqlite3
-import sys
-import tempfile
-import threading
-import time
-import wave
-
-
-# global action queue
-queue = []
 
 
 class Unexpected(Exception):
+    """
+    The "Unexpected" class is an exception that is fired if the expect method
+    recieves unexpected input. This allows the function to return control to
+    the
+    """
     def __init__(
         self,
-        utterance
+        utterance,
+        audio
     ):
         self.utterance = utterance
+        self.audio = audio
 
 
-class Mic(object):
+class Mic(i18n.GettextMixin):
     """
-    The Mic class handles all interactions with the microphone and speaker.
+    Calling this class "Mic" seems like a misnomer since it handles both
+    input and output. "MicAndSpeaker" might be a better name, or it might
+    make sense to implement a separate "Speaker" class for things like
+    say.
     """
-    current_thread = None
+    actions_thread = None
+    Continue = True
 
-    def __init__(
-        self,
-        input_device,
-        output_device,
-        active_stt_reply,
-        active_stt_response,
-        passive_stt_engine,
-        active_stt_engine,
-        special_stt_slug,
-        plugins,
-        tts_engine,
-        vad_plugin,
-        keyword=['NAOMI'],
-        print_transcript=False,
-        passive_listen=False,
-        save_audio=False,
-        save_passive_audio=False,
-        save_active_audio=False,
-        save_noise=False
-    ):
+    def __init__(self, *args, **kwargs):
+        translations = i18n.parse_translations(paths.data('locale'))
+        translator = i18n.GettextMixin(translations)
+        self.gettext = translator.gettext
+        self.keywords = kwargs['keywords']
+        self._input_device = kwargs['input_device']
+        self._output_device = kwargs['output_device']
+        self.passive_stt_plugin = kwargs['passive_stt_plugin']
+        self.active_stt_plugin = kwargs['active_stt_plugin']
+        self.special_stt_slug = kwargs['special_stt_slug']
+        self.vad_plugin = kwargs['vad_plugin']
+        self.tts_engine = kwargs['tts_engine']
+        self.brain = kwargs['brain']
         self._logger = logging.getLogger(__name__)
-        self._keyword = keyword
-        self.tts_engine = tts_engine
-        self.passive_stt_engine = passive_stt_engine
-        self.active_stt_engine = active_stt_engine
-        self.special_stt_slug = special_stt_slug
-        self.plugins = plugins
-        self._input_device = input_device
-        self._output_device = output_device
-        self._vad_plugin = vad_plugin
-        self._active_stt_reply = active_stt_reply
-        self._active_stt_response = active_stt_response
-        self.passive_listen = passive_listen
-        # transcript for monitoring
-        self._print_transcript = print_transcript
-        # audiolog for training
-        if(save_audio):
-            self._save_passive_audio = True
-            self._save_active_audio = True
-            self._save_noise = True
-        else:
-            self._save_passive_audio = save_passive_audio
-            self._save_active_audio = save_active_audio
-            self._save_noise = save_noise
-        if(
-            (
-                self._save_active_audio
-            ) or (
-                self._save_passive_audio
-            ) or (
-                self._save_noise
-            )
-        ):
-            self._audiolog = paths.sub("audiolog")
-            self._logger.info(
-                "Checking audio log directory %s" % self._audiolog
-            )
-            if not os.path.exists(self._audiolog):
-                self._logger.info(
-                    "Creating audio log directory %s" % self._audiolog
-                )
-                os.makedirs(self._audiolog)
-            self._audiolog_db = os.path.join(self._audiolog, "audiolog.db")
-            self._conn = sqlite3.connect(self._audiolog_db)
+        self._save_passive_audio = profile.get_arg('save_passive_audio', False)
+        self._save_active_audio = profile.get_arg('save_active_audio', False)
+        self._save_noise = profile.get_arg('save_noise', False)
+        self.passive_listen = profile.get_profile_flag(["passive_listen"], False)
+        self.verify_wakeword = profile.get_profile_flag(['passive_stt', 'verify_wakeword'], False)
+        self._active_stt_reply = profile.get_arg("active_stt_reply")
+        self._active_stt_response = profile.get_arg("active_stt_response")
 
-    # Copies a file pointed to by a file pointer to a permanent
-    # file for training purposes
+    @abc.abstractmethod
+    def listen(self):
+        """
+        Fetch the next utterance and check for wake word
+        """
+        pass
+
+    @abc.abstractmethod
+    def active_listen(self, play_prompts=True):
+        """
+        Fetch the next utterance without checking for wake word
+        (to be used when Naomi asks a question)
+        """
+        pass
+
+    @abc.abstractmethod
+    def main_loop(self):
+        pass
+
     def _log_audio(self, fp, transcription, sample_type="unknown"):
+        """
+        Copies a file pointed to by a file pointer to a permanent
+        file for training purposes
+        """
         # Any empty transcriptions are noise regardless of how they are being
         # collected
-        if(" ".join(transcription) == ""):
+        if isinstance(transcription, list):
+            transcription = " ".join(transcription)
+        if(transcription == ""):
             sample_type = 'noise'
         if(
             (
@@ -118,14 +102,14 @@ class Mic(object):
             fp.seek(0)
             # Get the slug from the engine
             if(sample_type.lower() == "active"):
-                engine = type(self.active_stt_engine).__name__
-                if(self.active_stt_engine._vocabulary_name != "default"):
+                engine = type(self.active_stt_plugin).__name__
+                if(self.active_stt_plugin._vocabulary_name != "default"):
                     # we are in a special mode. We don't want to put words
                     # from this sample into the default standard_phrases
-                    sample_type = self.active_stt_engine._vocabulary_name
+                    sample_type = self.active_stt_plugin._vocabulary_name
             else:
                 # noise (empty transcript) response is only from passive engine
-                engine = type(self.passive_stt_engine).__name__
+                engine = type(self.passive_stt_plugin).__name__
             # Now, it is very possible that the file might already exist
             # since the same file could be used for both passive and active
             # parsing. Should we check to see if the file already exists
@@ -200,20 +184,51 @@ class Mic(object):
                     engine,
                     filename,
                     sample_type,
-                    " ".join(transcription)
+                    transcription
                 )
             )
             self._conn.commit()
 
     @contextlib.contextmanager
+    def _write_frames_to_file(self, frames, volume=None):
+        """
+        This is used internally to create an audio file
+        """
+        with tempfile.NamedTemporaryFile(
+            mode='w+b',
+            suffix=".wav",
+            prefix=datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        ) as f:
+            wav_fp = wave.open(f, 'wb')
+            wav_fp.setnchannels(self._input_device._input_channels)
+            wav_fp.setsampwidth(int(self._input_device._input_bits / 8))
+            wav_fp.setframerate(self._input_device._input_rate)
+            fragment = b''.join(frames)
+            if volume is not None:
+                maxvolume = audioop.minmax(
+                    fragment,
+                    self._input_device._input_bits / 8
+                )[1]
+                fragment = audioop.mul(
+                    fragment,
+                    int(self._input_device._input_bits / 8),
+                    volume * (2. ** 15) / maxvolume
+                )
+
+            wav_fp.writeframes(fragment)
+            wav_fp.close()
+            f.seek(0)
+            yield f
+
+    @contextlib.contextmanager
     def special_mode(self, name, phrases):
-        plugin_info = self.plugins.get_plugin(
+        plugin_info = profile.get_arg('plugins').get_plugin(
             self.special_stt_slug,
             category='stt'
         )
         plugin_config = profile.get_profile()
 
-        original_stt_engine = self.active_stt_engine
+        original_stt_plugin = self.active_stt_plugin
 
         # If the special_mode engine is not specifically set,
         # copy the settings from the active stt engine.
@@ -248,234 +263,129 @@ class Mic(object):
             else:
                 mode_stt_engine._samplerate = original_stt_engine._samplerate
                 mode_stt_engine._volume_normalization = original_stt_engine._volume_normalization
-            self.active_stt_engine = mode_stt_engine
+            self.active_stt_plugin = mode_stt_engine
             yield
         finally:
-            self.active_stt_engine = original_stt_engine
+            self.active_stt_plugin = original_stt_plugin
 
-    @contextlib.contextmanager
-    def _write_frames_to_file(self, frames, framerate, volume):
-        with tempfile.NamedTemporaryFile(
-            mode='w+b',
-            suffix=".wav",
-            prefix=datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        ) as f:
-            wav_fp = wave.open(f, 'wb')
-            wav_fp.setnchannels(self._input_device._input_channels)
-            wav_fp.setsampwidth(int(self._input_device._input_bits / 8))
-            wav_fp.setframerate(framerate)
-            if self._input_device._input_rate == framerate:
-                fragment = b''.join(frames)
-            else:
-                fragment = audioop.ratecv(
-                    ''.join(frames),
-                    int(self._input_device._input_bits / 8),
-                    self._input_device._input_channels,
-                    self._input_device._input_rate,
-                    framerate,
-                    None
-                )[0]
-            if volume is not None:
-                maxvolume = audioop.minmax(
-                    fragment,
-                    self._input_device._input_bits / 8
-                )[1]
-                fragment = audioop.mul(
-                    fragment,
-                    int(self._input_device._input_bits / 8),
-                    volume * (2. ** 15) / maxvolume
-                )
-
-            wav_fp.writeframes(fragment)
-            wav_fp.close()
-            f.seek(0)
-            yield f
-
-    def check_for_keyword(self, phrase, keyword=None):
-        if not keyword:
-            keyword = self._keyword
+    def check_for_keyword(self, phrase, keywords=None):
+        if not keywords:
+            keywords = self.keywords
         # This allows multi-word keywords like 'Hey Naomi' or 'You there'
         wakewords = []
-        for word in keyword:
+        for word in keywords:
             for w in phrase:
                 if word.upper() in w.upper():
                     wakewords.append(word.upper())
-        if any(wakewords):
-            return True
-        return False
+        return wakewords
 
-    def wait_for_keyword(self, keyword=None):
-        if not keyword:
-            keyword = self._keyword
-        while not profile.get_arg("resetmic"):
-            transcribed = []
-            with self._write_frames_to_file(
-                self._vad_plugin.get_audio(),
-                self.passive_stt_engine._samplerate,
-                self.passive_stt_engine._volume_normalization
-            ) as f:
+    def handleRequest(self, utterance, audio):
+        """
+        Respond to an utterance
+        """
+        handled = False
+        if utterance:
+            intent = self.brain.query(utterance)
+            if intent:
                 try:
-                    transcribed = [word.upper() for word in self.passive_stt_engine.transcribe(f)]
-                except Exception:
-                    transcribed = []
-                    dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
-                    self._logger.error(
-                        "Passive transcription failed!",
-                        exc_info=dbg
-                    )
-                else:
-                    if(len(transcribed)):
-                        if(self._print_transcript):
-                            visualizations.run_visualization(
-                                "output",
-                                f"<  {transcribed}"
-                            )
-                        if self.check_for_keyword(transcribed, keyword):
-                            self._log_audio(f, transcribed, "passive")
-                            if(self.passive_listen):
-                                # Take the same block of audio and put it
-                                # through the active listener
-                                f.seek(0)
-                                try:
-                                    transcribed = [word.upper() for word in self.active_stt_engine.transcribe(f)]
-                                except Exception:
-                                    transcribed = []
-                                    dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
-                                    self._logger.error("Active transcription failed!", exc_info=dbg)
-                                else:
-                                    if(" ".join(transcribed).strip() == ""):
-                                        if(self._print_transcript):
-                                            visualizations.run_visualization("output", "<< <noise>")
-                                        self._log_audio(f, transcribed, "noise")
-                                    else:
-                                        if(self._print_transcript):
-                                            visualizations.run_visualization("output", "<< {}".format(transcribed))
-                                        self._log_audio(f, transcribed, "active")
-                                if(profile.get_profile_flag(['passive_stt', 'verify_wakeword'], False)):
-                                    # Check if any of the wakewords identified by
-                                    # the passive stt engine appear in the active
-                                    # transcript
-                                    if self.check_for_keyword(transcribed, keyword):
-                                        return transcribed
-                                    else:
-                                        self._logger.info('Wakeword not matched in active transcription')
-                                else:
-                                    return transcribed
-                            else:
-                                if(profile.get_profile_flag(['passive_stt', 'verify_wakeword'], False)):
-                                    transcribed = [word.upper() for word in self.active_stt_engine.transcribe(f)]
-                                    if self.check_for_keyword(transcribed, keyword):
-                                        return transcribed
-                                    else:
-                                        self._logger.info('Wakeword not matched in active transcription')
-                                else:
-                                    return transcribed
-                        else:
-                            self._log_audio(f, transcribed, "noise")
+                    self._logger.info(intent)
+                    intent['action'](intent, self)
+                    handled = True
+                except Unexpected as e:
+                    # The user responded to a prompt within the intent with a new
+                    # request.
+                    utterance = e.utterance
+                    audio = e.audio
+                    # If passive_listen is true, then use the same audio
+                    # for the utterance
+                    if(self.passive_listen):
+                        # Because the user would have been using a special
+                        # listener which may have only been trained to hear
+                        # certain phrases, go back and run the same audio
+                        # through the standard listener
+                        with self._write_frames_to_file(audio) as f:
+                            utterance = self.active_stt_plugin.transcribe(f)
                     else:
-                        if(self._print_transcript):
-                            visualizations.run_visualization("output", "<  <noise>")
-                            self._log_audio(f, "", "noise")
-        return False
-
-    def active_listen(self, play_prompts=True):
-        transcribed = []
-        if(play_prompts):
-            # let the user know we are listening
-            if self._active_stt_reply:
-                self.say(self._active_stt_reply)
-            else:
-                self._logger.debug("No text to respond with using beep")
-                if(self._print_transcript):
-                    visualizations.run_visualization("output", ">> <beep>")
-                self.play_file(paths.data('audio', 'beep_hi.wav'))
-        with self._write_frames_to_file(
-            self._vad_plugin.get_audio(),
-            self.active_stt_engine._samplerate,
-            self.active_stt_engine._volume_normalization
-        ) as f:
-            if(play_prompts):
-                if self._active_stt_response:
-                    self.say(self._active_stt_response)
+                        # The user responded by saying the assistant's name
+                        utterance, audio = self.active_listen()
+                    return self.handleRequest(utterance, audio)
+                except Exception as e:
+                    self._logger.error(
+                        'Failed to service intent {}: {}'.format(intent, str(e)),
+                        exc_info=True
+                    )
+                    self.say(self.gettext("I'm sorry."))
+                    self.say(self.gettext("I had some trouble with that operation."))
+                    self.say(str(e))
+                    self.say(self.gettext("Please try again later."))
+                    handled = True
                 else:
-                    self._logger.debug("No text to respond with using beep")
-                    if(self._print_transcript):
-                        visualizations.run_visualization("output", ">> <boop>")
-                    self.play_file(paths.data('audio', 'beep_lo.wav'))
-            try:
-                transcribed = [word.upper() for word in self.active_stt_engine.transcribe(f)]
-            except Exception:
-                transcribed = []
-                dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
-                self._logger.error("Active transcription failed!", exc_info=dbg)
+                    self._logger.debug(
+                        " ".join([
+                            "Handling of phrase '{}'",
+                            "by plugin '{}' completed"
+                        ]).format(
+                            utterance,
+                            intent
+                        )
+                    )
             else:
-                if(" ".join(transcribed).strip() == ""):
-                    if(self._print_transcript):
-                        visualizations.run_visualization("output", "<< <noise>")
-                    self._log_audio(f, transcribed, "noise")
-                else:
-                    if(self._print_transcript):
-                        visualizations.run_visualization("output", "<< {}".format(transcribed))
-                    self._log_audio(f, transcribed, "active")
-        return transcribed
+                self.say_i_do_not_understand()
+                handled = True
+        return utterance, handled
 
-    def listen(self):
-        if(self.passive_listen):
-            return self.wait_for_keyword(self._keyword)
+    def say_i_do_not_understand(self):
+        """
+        Handles a response where Naomi does not understand the intention
+        """
+        self.say(
+            random.choice(
+                [  # nosec
+                    self.gettext("I'm sorry, could you repeat that?"),
+                    self.gettext("My apologies, could you try saying that again?"),
+                    self.gettext("Say that again?"),
+                    self.gettext("I beg your pardon?"),
+                    self.gettext("Pardon?")
+                ]
+            )
+        )
+
+    def list_choices(self, choices):
+        """
+        This method is used with the expect method and reminds the user of
+        the available choices if the user said something unexpected.
+        """
+        if len(choices) == 1:
+            self.say(self.gettext("Please say {}").format(choices[0]))
+        elif len(choices) == 2:
+            self.say(self.gettext("Please respond with {} or {}").format(choices[0], choices[1]))
         else:
-            kw = self.wait_for_keyword(self._keyword)
-            # wait_for_keyword normally returns either a list of key
-            if isinstance(kw, bool):
-                if(not kw):
-                    return []
-            # if not in passive_listen mode, then the user has tried to
-            # interrupt, go ahead and stop talking
-            self.stop(wait=True)
-            return self.active_listen()
+            self.say(
+                self.gettext("Please respond with one of the following: {}").format(choices)
+            )
 
-    # If we are using the asynchronous say, so we can hear the "stop"
-    # command, what we want to do is put the prompt on the queue, then
-    # yield control back to the main conversation loop. When the prompt
-    # is spoken in the thread, then we want to return to this point in
-    # the main thread and use the blocking listen to listen until we get
-    # an actual transcription. That should then be used to determine
-    # whether the user responded with one of the expected phrases or not.
     def expect(self, prompt, phrases, name='expect', instructions=None):
+        """
+        The expect method has different implementations depending on whether
+        it is synchronous or asynchronous. Most mics are synchronous, so I will
+        implement it that way here and override this method in the
+        MicAsynchronous class.
+        """
         expected_phrases = phrases.copy()
         phrases.extend(
-            profile.get_arg("application").brain.get_plugin_phrases(True)
+            self.brain.get_plugin_phrases(True)
         )
         # set up the special mode so it is pre-generated later
         with self.special_mode(name, phrases):
             pass
-        # If "listen_while_talking" is set to true, then we want to create the
-        # special mode after saying the prompt. If not, then we want to create
-        # the special mode first, so we are ready to listen. Also, there is no
-        # need to add anything to the queue if we are not listening while
-        # talking.
-        if(profile.get_arg('listen_while_talking', False)):
-            self.say(prompt)
-            self.add_queue(lambda: profile.set_arg('resetmic', True))
-            # Now wait for any sounds in the queue to be processed
-            while not profile.get_arg('resetmic'):
-                transcribed = self.listen()
-                handled = False
-                if isinstance(transcribed, bool):
-                    handled = True
-                else:
-                    while(" ".join(transcribed) != "" and not handled):
-                        transcribed, handled = profile.get_arg('application').conversation.handleRequest(transcribed)
-            # Now that we are past the mic reset
-            profile.set_arg('resetmic', False)
-        else:
-            self.say(prompt)
+        self.say(prompt)
         # Now start listening for a response
         with self.special_mode(name, phrases):
             while True:
-                transcribed = self.active_listen()
+                transcribed, audio = self.active_listen()
                 if(len(' '.join(transcribed))):
                     # Now that we have a transcription, check if it matches one of the phrases
-                    phrase, score = profile.get_arg("application").brain._intentparser.match_phrase(transcribed, expected_phrases)
+                    phrase, score = self.brain._intentparser.match_phrase(transcribed, expected_phrases)
                     # If it does, then return the phrase
                     self._logger.info("Expecting: {} Got: {}".format(expected_phrases, transcribed))
                     self._logger.info("Score: {}".format(score))
@@ -488,16 +398,19 @@ class Mic(object):
                         # they are starting a new command. This should mean that the wake
                         # word would be included.
                         if(self.check_for_keyword(transcribed)):
-                            raise Unexpected(transcribed)
+                            raise Unexpected(transcribed, audio)
                         else:
                             # The user just said something unexpected. Remind them of their choices
                             if instructions is None:
-                                profile.get_arg("application").conversation.list_choices(expected_phrases)
+                                self.list_choices(expected_phrases)
                             else:
                                 self.say(instructions)
 
-    # confirm is a special case of expect which expects "yes" or "no"
+
     def confirm(self, prompt):
+        """
+        confirm is a special case of expect which expects "yes" or "no"
+        """
         # default to english
         language = profile.get(['language'], 'en-US')[:2]
         POSITIVE = ['YES', 'SURE', 'YES PLEASE']
@@ -512,7 +425,7 @@ class Mic(object):
             prompt,
             POSITIVE + NEGATIVE,
             name='confirm',
-            instructions=profile.get_arg("application").conversation.gettext(
+            instructions=self.gettext(
                 "Please respond with Yes or No"
             )
         )
@@ -521,32 +434,11 @@ class Mic(object):
         else:
             return False
 
-    # Output methods
-    def play_file(self, filename):
-        if(profile.get_arg('listen_while_talking', False)):
-            self.play_file_async(filename)
-        else:
-            self.play_file_sync(filename)
-
-    def play_file_async(self, filename):
-        global queue
-        queue.append(lambda: self.play_file_sync(filename))
-        if(hasattr(self.current_thread, "is_alive")):
-            if self.current_thread.is_alive():
-                # if Naomi is currently talking, then we are done
-                return
-        # otherwise, start talking
-        self.current_thread = threading.Thread(
-            target=self.process_queue
-        )
-        self.current_thread.start()
-
-    def play_file_sync(self, filename):
-        with open(filename, 'rb') as f:
-            self._output_device.play_fp(f)
-
-    # Stop talking and delete the queue
     def stop(self, wait=False):
+        """
+        Stop talking, delete the queue, run "stop" on any plugins that have
+        a "stop" method
+        """
         global queue
         visualizations.run_visualization("output", "Stopping...")
         if(hasattr(self, "current_thread")):
@@ -564,61 +456,37 @@ class Mic(object):
                 self._logger.info("Can't terminate thread")
         self._logger.info("Stopped")
 
-    def process_queue(self, *args, **kwargs):
-        while(True):
-            try:
-                queue.pop(0)()
-            except IndexError:
-                sys.exit()
-
-    def add_queue(self, action):
-        global queue
-        queue.append(action)
-        if(hasattr(self.current_thread, "is_alive")):
-            if self.current_thread.is_alive():
-                # if Naomi is currently talking, then we are done
-                return
-        # otherwise, start talking
-        self.current_thread = threading.Thread(
-            target=self.process_queue
-        )
-        self.current_thread.start()
+    # Output methods
+    def play_file(self, filename):
+        with open(filename, 'rb') as f:
+            self._output_device.play_fp(f)
 
     def say(self, phrase):
-        altered_phrase = alteration.clean(phrase)
-        if(profile.get_arg('listen_while_talking', False)):
-            self.say_async(altered_phrase)
-        else:
-            self.say_sync(altered_phrase)
-
-    def say_async(self, phrase):
-        self.add_queue(lambda: self.say_sync(phrase))
-        if(hasattr(self.current_thread, "is_alive")):
-            if self.current_thread.is_alive():
-                # if Naomi is currently talking, then we are done
-                return
-        # otherwise, start talking
-        self.current_thread = threading.Thread(
-            target=self.process_queue
-        )
-        self.current_thread.daemon = True
-        self.current_thread.start()
-
-    def say_sync(self, phrase):
-        if(profile.get_arg('print_transcript')):
-            visualizations.run_visualization("output", ">> {}\n".format(phrase))
+        visualizations.run_visualization("output", ">> {}".format(phrase))
         with tempfile.SpooledTemporaryFile() as f:
             f.write(self.tts_engine.say(phrase))
             f.seek(0)
             self._output_device.play_fp(f)
-            time.sleep(.2)
+            time.sleep(.5)
 
+    def main_loop(self):
+        """This is a synchronous main loop"""
+        stt_thread = None
+        try:
+            while self.Continue:
+                # put the audio in a queue and call the stt engine
+                transcription, audio = self.listen()
+                self.handleRequest(transcription, audio)
+        except KeyboardInterrupt:
+            self.Continue = False
+        visualizations.run_visualization(
+            "output",
+            "Exiting..."
+        )
 
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-    logging.getLogger("stt").setLevel(logging.WARNING)
-    audio = Mic.get_instance()
-    while True:
-        text = audio.listen()[0]
-        if text:
-            audio.say(text)
+    # The following are no longer necessary and are just wrappers now.
+    def say_sync(self, phrase):
+        self.say(phrase)
+
+    def say_async(self, phrase):
+        self.say(phrase)

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -42,8 +42,7 @@ class Mic(i18n.GettextMixin):
 
     def __init__(self, *args, **kwargs):
         translations = i18n.parse_translations(paths.data('locale'))
-        translator = i18n.GettextMixin(translations)
-        self.gettext = translator.gettext
+        i18n.GettextMixin.__init__(self, translations, profile)
         self.keywords = kwargs['keywords']
         self._input_device = kwargs['input_device']
         self._output_device = kwargs['output_device']
@@ -292,7 +291,6 @@ class Mic(i18n.GettextMixin):
                 except Unexpected as e:
                     # The user responded to a prompt within the intent with a new
                     # request.
-                    utterance = e.utterance
                     audio = e.audio
                     # If passive_listen is true, then use the same audio
                     # for the utterance

--- a/naomi/mic_asynchronous.py
+++ b/naomi/mic_asynchronous.py
@@ -1,0 +1,264 @@
+import collections
+import contextlib
+import logging
+import random
+import tempfile
+import threading
+import time
+import wave
+from datetime import datetime
+from naomi import alteration
+from naomi import i18n
+from naomi import mic
+from naomi import paths
+from naomi import profile
+from naomi import visualizations
+
+
+recordings_available_event = threading.Event()
+
+
+class MicAsynchronous(mic.Mic):
+    actions_thread = None
+    Continue = True
+
+    def __init__(self, *args, **kwargs):
+        mic.Mic.__init__(self, *args, **kwargs)
+        self.recordings_queue = collections.deque([], maxlen=10)
+        self.actions_queue = collections.deque([], maxlen=10)
+
+    def queue_recording(self, audio):
+        self.recordings_queue.appendleft(audio)
+        recordings_available_event.set()
+
+    def queue_action(self, action):
+        self.actions_queue.appendleft(action)
+
+    def listen(self):
+        """Grab the next block of audio out of the queue and convert to text"""
+        transcription = []
+        audio = b''
+        recordings_available_event.wait()
+        try:
+            audio = self.recordings_queue.pop()
+            if len(audio)>0:
+                with self._write_frames_to_file(audio) as f:
+                    passive_transcription = self.passive_stt_plugin.transcribe(f)
+
+                    if len(passive_transcription) > 0:
+                        visualizations.run_visualization(
+                            "output",
+                            f"<  {passive_transcription}"
+                        )
+                        if self.passive_listen:
+                            if(self.check_for_keyword(passive_transcription)):
+                                active_transcription = [" ".join(self.active_stt_plugin.transcribe(f))]
+                                if len(active_transcription) > 0:
+                                    if self.check_for_keyword(active_transcription):
+                                        transcription = active_transcription
+                                else:
+                                    visualizations.run_visualization(
+                                        "output",
+                                        f"<< <noise>"
+                                    )
+                        else:
+                            transcription = []
+                            # Clear the queue and event
+                            self.recordings_queue.clear()
+                            recordings_available_event.clear()
+                            while not transcription:
+                                transcription, audio = self.active_listen()
+                            print(f"listen: {transcription}")
+                    else:
+                        visualizations.run_visualization(
+                            "output",
+                            f"<  <noise>"
+                        )
+        except IndexError:
+            recordings_available_event.clear()
+        if len(transcription) > 0:
+            visualizations.run_visualization(
+                "output",
+                f"<< {transcription}"
+            )
+        return transcription, audio
+
+    def active_listen(self, play_prompts=False):
+        """
+        Active listen does not check for a wakeword.
+    `   It should only be used in cases where Naomi has just asked a question.
+        """
+        if(play_prompts):
+            # let the user know we are listening
+            if self._active_stt_reply:
+                self.say(self._active_stt_reply)
+            else:
+                self._logger.debug("No text to respond with using beep")
+                visualizations.run_visualization("output", ">> <beep>")
+                self.actions_queue.appendleft(lambda: self.play_file(paths.data('audio', 'beep_hi.wav')))
+
+        transcription = ""
+        audio = b''
+        recordings_available_event.wait()
+        try:
+            audio = self.recordings_queue.pop()
+            if len(audio)>0:
+                with self._write_frames_to_file(audio, None) as f:
+                    transcription = [" ".join(self.active_stt_plugin.transcribe(f))]
+        except IndexError:
+            recordings_available_event.clear()
+        if len(transcription) > 0:
+            visualizations.run_visualization(
+                "output",
+                f"<< {transcription}"
+            )
+        else:
+            visualizations.run_visualization(
+                "output",
+                f"<< <noise>"
+            )
+        if(play_prompts):
+            if self._active_stt_response:
+                self.say(self._active_stt_response)
+            else:
+                self._logger.debug("No text to respond with using beep")
+                visualizations.run_visualization("output", ">> <boop>")
+                self.actions_queue.appendleft(lambda: self.play_file(paths.data('audio', 'beep_lo.wav')))
+        return transcription, audio
+
+    def handle_vad_output(self):
+        """This is a thread that converts the audio captured by VAD sequentially
+        into a transcript of the words spoken until it runs out of audio to process"""
+        while self.Continue:
+            try:
+                transcription, audio = self.listen()
+                if len(transcription):
+                    self.handleRequest(transcription, audio)
+            except IndexError:
+                break
+
+    def say(self, phrase):
+        self.actions_queue.appendleft(lambda: self.tts(phrase))
+        if not (self.actions_thread and hasattr(self.actions_thread, "is_alive") and self.actions_thread.is_alive()):
+            # start the thread
+            self.actions_thread = threading.Thread(
+                target=self.process_actions
+            )
+            self.actions_thread.start()
+
+    def process_actions(self):
+        while self.Continue:
+            try:
+                action = self.actions_queue.pop()
+                action()
+            except IndexError:
+                break
+
+    def tts(self, phrase):
+        altered_phrase = alteration.clean(phrase)
+        if(profile.get_arg('print_transcript')):
+            visualizations.run_visualization("output", ">> {}".format(phrase))
+        with tempfile.SpooledTemporaryFile() as f:
+            f.write(self.tts_engine.say(phrase))
+            f.seek(0)
+            self._output_device.play_fp(f)
+            time.sleep(.2)
+
+    def main_loop(self):
+        """This is an asynchronous main loop"""
+        stt_thread = None
+        try:
+            with self._input_device.open_stream(
+                output=False
+            ) as stream:
+                while self.Continue:
+                    # put the audio in a queue and call the stt engine
+                    self.queue_recording(
+                        self.vad_plugin.get_audio(
+                            stream=stream
+                        )
+                    )
+                    if not (
+                        stt_thread
+                        and hasattr(stt_thread, "is_alive")
+                        and stt_thread.is_alive()
+                    ):
+                        # start the thread
+                        stt_thread = threading.Thread(
+                            target=self.handle_vad_output
+                        )
+                        stt_thread.start()
+        except KeyboardInterrupt:
+            self.Continue = False
+        visualizations.run_visualization(
+            "output",
+            "Exiting..."
+        )
+
+    def say_i_do_not_understand(self):
+        self.say(
+            random.choice(
+                [  # nosec
+                    self.gettext("I'm sorry, could you repeat that?"),
+                    self.gettext("My apologies, could you try saying that again?"),
+                    self.gettext("Say that again?"),
+                    self.gettext("I beg your pardon?"),
+                    self.gettext("Pardon?")
+                ]
+            )
+        )
+
+    # If we are using the asynchronous say, so we can hear the "stop"
+    # command, what we want to do is put the prompt on the queue, then
+    # yield control back to the main conversation loop. When the prompt
+    # is spoken in the thread, then we want to return to this point in
+    # the main thread and use the blocking listen to listen until we get
+    # an actual transcription. That should then be used to determine
+    # whether the user responded with one of the expected phrases or not.
+    def expect(self, prompt, phrases, name='expect', instructions=None):
+        expected_phrases = phrases.copy()
+        phrases.extend(
+            self.brain.get_plugin_phrases(True)
+        )
+        # set up the special mode so it is pre-generated later
+        with self.special_mode(name, phrases):
+            pass
+        self.queue_action(lambda: profile.set_arg('resetmic', True))
+        self.say(prompt)
+        # Now wait for any sounds in the queue to be processed
+        while not profile.get_arg('resetmic'):
+            transcribed, audio = self.listen()
+            handled = False
+            if isinstance(transcribed, bool):
+                handled = True
+            else:
+                while(transcribed and not handled):
+                    transcribed, handled = self.handleRequest(transcribed, audio)
+        # Now that we are past the mic reset
+        profile.set_arg('resetmic', False)
+        # Now start listening for a response
+        with self.special_mode(name, phrases):
+            while True:
+                transcribed, audio = self.active_listen()
+                if(len(' '.join(transcribed))):
+                    # Now that we have a transcription, check if it matches one of the phrases
+                    phrase, score = self.brain._intentparser.match_phrase(transcribed, expected_phrases)
+                    # If it does, then return the phrase
+                    self._logger.info("Expecting: {} Got: {}".format(expected_phrases, transcribed))
+                    self._logger.info("Score: {}".format(score))
+                    if(score > .1):
+                        return phrase
+                    # Otherwise, raise an exception with the active transcription.
+                    # This will break us back into the main conversation loop
+                    else:
+                        # If the user is not responding to the prompt, then assume that
+                        # they are starting a new command. This should mean that the wake
+                        # word would be included.
+                        if(self.check_for_keyword(transcribed)):
+                            raise mic.Unexpected(transcribed, audio)
+                        else:
+                            # The user just said something unexpected. Remind them of their choices
+                            if instructions is None:
+                                self.list_choices(expected_phrases)
+                            else:
+                                self.say(instructions)

--- a/naomi/mic_synchronous.py
+++ b/naomi/mic_synchronous.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+from naomi import alteration
+from naomi import paths
+from naomi import mic
+from naomi import profile
+from naomi import visualizations
+import audioop
+import contextlib
+import logging
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+import wave
+
+
+# global action queue
+queue = []
+
+
+class MicSynchronous(mic.Mic):
+    """
+    The Mic class handles all interactions with the microphone and speaker.
+    """
+    def active_listen(self, play_prompts=True):
+        """
+        Active listen does not check for a wakeword.
+    `   It should only be used in cases where Naomi has just asked a question.
+        """
+        transcribed = []
+        if(play_prompts):
+            # let the user know we are listening
+            if self._active_stt_reply:
+                self.say(self._active_stt_reply)
+            else:
+                self._logger.debug("No text to respond with using beep")
+                visualizations.run_visualization("output", ">> <beep>")
+                self.play_file(paths.data('audio', 'beep_hi.wav'))
+        audio = self.vad_plugin.get_audio()
+        with self._write_frames_to_file(
+            audio
+        ) as f:
+            if(play_prompts):
+                if self._active_stt_response:
+                    self.say(self._active_stt_response)
+                else:
+                    self._logger.debug("No text to respond with using beep")
+                    visualizations.run_visualization("output", ">> <boop>")
+                    self.play_file(paths.data('audio', 'beep_lo.wav'))
+            try:
+                transcribed = [word.upper() for word in self.active_stt_plugin.transcribe(f)]
+            except Exception:
+                transcribed = []
+                dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
+                self._logger.error("Active transcription failed!", exc_info=dbg)
+            else:
+                if transcribed:
+                    visualizations.run_visualization(
+                        "output",
+                        "<< {}".format(transcribed)
+                    )
+                    self._log_audio(f, transcribed, "active")
+                else:
+                    visualizations.run_visualization("output", "<< <noise>")
+                    self._log_audio(f, transcribed, "noise")
+        return transcribed, audio
+
+    def listen(self):
+        """
+        Listen for a request
+        """
+        transcription = []
+        audio = self.vad_plugin.get_audio()
+        with self._write_frames_to_file(
+            audio
+        ) as f:
+            passive_transcription = [word.upper() for word in self.passive_stt_plugin.transcribe(f)]
+            if len(passive_transcription):
+                visualizations.run_visualization(
+                    "output",
+                    f"<  {passive_transcription}"
+                )
+                keywords_detected = self.check_for_keyword(passive_transcription, self.keywords)
+                if len(keywords_detected):
+                    if self.passive_listen:
+                        # If passive listen, then just use the same audio with the active stt engine
+                        active_transcription = self.active_stt_plugin.transcribe(f)
+                        if self.verify_wakeword:
+                            # Check if any of the same wakewords are heard by the active stt engine
+                            if self.check_for_keyword(active_transcription, keywords_detected):
+                                transcription = active_transcription
+                        else:
+                            transcription = active_transcription
+                        if transcription:
+                            visualizations.run_visualization(
+                                "output",
+                                f"<< {transcription}"
+                            )
+                            self._log_audio(f, transcribed, "active")
+                        else:
+                            visualizations.run_visualization(
+                                "output",
+                                f"<< <noise>"
+                            )
+                            self._log_audio(f, transcribed, "noise")
+                    else:
+                        transcription, audio = self.active_listen()
+                else:
+                    visualizations.run_visualization(
+                        "output",
+                        f"<< <noise>"
+                    )
+                    self._log_audio(f, transcribed, "noise")
+            else:
+                visualizations.run_visualization(
+                    "output",
+                    f"<  <noise>"
+                )
+        return transcription, audio
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger("stt").setLevel(logging.WARNING)
+    audio = Mic.get_instance()
+    while True:
+        text = audio.listen()[0]
+        if text:
+            audio.say(text)

--- a/naomi/mic_synchronous.py
+++ b/naomi/mic_synchronous.py
@@ -1,20 +1,8 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
-from naomi import alteration
+import logging
 from naomi import paths
 from naomi import mic
-from naomi import profile
 from naomi import visualizations
-import audioop
-import contextlib
-import logging
-import os
-import sqlite3
-import sys
-import tempfile
-import threading
-import time
-import wave
 
 
 # global action queue
@@ -31,7 +19,7 @@ class MicSynchronous(mic.Mic):
     `   It should only be used in cases where Naomi has just asked a question.
         """
         transcribed = []
-        if(play_prompts):
+        if play_prompts:
             # let the user know we are listening
             if self._active_stt_reply:
                 self.say(self._active_stt_reply)
@@ -43,7 +31,7 @@ class MicSynchronous(mic.Mic):
         with self._write_frames_to_file(
             audio
         ) as f:
-            if(play_prompts):
+            if play_prompts:
                 if self._active_stt_response:
                     self.say(self._active_stt_response)
                 else:
@@ -99,25 +87,25 @@ class MicSynchronous(mic.Mic):
                                 "output",
                                 f"<< {transcription}"
                             )
-                            self._log_audio(f, transcribed, "active")
+                            self._log_audio(f, transcription, "active")
                         else:
                             visualizations.run_visualization(
                                 "output",
-                                f"<< <noise>"
+                                "<< <noise>"
                             )
-                            self._log_audio(f, transcribed, "noise")
+                            self._log_audio(f, transcription, "noise")
                     else:
                         transcription, audio = self.active_listen()
                 else:
                     visualizations.run_visualization(
                         "output",
-                        f"<< <noise>"
+                        "<< <noise>"
                     )
-                    self._log_audio(f, transcribed, "noise")
+                    self._log_audio(f, transcription, "noise")
             else:
                 visualizations.run_visualization(
                     "output",
-                    f"<  <noise>"
+                    "<  <noise>"
                 )
         return transcription, audio
 
@@ -125,7 +113,7 @@ class MicSynchronous(mic.Mic):
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     logging.getLogger("stt").setLevel(logging.WARNING)
-    audio = Mic.get_instance()
+    audio = MicSynchronous.get_instance()
     while True:
         text = audio.listen()[0]
         if text:

--- a/naomi/notifier.py
+++ b/naomi/notifier.py
@@ -7,6 +7,7 @@ from naomi import profile
 
 class Notifier(object):
     def __init__(self, mic, brain, *args, **kwargs):
+        self.mic = mic
         self._logger = logging.getLogger(__name__)
         self._logger.info("Setting up notifier")
         self.notifiers = []
@@ -27,11 +28,14 @@ class Notifier(object):
                 )
                 print("Added notifier notification client {}".format(info.name))
 
-        sched = BackgroundScheduler(timezone="UTC", daemon=True)
-        sched.start()
+        self.sched = BackgroundScheduler(timezone="UTC", daemon=True)
+        self.sched.start()
         # FIXME add an interval setting to profile so this can be overridden
-        sched.add_job(self.gather, 'interval', seconds=30)
-        atexit.register(lambda: sched.shutdown(wait=False))
+        self.sched.add_job(self.gather, 'interval', seconds=30)
 
     def gather(self):
         [client.run() for client in self.notifiers]
+        if self.mic.Continue == False:
+            print("Notifier shutting down")
+            self.sched.shutdown(wait=False)
+

--- a/naomi/notifier.py
+++ b/naomi/notifier.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import atexit
 import logging
 from apscheduler.schedulers.background import BackgroundScheduler
 from naomi import profile
@@ -22,7 +21,7 @@ class Notifier(object):
                 brain=brain,
                 timestamp=None
             )
-            if(hasattr(notifier, "gather")):
+            if hasattr(notifier, "gather"):
                 self.notifiers.append(
                     notifier
                 )
@@ -35,7 +34,6 @@ class Notifier(object):
 
     def gather(self):
         [client.run() for client in self.notifiers]
-        if self.mic.Continue == False:
+        if self.mic.Continue is False:
             print("Notifier shutting down")
             self.sched.shutdown(wait=False)
-

--- a/plugins/speechhandler/joke/data/en-US.txt
+++ b/plugins/speechhandler/joke/data/en-US.txt
@@ -41,7 +41,7 @@ doctor
 that is the best show ever
 
 arizona
-arizona room for only one of us in this room
+arizona room for one of us in this room
 
 spider
 in spider what everyone says, I still feel like a human

--- a/plugins/speechhandler/mpdcontrol/mpdcontrol.py
+++ b/plugins/speechhandler/mpdcontrol/mpdcontrol.py
@@ -180,13 +180,16 @@ class MPDControlPlugin(plugin.SpeechHandlerPlugin):
         return True
 
     def stop(self, intent, mic):
-        _ = self.gettext  # Alias for better readability
-        playback_state = self._music.get_playback_state()
-        # stop playback even if playback appears to already be stopped
-        self._music.stop()
-        # if music is playing or paused, tell the user that playback is stopped
-        if playback_state != mpdclient.PLAYBACK_STATE_STOPPED:
-            self.say(mic, _('Music stopped.'))
+        try:
+            _ = self.gettext  # Alias for better readability
+            playback_state = self._music.get_playback_state()
+            # stop playback even if playback appears to already be stopped
+            self._music.stop()
+            # if music is playing or paused, tell the user that playback is stopped
+            if playback_state != mpdclient.PLAYBACK_STATE_STOPPED:
+                self.say(mic, _('Music stopped.'))
+        except (ConnectionRefusedError, RuntimeError) as e:
+            self._logger.warn(e)
 
     def load_playlist(self, playlist):
         playlists = self._music.get_playlists()

--- a/plugins/speechhandler/shutdownplugin/shutdown.py
+++ b/plugins/speechhandler/shutdownplugin/shutdown.py
@@ -54,5 +54,5 @@ class ShutdownPlugin(plugin.SpeechHandlerPlugin):
         message = random.choice(messages)
 
         mic.say(message)
-
+        mic.Continue = False
         quit()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have turned the Mic class into an abstract class and used it to create two new classes, MicSynchronous and MicAsynchronous. I'm hoping to expand it to all the different mic classes, including the local (text) mic and the batch mic.

I'm attempting to support both active listen mode (where the computer only starts listening for a command after hearing its wakeword - Siri-like mode) and passive listen mode (where the computer records blocks of audio, then checks for the wake word and then checks the same block of audio for a command - Echo-like).

Right now, I am having trouble with the expect function when using passive listen mode with the asynchronous listener. This has to do with the pyaudio device play_file, which returns when it has finished writing to the queue, but before the audio is done playing. This leads to situations where the next audio starts getting queued before the last audio finishes playing. If the audio's have different frame sizes, this leads to a segmentation fault.

I have been testing by using the "knock knock joke" and "time" speechhandler plugins. Knock-knock joke uses expect quite a bit. I have been using Pocketsphinx_KWS for my passive STT engine, Pocketsphinx for my special STT engine and VOSK (which is available here: https://github.com/aaronchantrill/Naomi_VOSK_STT) as my active STT engine. VOSK works well, at least in English, but requires some additional training if you have non-standard words in your vocabulary. I'd like to make VOSK officially available through NPE but the last time I trained VOSK to recognize some additional words, it required a computer with 32GiB of ram. I will test on my Raspberry Pi 5 with 8 GiB and see if it can handle it, but have low expectations. I would like to add an option to export the Naomi vocabulary so VOSK can be trained on another computer, as it does run well on the Raspberry Pi 4 and 5.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Naomi does not listen while thinking #340](https://github.com/NaomiProject/Naomi/issues/340)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The microphone does not currently continue to collect audio while Naomi is processing. This is especially a problem when entering a room, as the VAD still often captures noises as audio to process. If you walk into the room and then address Naomi while it is processing the audio of you walking into the room, it will miss your request.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested with both "listen while talking=True" (asynchronous) and "listen while talking=False" (synchronous) modes.
I have tested with both "passive_listen=True" (passive listening) and "passive_listen=False" (active listen) modes
I have been testing by asking Naomi to tell me a knock-knock joke (which uses the "expect" method) and then either allowing it to finish the joke, or asking it to tell me the time before it completes the joke:
User: Tel me a knock knock joke
Naomi: Knock knock
User: Naomi, what time is it?
Naomi: It is 12:15 PM right now

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
