### PR TITLE
These are some small fixes

### DIFF
--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -76,7 +76,7 @@ class Mic(i18n.GettextMixin):
         self._save_active_audio = profile.get_arg('save_active_audio', False)
         self._save_noise = profile.get_arg('save_noise', False)
         self.passive_listen = profile.get_profile_flag(["passive_listen"], False)
-        self.verify_wakeword = profile.get_profile_flag(['passive_stt', 'verify_wakeword'], False)
+        self.verify_keyword = profile.get_arg('verify_keyword', False)
         self._active_stt_reply = profile.get_arg("active_stt_reply")
         self._active_stt_response = profile.get_arg("active_stt_response")
 

--- a/naomi/mic_asynchronous.py
+++ b/naomi/mic_asynchronous.py
@@ -49,12 +49,36 @@ class MicAsynchronous(mic.Mic):
                             if self.check_for_keyword(passive_transcription):
                                 active_transcription = [" ".join(self.active_stt_plugin.transcribe(f))]
                                 if len(active_transcription) > 0:
-                                    if self.check_for_keyword(active_transcription):
+                                    if self.verify_keyword:
+                                        if self.check_for_keyword(active_transcription):
+                                            transcription = active_transcription
+                                            if len(transcription) > 0:
+                                                visualizations.run_visualization(
+                                                    "output",
+                                                    f"<< {transcription}"
+                                                )
+                                            else:
+                                                visualizations.run_visualization(
+                                                    "output",
+                                                    "<< <noise>"
+                                                )
+                                        else:
+                                            visualizations.run_visualization(
+                                                "output",
+                                                "<< <noise>"
+                                            )
+                                    else:
+                                        # Don't verify keyword
                                         transcription = active_transcription
                                         if len(transcription) > 0:
                                             visualizations.run_visualization(
                                                 "output",
                                                 f"<< {transcription}"
+                                            )
+                                        else:
+                                            visualizations.run_visualization(
+                                                "output",
+                                                "<< <noise>"
                                             )
                                 else:
                                     visualizations.run_visualization(

--- a/naomi/mic_synchronous.py
+++ b/naomi/mic_synchronous.py
@@ -76,7 +76,7 @@ class MicSynchronous(mic.Mic):
                     if self.passive_listen:
                         # If passive listen, then just use the same audio with the active stt engine
                         active_transcription = self.active_stt_plugin.transcribe(f)
-                        if self.verify_wakeword:
+                        if self.verify_keyword:
                             # Check if any of the same wakewords are heard by the active stt engine
                             if self.check_for_keyword(active_transcription, keywords_detected):
                                 transcription = active_transcription

--- a/naomi/vocabcompiler.py
+++ b/naomi/vocabcompiler.py
@@ -147,22 +147,22 @@ class VocabularyCompiler(object):
             self._logger.info('Starting compilation...')
             try:
                 compilation_func(self.path, phrases)
-            except Exception as e:
+            except Exception as e1:
                 msg = "Fatal compilation error occured"
-                if hasattr(e, 'message') and len(e.message) > 0:
-                    msg += ": %s" % e.message
+                if hasattr(e1, 'message') and len(e1.message) > 0:
+                    msg += ": %s" % e1.message
                 self._logger.error(msg, exc_info=debug)
                 try:
                     os.remove(self.revision_file)
                     shutil.rmtree(self.path)
-                except EnvironmentError as e:
+                except EnvironmentError as e2:
                     msg = 'Another error occured while cleaning up'
-                    if e.strerror and e.errno:
-                        msg = '%s: %s (Errno: %d)' % (msg, e.strerror, e.errno)
+                    if e2.strerror and e2.errno:
+                        msg = '%s: %s (Errno: %d)' % (msg, e2.strerror, e2.errno)
                     else:
-                        msg = '%s: %r' % (msg, e.args)
+                        msg = '%s: %r' % (msg, e2.args)
                     self._logger.error(msg, exc_info=debug)
-                raise e
+                raise e1
             else:
                 self._logger.info('Compilation done.')
         return revision


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Probably the most notable here is the breaking change of changing the "verify_wakeword" argument to "verify_keyword". This really isn't an important change, and it may cause some issues with the VOSK plugin depending on which version is installed.

This fixes an issue where the asyncronous mic assumes you are using verify_keyword even if you are not.

Finally, this sets the variable keyword to a string and keywords to a list in application.py, and saves the keywords to an arg variable.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
