### PR TITLE
Fixes for Alsa

### DIFF
--- a/naomi/audioengine.py
+++ b/naomi/audioengine.py
@@ -50,7 +50,7 @@ class AudioDevice(object):
         self._slug = slugify.slugify(name)
         self._input_rate = int(
             profile.get_profile_var(
-                ['audio', 'input_samplerate'],
+                ['audio', 'input_rate'],
                 16000
             )
         )
@@ -134,11 +134,11 @@ class AudioDevice(object):
 
     def play_fp(self, fp, *args, **kwargs):
         self._stop = False
-        if('chunksize' in kwargs):
+        if ('chunksize' in kwargs):
             chunksize = kwargs['chunksize']
         else:
             chunksize = int(profile.get(['audio', 'output_chunksize'], 1024))
-        if('add_padding' in kwargs):
+        if ('add_padding' in kwargs):
             add_padding = kwargs['add_padding']
         else:
             add_padding = profile.get(['audio', 'output_padding'], False)
@@ -149,14 +149,14 @@ class AudioDevice(object):
             bits = w.getsampwidth() * 8
             rate = w.getframerate()
             with self.open_stream(
-                bits,
-                channels,
-                rate,
+                bits=bits,
+                channels=channels,
+                rate=rate,
                 chunksize=chunksize
             ) as stream:
                 data = w.readframes(chunksize)
                 datalen = len(data)
-                if(
+                if (
                     (add_padding)
                     and (datalen > 0)
                     and (datalen < (chunksize * samplewidth))
@@ -165,13 +165,13 @@ class AudioDevice(object):
                     datalen = len(data)
                 while data:
                     # Check to see if we need to stop
-                    if(self._stop):
+                    if (self._stop):
                         self._stop = False
                         break
                     stream.write(data)
                     data = w.readframes(chunksize)
                     datalen = len(data)
-                    if(
+                    if (
                         (add_padding)
                         and (datalen > 0)
                         and (datalen < (chunksize * samplewidth))
@@ -179,7 +179,7 @@ class AudioDevice(object):
                         data += b'\00' * (chunksize * samplewidth - datalen)
                         datalen = len(data)
                 # pause before closing the stream (reduce clipping)
-                if(pause > 0):
+                if (pause > 0):
                     time.sleep(pause)
             self._stop = False
 

--- a/plugins/audioengine/alsa-ae/alsaaudioengine.py
+++ b/plugins/audioengine/alsa-ae/alsaaudioengine.py
@@ -134,7 +134,7 @@ class AlsaAudioDevice(plugin.audioengine.AudioDevice):
                                "output" if output else "input", self.slug)
 
     def record(self, *args, **kwargs):
-        # AJC 2018-08-02 Add a second while loop so if the pyaudio stream
+        # AJC 2018-08-02 Add a second while loop so if the stream
         # gets closed, we immediately reopen it rather than continue
         # to try to read from a closed stream
         stream = None
@@ -145,22 +145,7 @@ class AlsaAudioDevice(plugin.audioengine.AudioDevice):
                 try:
                     frame = stream.read()
                 except IOError as e:
-                    if type(e.errno) is not int:
-                        # Simple hack to work around the fact that the
-                        # errno/strerror arguments were swapped in older
-                        # PyAudio versions. This was fixed in upstream
-                        # commit 1783aaf9bcc6f8bffc478cb5120ccb6f5091b3fb.
-                        strerror, errno = e.errno, e.strerror
-                    else:
-                        strerror, errno = e.strerror, e.errno
-                    self._logger.warning(
-                        "IO error while reading from device" +
-                        " '%s': '%s' (Errno: %d)" % (
-                            self.slug,
-                            strerror,
-                            errno
-                        )
-                    )
+                    self._logger.warning(e)
                     break
                 else:
                     yield frame[1]
@@ -176,22 +161,7 @@ class AlsaAudioDevice(plugin.audioengine.AudioDevice):
                         try:
                             frame = stream.read()
                         except IOError as e:
-                            if type(e.errno) is not int:
-                                # Simple hack to work around the fact that the
-                                # errno/strerror arguments were swapped in older
-                                # PyAudio versions. This was fixed in upstream
-                                # commit 1783aaf9bcc6f8bffc478cb5120ccb6f5091b3fb.
-                                strerror, errno = e.errno, e.strerror
-                            else:
-                                strerror, errno = e.strerror, e.errno
-                            self._logger.warning(
-                                "IO error while reading from device" +
-                                " '%s': '%s' (Errno: %d)" % (
-                                    self.slug,
-                                    strerror,
-                                    errno
-                                )
-                            )
+                            self._logger.warning(e)
                             break
                         else:
                             yield frame[1]

--- a/plugins/audioengine/alsa-ae/alsaaudioengine.py
+++ b/plugins/audioengine/alsa-ae/alsaaudioengine.py
@@ -84,7 +84,23 @@ class AlsaAudioDevice(plugin.audioengine.AudioDevice):
         return True
 
     @contextlib.contextmanager
-    def open_stream(self, bits, channels, rate, chunksize=1024, output=True):
+    def open_stream(self, *args, **kwargs):
+        bits = self._input_bits
+        if 'bits' in kwargs:
+            bits = kwargs['bits']
+        channels = self._input_channels
+        if 'channels' in kwargs:
+            channels = kwargs['channels']
+        rate = self._input_rate
+        if 'rate' in kwargs:
+            rate = kwargs['rate']
+        output = True
+        if 'output' in kwargs:
+            output = kwargs['output']
+        chunksize = self._input_chunksize
+        if 'chunksize' in kwargs:
+            chunksize = kwargs['chunksize']
+
         # Check if format is supported
         is_supported_fmt = self.supports_format(bits, channels, rate,
                                                 output=output)
@@ -117,8 +133,65 @@ class AlsaAudioDevice(plugin.audioengine.AudioDevice):
             self._logger.debug("%s stream closed on device '%s'",
                                "output" if output else "input", self.slug)
 
-    def record(self, chunksize, *args):
-        with self.open_stream(*args, chunksize=chunksize,
-                              output=False) as stream:
-            while True:
-                yield stream.read()[1]
+    def record(self, *args, **kwargs):
+        # AJC 2018-08-02 Add a second while loop so if the pyaudio stream
+        # gets closed, we immediately reopen it rather than continue
+        # to try to read from a closed stream
+        stream = None
+        if 'stream' in kwargs:
+            stream = kwargs['stream']
+        while True:
+            if stream:
+                try:
+                    frame = stream.read()
+                except IOError as e:
+                    if type(e.errno) is not int:
+                        # Simple hack to work around the fact that the
+                        # errno/strerror arguments were swapped in older
+                        # PyAudio versions. This was fixed in upstream
+                        # commit 1783aaf9bcc6f8bffc478cb5120ccb6f5091b3fb.
+                        strerror, errno = e.errno, e.strerror
+                    else:
+                        strerror, errno = e.strerror, e.errno
+                    self._logger.warning(
+                        "IO error while reading from device" +
+                        " '%s': '%s' (Errno: %d)" % (
+                            self.slug,
+                            strerror,
+                            errno
+                        )
+                    )
+                    break
+                else:
+                    yield frame[1]
+            else:
+                with self.open_stream(
+                    bits=self._input_bits,
+                    channels=self._input_channels,
+                    rate=self._input_rate,
+                    chunksize=self._input_chunksize,
+                    output=False
+                ) as stream:
+                    while True:
+                        try:
+                            frame = stream.read()
+                        except IOError as e:
+                            if type(e.errno) is not int:
+                                # Simple hack to work around the fact that the
+                                # errno/strerror arguments were swapped in older
+                                # PyAudio versions. This was fixed in upstream
+                                # commit 1783aaf9bcc6f8bffc478cb5120ccb6f5091b3fb.
+                                strerror, errno = e.errno, e.strerror
+                            else:
+                                strerror, errno = e.strerror, e.errno
+                            self._logger.warning(
+                                "IO error while reading from device" +
+                                " '%s': '%s' (Errno: %d)" % (
+                                    self.slug,
+                                    strerror,
+                                    errno
+                                )
+                            )
+                            break
+                        else:
+                            yield frame[1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When the asynchronous mic was introduced, some formatting changes were made that were not copied into the Alsa audio engine plugin.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Alsa engine not working #406](https://github.com/NaomiProject/Naomi/issues/406)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm just trying to use the Alsa engine with Naomi, mostly because right now, running inside the docker container, we don't have pulseaudio or pipewire working yet. The devices pyaudio can see are not compatible with any arbitrary bitrate and format. Plughw alsa devices do the audio format conversions on the fly so they can play anything, which is also what we use pulseaudio/pipewire for.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running Naomi with alsa selected as the audio engine, also by running unittests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
