### PR TITLE
Phonetisaurus Fix

### DIFF
--- a/plugins/stt/pocketsphinx-stt/sphinxplugin.py
+++ b/plugins/stt/pocketsphinx-stt/sphinxplugin.py
@@ -18,7 +18,13 @@ except ModuleNotFoundError:
         'pip', 'install', 'phonetisaurus'
     ]
     completedprocess = run_command(cmd)
-    if completedprocess.returncode != 0:
+    if completedprocess.returncode == 0:
+        if importlib.util.find_spec("phonetisaurus"):
+            from . import sphinxvocab
+            from .g2p import PhonetisaurusG2P
+        else:
+            raise Exception("Phonetisaurus install failed")
+    else:
         # check what architecture we are on
         architecture = platform.machine()
         phonetisaurus_url = ""
@@ -189,7 +195,7 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
         if (not hmm_dir):
             # Make a list of possible paths to check
             hmm_dir_paths = [
-                paths.sub("pocketsphinx", "standard")
+                paths.sub("pocketsphinx", "standard", language)
             ]
             # see if any of these paths exist
             for path in hmm_dir_paths:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Import sphinxvocab and PhonetisaurusG2P modules after installing phonetisaurus with pip. Add locale to default pocketsphinx hmm_dir.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[name 'PhonetisaurusG2P' is not defined #410](https://github.com/NaomiProject/Naomi/issues/410)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change showed up because of the x86_64 docker image, where it is more difficult to just restart Naomi.py with the --repopulate flag.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
$ flake8 --config=.flake8 plugins/stt/pocketsphinx-stt/sphinxplugin.py
$ python -m unittest discover
I also updated the Naomi folder in the docker image with this branch and it worked.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
