### PR TITLE
Fix issue with empty profile.yml file

### DIFF
--- a/naomi/profile.py
+++ b/naomi/profile.py
@@ -157,6 +157,11 @@ def get_profile(command=""):
             try:
                 with open(new_configfile, "r") as f:
                     _profile = yaml.safe_load(f)
+                    # If the profile.yml file is empty, the _profile will be
+                    # None rather than an empty dictionary. This will cause
+                    # issues later.
+                    if _profile is None:
+                        _profile = {}
                     _profile_read = True
                     config_read = True
             except (IOError, FileNotFoundError):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using yaml.safe_load() on an empty text file, the returned value is None rather than an empty dictionary as I expected. This caused an error when adding the first value, as I would get the error message "NoneType object does not support item assignment".

This patch changes a None value into an empty dictionary.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[NoneType does not support item assignment #413](https://github.com/NaomiProject/Naomi/issues/413)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
flake8 and unit tests. I also tried running Naomi with an empty profile.yml file and it worked after applying this patch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
