### PR TITLE
Play greeting before starting mic

### DIFF
--- a/naomi/application.py
+++ b/naomi/application.py
@@ -1073,6 +1073,6 @@ class Naomi(object):
                 verbose=(self._logger.getEffectiveLevel() == logging.DEBUG))
 
     def run(self):
-        self.conversation.askName()
+        self.conversation.sayName()
         self.conversation.greet()
         self.conversation.handleForever()

--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -437,11 +437,15 @@ class commandline(object):
                         definition["title"]
                     )
                 )
-                # Make sure the default value is actually available in the list of options
-                if (value in options):
-                    response = value
+                # If there is only one option available, select it by default
+                if len(options) == 1:
+                    response = [option for option in options][0]
                 else:
-                    response = ""
+                    # Make sure the default value is actually available in the list of options
+                    if value in options:
+                        response = value
+                    else:
+                        response = ""
                 once = False
                 while not ((once) and (profile.validate(definition, response))):
                     once = True

--- a/naomi/conversation.py
+++ b/naomi/conversation.py
@@ -17,7 +17,7 @@ class Conversation(i18n.GettextMixin):
         self.translations = {}
 
     # Add way for the system to ask for name if is not found in the config
-    def askName(self):
+    def sayName(self):
         keywords = profile.get(['keyword'], ['NAOMI'])
         if isinstance(keywords, str):
             keywords = [keywords]
@@ -32,7 +32,7 @@ class Conversation(i18n.GettextMixin):
             salutation = self.gettext(
                 "My name is {}"
             ).format(keywords[0])
-        self.mic.say(salutation)
+        self.mic.say_sync(salutation)
 
     def greet(self):
         if profile.get(['first_name']):
@@ -41,7 +41,7 @@ class Conversation(i18n.GettextMixin):
             )
         else:
             salutation = self.gettext("How can I be of service?")
-        self.mic.say(salutation)
+        self.mic.say_sync(salutation)
 
     def handleForever(self):
         """

--- a/naomi/mic.py
+++ b/naomi/mic.py
@@ -558,7 +558,12 @@ class Mic(i18n.GettextMixin):
 
     # The following are no longer necessary and are just wrappers now.
     def say_sync(self, phrase):
-        self.say(phrase)
+        visualizations.run_visualization("output", ">> {}".format(phrase))
+        with tempfile.SpooledTemporaryFile() as f:
+            f.write(self.tts_engine.say(phrase))
+            f.seek(0)
+            self._output_device.play_fp(f)
+            time.sleep(.5)
 
     def say_async(self, phrase):
         self.say(phrase)

--- a/naomi/plugin.py
+++ b/naomi/plugin.py
@@ -50,7 +50,8 @@ class GenericPlugin(object):
             if not settings_complete:
                 visualizations.run_visualization(
                     "output",
-                    self.gettext("Configuring {}").format(self._plugin_info.name)
+                    interface.status_text(self.gettext("Configuring {}").format(self._plugin_info.name)),
+                    timestamp=False
                 )
                 for setting in settings:
                     interface.get_setting(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I realized that one of the big problems with Naomi listening to itself speak is that it says all of its keywords/wakewords as part of the first message, which causes it to scan its greeting for intent and causes it to respond with a message immediately, which isn't great.

I added a say_sync method to the mic.py interface and used that directly in conversation.py. I also changed the askName method to sayName since that's what it actually does now.

I also made a small change to plugin.py so that the messages about which plugin it is configuring when configuring plugins appears highlighted.

Finally, I made a small change to commandline.py so that if a listbox setting has only one option, that option will be selected by default.

Small changes, nothing earth shattering here.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Naomi listens to itself #212](https://github.com/NaomiProject/Naomi/issues/212)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my laptop. Ran the startup sequence a few times. I have been testing the plugin names announcements and listbox changes as part of developing a new Piper TTS plugin. I ran the unittests and got no errors, 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
