### PR TITLE
Fix adding new settings array

### DIFF
--- a/naomi/commandline.py
+++ b/naomi/commandline.py
@@ -407,10 +407,17 @@ class commandline(object):
                     first = True
                     newarray = [part for part in setting]
                     newarray.extend([currentvalue])
-                    for subsetting in definition['each']:
+                    for settingindex in range(len(definition['each'])):
+                        subsetting = definition['each'][settingindex]
                         newsetting = newarray.copy()
-                        newsetting.extend([subsetting[0]])
-                        self.get_setting(tuple(newsetting), definition['each'][subsetting])
+                        # Subsetting looks something like:
+                        # (('id',), {'title': 'ID of your light', 'description': 'The ID of your light as reported by HomeAssistant'})
+                        # subsetting[0] could be a path with multiple nodes
+                        # subsetting[1] is the definition of this setting
+                        # Add the path nodes to newsetting
+                        for subnode in subsetting[0]:
+                            newsetting.append(subnode)
+                        self.get_setting(tuple(newsetting), subsetting[1])
                         if first:
                             first = False
                             if not profile.get(newsetting):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes an issue with plugins that use the new "array" setting type. The array setting type allows you to specify an arbitrary number of items for a setting. For instance, you could define "user" as type "array" and then have a name and email address defined for each user.

The issue is that when first creating the setting, I was treating the subsettings like dictionaries, but they are actually a tuple of tuples, with the first representing the path and the second the definition.

The new "array" type setting is necessary, but overly complex. I wish I could come up with a simpler implementation.

Anyway, this fixes a "TypeError" error when attempting to prompt the user for a value for an "array" setting that has not been initialized before.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
